### PR TITLE
Add Cognito User Pool (email + password)

### DIFF
--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -1,0 +1,82 @@
+# Cognito User Pool for StartLine.
+#
+# Email + password only. The Next.js app's sign-in UI is built later and will
+# call Cognito directly via the SDK (USER_SRP_AUTH) — no Hosted UI / OAuth /
+# callback URLs needed. Add social IdPs back here when needed.
+
+resource "aws_cognito_user_pool" "this" {
+  name = "${var.project_name}-users"
+
+  username_attributes      = ["email"]
+  auto_verified_attributes = ["email"]
+
+  password_policy {
+    minimum_length                   = 8
+    require_lowercase                = true
+    require_uppercase                = true
+    require_numbers                  = true
+    require_symbols                  = false
+    temporary_password_validity_days = 7
+  }
+
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
+
+  email_configuration {
+    email_sending_account = "COGNITO_DEFAULT"
+  }
+
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_CODE"
+    email_subject        = "Verify your ${var.project_name} email"
+    email_message        = "Your verification code is {####}"
+  }
+
+  schema {
+    name                     = "email"
+    attribute_data_type      = "String"
+    required                 = true
+    mutable                  = true
+    developer_only_attribute = false
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 256
+    }
+  }
+
+  mfa_configuration   = "OFF"
+  deletion_protection = var.cognito_deletion_protection ? "ACTIVE" : "INACTIVE"
+}
+
+# Confidential client (with secret) — the Next.js app runs server-side on
+# Amplify SSR, so it can keep the secret. Switch generate_secret to false if
+# you ever need to use this client from a pure browser SPA.
+resource "aws_cognito_user_pool_client" "web" {
+  name         = "${var.project_name}-web"
+  user_pool_id = aws_cognito_user_pool.this.id
+
+  generate_secret = true
+
+  explicit_auth_flows = [
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+  ]
+
+  prevent_user_existence_errors = "ENABLED"
+  enable_token_revocation       = true
+
+  access_token_validity  = 60
+  id_token_validity      = 60
+  refresh_token_validity = 30
+
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "days"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -44,6 +44,32 @@ output "route53_nameservers" {
   value       = aws_route53_zone.primary.name_servers
 }
 
+output "cognito_user_pool_id" {
+  description = "Cognito User Pool ID."
+  value       = aws_cognito_user_pool.this.id
+}
+
+output "cognito_user_pool_arn" {
+  description = "Cognito User Pool ARN."
+  value       = aws_cognito_user_pool.this.arn
+}
+
+output "cognito_issuer_url" {
+  description = "OIDC issuer URL for the User Pool. Append /.well-known/openid-configuration for discovery."
+  value       = "https://${aws_cognito_user_pool.this.endpoint}"
+}
+
+output "cognito_app_client_id" {
+  description = "App Client ID used by the Next.js app."
+  value       = aws_cognito_user_pool_client.web.id
+}
+
+output "cognito_app_client_secret" {
+  description = "App Client secret. Store in Amplify env / Secrets Manager — do not commit."
+  value       = aws_cognito_user_pool_client.web.client_secret
+  sensitive   = true
+}
+
 output "amplify_domain_dns_records" {
   description = "DNS records you must create at GoDaddy to validate the cert and route traffic. Each entry has type/name/value."
   value = var.amplify_custom_domain == null ? [] : concat(

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -14,3 +14,6 @@
 # Optional: non-secret build/runtime env. Set DATABASE_URL from the Terraform output
 # or from Secrets Manager (see output database_secret_arn) — do not commit it here.
 # amplify_environment_variables = {}
+#
+# === Cognito ===
+# cognito_deletion_protection = true   # set false in dev if you want easy teardown

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -145,3 +145,11 @@ variable "database_secret_recovery_window_days" {
   type        = number
   default     = 0
 }
+
+# --- Cognito ---
+
+variable "cognito_deletion_protection" {
+  description = "Enable deletion protection on the User Pool. Recommended for production."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary
- Provisions a Cognito User Pool for email/password sign-in (no Hosted UI, no social IdPs yet)
- Confidential App Client with `USER_SRP_AUTH` + refresh-token flow
- Outputs: user_pool_id, user_pool_arn, issuer_url, app_client_id/secret

## Test plan
- [x] `terraform plan` from master shows the Cognito resources only
- [x] `terraform apply` succeeds
- [x] User Pool visible in AWS console (ap-southeast-2)
