### PR TITLE
Add Terraform S3 backend for state management

### DIFF
--- a/terraform/state.tf
+++ b/terraform/state.tf
@@ -1,0 +1,41 @@
+# S3 bucket holding Terraform state for StartLine infra.
+#
+# Bootstrap order (one-time):
+#   1. Apply with current local backend to create this bucket.
+#   2. Uncomment the backend "s3" block in versions.tf (with the bucket name
+#      this resource creates).
+#   3. terraform init -migrate-state  (moves local state into the bucket).
+# After migration this bucket holds the state that describes itself — fine,
+# prevent_destroy guards against accidental teardown.
+
+resource "aws_s3_bucket" "tfstate" {
+  bucket = "${var.project_name}-tf-state-${data.aws_caller_identity.current.account_id}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket                  = aws_s3_bucket.tfstate.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.10.0" # native S3 state locking landed in 1.10
 
   required_providers {
     aws = {
@@ -11,13 +11,12 @@ terraform {
       version = "~> 3.6"
     }
   }
-
-  # Uncomment and configure for remote state (recommended for teams).
-  # backend "s3" {
-  #   bucket         = "your-terraform-state-bucket"
-  #   key            = "startline/terraform.tfstate"
-  #   region         = "ap-southeast-2"
-  #   encrypt        = true
-  #   dynamodb_table = "terraform-locks"
-  # }
+  
+  backend "s3" {
+    bucket       = "startline-tf-state-829182232071"
+    key          = "startline/terraform.tfstate"
+    region       = "ap-southeast-2"
+    encrypt      = true
+    use_lockfile = true
+  }
 }


### PR DESCRIPTION
- Created a new `state.tf` file to define an S3 bucket for storing Terraform state, including versioning and server-side encryption configurations.
- Updated `versions.tf` to set the required Terraform version to 1.10.0 and configured the S3 backend for remote state management, enabling state locking and encryption.

This setup enhances state management and security for the Terraform infrastructure.