### PR TITLE
Restore lib/prisma.ts on non-production

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from "@prisma/client";
+
+// Create a singleton so that hot‑reloading in development doesn't create
+// multiple clients. This pattern is recommended in the Prisma docs for Next.js.
+
+declare global {
+  // allow global `var` declarations
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+const client = global.prisma || new PrismaClient();
+if (process.env.NODE_ENV !== "production") global.prisma = client;
+
+export default client;


### PR DESCRIPTION
Hotfix for nonprod build failure.

## What broke

\`app/api/waitlist/route.ts\` imports \`@/lib/prisma\` but \`lib/prisma.ts\` is missing on \`non-production\`. \`next build\` fails with:

\`\`\`
./app/api/waitlist/route.ts
Module not found: Can't resolve '@/lib/prisma'
\`\`\`

## Why merging main didn't fix it

The file exists on \`main\` but was deleted on the front-end-stitch lineage that \`non-production\` was created from. The merge-base between main and non-production is from before that delete, so standard 3-way merge sees:

- merge-base: file present
- non-production: file deleted
- main: file unchanged vs merge-base

Resolution: respect the delete. Both regular merge commits AND squash merges keep the file gone — even after PR #13 brought stitch onto main and PR #14 promoted main → non-production. The file's restoration on main was a merge resolution, not a discrete commit, so it didn't survive squashing.

## Fix

Re-add the file as a normal new commit on non-production. Once both branches genuinely have the file (not as merge-resolution metadata), future main → non-production promotions resolve correctly.

## Test plan

- [ ] Merge → Amplify auto-rebuilds non-production
- [ ] Build succeeds; non-production is reachable at its amplifyapp.com URL
