### PR TITLE
fix(admin): robust admin session, paginated events, atomic review

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -11,13 +11,18 @@ export const dynamic = "force-dynamic";
 
 async function getStats() {
   await archivePastEvents();
-  const [pending, approved, rejected, organisers] = await Promise.all([
-    prisma.event.count({ where: { status: "PENDING"  } }),
-    prisma.event.count({ where: { status: "APPROVED" } }),
-    prisma.event.count({ where: { status: "REJECTED" } }),
-    prisma.organiser.count(),
-  ]);
-  return { pending, approved, rejected, organisers };
+  try {
+    const [pending, approved, rejected, organisers] = await Promise.all([
+      prisma.event.count({ where: { status: "PENDING"  } }),
+      prisma.event.count({ where: { status: "APPROVED" } }),
+      prisma.event.count({ where: { status: "REJECTED" } }),
+      prisma.organiser.count(),
+    ]);
+    return { pending, approved, rejected, organisers };
+  } catch (err) {
+    console.error("Admin dashboard stats error:", err);
+    return { pending: 0, approved: 0, rejected: 0, organisers: 0 };
+  }
 }
 
 interface StatCardProps {

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -308,26 +308,37 @@ function AdminEventsContent() {
   const statusParam  = (searchParams.get("status") ?? "PENDING").toUpperCase() as EventStatus;
   const activeTab    = TABS.find((t) => t.status === statusParam)?.status ?? "PENDING";
 
-  const [events,  setEvents]  = useState<AdminEventRow[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [events,     setEvents]     = useState<AdminEventRow[]>([]);
+  const [loading,    setLoading]    = useState(true);
+  const [total,      setTotal]      = useState(0);
+  const [page,       setPage]       = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
 
-  const fetchEvents = useCallback(async (status: EventStatus) => {
+  const fetchEvents = useCallback(async (status: EventStatus, p = 1) => {
     setLoading(true);
     try {
-      const res  = await fetch(`/api/admin/events?status=${status}`);
+      const res  = await fetch(`/api/admin/events?status=${status}&page=${p}&limit=50`);
       const data = await res.json();
-      if (res.ok && Array.isArray(data)) setEvents(data);
-      else setEvents([]);
+      if (res.ok && Array.isArray(data.events)) {
+        setEvents(data.events);
+        setTotal(data.total);
+        setTotalPages(data.totalPages);
+      } else {
+        setEvents([]);
+        setTotal(0);
+        setTotalPages(1);
+      }
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    fetchEvents(activeTab);
+    fetchEvents(activeTab, 1);
   }, [activeTab, fetchEvents]);
 
   const switchTab = (status: EventStatus) => {
+    setPage(1);
     router.push(`/admin/events?status=${status}`, { scroll: false });
   };
 
@@ -353,7 +364,7 @@ function AdminEventsContent() {
               </h1>
             </div>
             <button
-              onClick={() => fetchEvents(activeTab)}
+              onClick={() => fetchEvents(activeTab, page)}
               className="self-start sm:self-end flex items-center gap-2 font-headline text-[12px] font-bold uppercase tracking-widest text-gray-500 hover:text-gray-900 transition-colors"
             >
               <RefreshCw className="w-3.5 h-3.5" /> Refresh
@@ -409,8 +420,27 @@ function AdminEventsContent() {
           </Card>
 
           {!loading && events.length > 0 && (
-            <div className="mt-4 font-headline text-[12px] uppercase tracking-widest text-gray-400 text-right">
-              {events.length} event{events.length !== 1 ? "s" : ""}
+            <div className="mt-4 flex items-center justify-between font-headline text-[12px] uppercase tracking-widest text-gray-400">
+              <span>{total} event{total !== 1 ? "s" : ""}</span>
+              {totalPages > 1 && (
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => { const p = page - 1; setPage(p); fetchEvents(activeTab, p); }}
+                    disabled={page <= 1}
+                    className="px-3 py-1 rounded border border-gray-200 hover:border-gray-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                  >
+                    Prev
+                  </button>
+                  <span className="text-gray-500">Page {page} of {totalPages}</span>
+                  <button
+                    onClick={() => { const p = page + 1; setPage(p); fetchEvents(activeTab, p); }}
+                    disabled={page >= totalPages}
+                    className="px-3 py-1 rounded border border-gray-200 hover:border-gray-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                  >
+                    Next
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/app/api/admin/events/[id]/review/route.ts
+++ b/app/api/admin/events/[id]/review/route.ts
@@ -51,20 +51,9 @@ export async function POST(
 
     const newStatus = action === "approve" ? "APPROVED" : "REJECTED";
 
-    await prisma.event.update({
-      where: { id },
-      data: {
-        status:          newStatus,
-        reviewedById:    session.sub,
-        reviewedAt:      new Date(),
-        rejectionReason: action === "reject" ? reason!.trim() : null,
-      },
-    });
-
     const organiserEmail = event.organiser.email;
     const organiserId    = event.organiser.id;
 
-    // Create in-app notification for the organiser
     const notifData = action === "approve"
       ? {
           type:  "EVENT_APPROVED" as const,
@@ -77,16 +66,27 @@ export async function POST(
           body:  `Your event "${event.title}" was not approved. Reason: ${reason?.trim() ?? "No reason provided."}`,
         };
 
-    await prisma.notification.create({
-      data: { organiserId, eventId: id, ...notifData },
-    }).catch(err => console.error("Failed to create notification:", err));
+    await prisma.$transaction([
+      prisma.event.update({
+        where: { id },
+        data: {
+          status:          newStatus,
+          reviewedById:    session.sub,
+          reviewedAt:      new Date(),
+          rejectionReason: action === "reject" ? reason!.trim() : null,
+        },
+      }),
+      prisma.notification.create({
+        data: { organiserId, eventId: id, ...notifData },
+      }),
+    ]);
 
     if (action === "approve") {
-      await sendEventApprovedEmail(organiserEmail, event.title).catch((err) =>
+      sendEventApprovedEmail(organiserEmail, event.title).catch((err) =>
         console.error("Failed to send approval email:", err),
       );
     } else {
-      await sendEventRejectedEmail(organiserEmail, event.title, reason?.trim()).catch((err) =>
+      sendEventRejectedEmail(organiserEmail, event.title, reason?.trim()).catch((err) =>
         console.error("Failed to send rejection email:", err),
       );
     }

--- a/app/api/admin/events/route.ts
+++ b/app/api/admin/events/route.ts
@@ -4,6 +4,29 @@ import { getAdminSession } from "@/lib/amplify-server";
 const VALID_STATUSES = ["DRAFT", "PENDING", "APPROVED", "REJECTED", "ARCHIVED"] as const;
 type EventStatus = (typeof VALID_STATUSES)[number];
 
+const EVENT_SELECT = {
+  id:             true,
+  title:          true,
+  discipline:     true,
+  city:           true,
+  state:          true,
+  eventDate:      true,
+  startTime:      true,
+  status:         true,
+  createdAt:      true,
+  coverImageUrl:  true,
+  rejectionReason: true,
+  reviewedAt:     true,
+  organiser: {
+    select: {
+      id:          true,
+      orgName:     true,
+      contactName: true,
+      email:       true,
+    },
+  },
+} as const;
+
 export async function GET(req: NextRequest) {
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
@@ -14,34 +37,30 @@ export async function GET(req: NextRequest) {
     ? (statusParam as EventStatus)
     : "PENDING";
 
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+  const limit = Math.min(100, Math.max(1, parseInt(searchParams.get("limit") ?? "50", 10)));
+  const skip = (page - 1) * limit;
+
   try {
-    const events = await prisma.event.findMany({
-      where:   { status },
-      orderBy: { createdAt: "desc" },
-      select: {
-        id:             true,
-        title:          true,
-        discipline:     true,
-        city:           true,
-        state:          true,
-        eventDate:      true,
-        startTime:      true,
-        status:         true,
-        createdAt:      true,
-        coverImageUrl:  true,
-        rejectionReason: true,
-        reviewedAt:     true,
-        organiser: {
-          select: {
-            id:          true,
-            orgName:     true,
-            contactName: true,
-            email:       true,
-          },
-        },
-      },
+    const [events, total] = await Promise.all([
+      prisma.event.findMany({
+        where:   { status },
+        orderBy: { createdAt: "desc" },
+        select:  EVENT_SELECT,
+        skip,
+        take: limit,
+      }),
+      prisma.event.count({ where: { status } }),
+    ]);
+
+    const response = NextResponse.json({
+      events,
+      total,
+      page,
+      totalPages: Math.ceil(total / limit),
     });
-    return NextResponse.json(events);
+    response.headers.set("Cache-Control", "no-store");
+    return response;
   } catch (err) {
     console.error("Admin events fetch error:", err);
     return NextResponse.json({ error: "Service unavailable." }, { status: 503 });

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect } from "@playwright/test";
+import { adminLogin } from "./helpers";
+
+test.describe("admin login", () => {
+  test("dev bypass login redirects to dashboard", async ({ page }) => {
+    await page.goto("/admin/login");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("h1")).toContainText("Admin");
+    await expect(page.locator("h1")).toContainText("sign in");
+
+    await page.getByPlaceholder(/admin@startlineau/i).fill("test.organiser@startlineau.com");
+    await page.locator('input[type="password"]').first().fill("password123");
+    await page.getByRole("button", { name: /sign in/i }).click();
+
+    await page.waitForURL("**/admin/dashboard**", { timeout: 10000 });
+    await expect(page.locator("h1")).toContainText("Overview");
+  });
+
+  test("login page renders all form elements", async ({ page }) => {
+    await page.goto("/admin/login");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByPlaceholder(/admin@startlineau/i)).toBeVisible();
+    await expect(page.locator('input[type="password"]')).toBeVisible();
+    await expect(page.getByRole("button", { name: /sign in/i })).toBeVisible();
+  });
+});
+
+test.describe("admin dashboard", () => {
+  test("dashboard shows stats cards after login", async ({ page }) => {
+    await adminLogin(page);
+
+    await expect(page.getByText("Pending review")).toBeVisible();
+    await expect(page.getByText("Published events")).toBeVisible();
+    await expect(page.getByText("Rejected")).toBeVisible();
+    await expect(page.getByText("registered accounts")).toBeVisible();
+
+    await expect(page.locator("h1")).toContainText("Overview");
+  });
+
+  test("dashboard has quick action links", async ({ page }) => {
+    await adminLogin(page);
+
+    await expect(page.getByText("Review pending events")).toBeVisible();
+    await expect(page.getByText("All events")).toBeVisible();
+    await expect(page.getByText("View accounts")).toBeVisible();
+    await expect(page.getByText("Moderate reviews")).toBeVisible();
+  });
+
+  test("review queue CTA links to pending events", async ({ page }) => {
+    await adminLogin(page);
+
+    const reviewCta = page.getByRole("link", { name: /review queue/i });
+    if (await reviewCta.isVisible()) {
+      await reviewCta.click();
+      await page.waitForURL("**/admin/events?status=PENDING**", { timeout: 5000 });
+      await expect(page.locator("h1")).toContainText("Events");
+    }
+  });
+
+  test("pending stats card links to pending events page", async ({ page }) => {
+    await adminLogin(page);
+
+    const pendingCard = page.getByRole("link", { name: /pending review/i });
+    if (await pendingCard.isVisible()) {
+      await pendingCard.click();
+      await page.waitForURL("**/admin/events?status=PENDING**", { timeout: 5000 });
+      await expect(page.getByRole("button", { name: "Pending" })).toBeVisible();
+    }
+  });
+});
+
+test.describe("admin events page", () => {
+  test("events page renders with tabs", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("h1")).toContainText("Events");
+    await expect(page.getByRole("button", { name: "Pending" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Approved" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Rejected" })).toBeVisible();
+  });
+
+  test("pending tab shows pending events after seed", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events?status=PENDING");
+    await page.waitForLoadState("networkidle");
+
+    const eventCount = page.locator("text=/\\d+ event(s)?/");
+    await expect(eventCount).toBeVisible({ timeout: 10000 });
+
+    await expect(page.getByText("Hybrid Hustle Series", { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("rejected tab shows rejected events with reason", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events?status=REJECTED");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByText("Autumn Run Festival", { exact: false })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("Event date has already passed", { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("pagination controls appear when count label is visible", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events?status=PENDING");
+    await page.waitForLoadState("networkidle");
+
+    const countLabel = page.locator("text=/\\d+ event(s)?/");
+    await expect(countLabel).toBeVisible({ timeout: 10000 });
+  });
+
+  test("can switch between tabs", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events?status=PENDING");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: "Approved" }).click();
+    await page.waitForURL("**/admin/events?status=APPROVED**");
+
+    await page.getByRole("button", { name: "Rejected" }).click();
+    await page.waitForURL("**/admin/events?status=REJECTED**");
+
+    await page.getByRole("button", { name: "Pending" }).click();
+    await page.waitForURL("**/admin/events?status=PENDING**");
+  });
+});
+
+test.describe("admin event approval flow", () => {
+  test("approve button is visible on pending events", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events?status=PENDING");
+    await page.waitForLoadState("networkidle");
+
+    const approveBtn = page.getByRole("button", { name: "Approve" });
+    const count = await approveBtn.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("reject button shows rejection form", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events?status=PENDING");
+    await page.waitForLoadState("networkidle");
+
+    const rejectBtn = page.locator("button").filter({ hasText: /^Reject$/ }).first();
+    await expect(rejectBtn).toBeVisible({ timeout: 5000 });
+    await rejectBtn.click();
+
+    await expect(page.getByText("Rejection reason")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("button", { name: /cancel/i })).toBeVisible();
+  });
+
+  test("can approve a pending event and it disappears from list", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events?status=PENDING");
+    await page.waitForLoadState("networkidle");
+
+    const approveBtn = page.getByRole("button", { name: "Approve" }).first();
+    if (await approveBtn.isVisible()) {
+      const eventTitle = await page.locator('[class*="font-headline"][class*="text-\\[15px\\]"]').first().textContent();
+
+      await approveBtn.click();
+
+      if (eventTitle) {
+        await expect(page.getByText(eventTitle.trim())).not.toBeVisible({ timeout: 5000 });
+      }
+    }
+  });
+});
+
+test.describe("admin organisers page", () => {
+  test("organisers page lists accounts", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/organisers");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByText("Apex Endurance Events", { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -21,3 +21,14 @@ export async function selectStateFilter(page: Page, state: string): Promise<void
     await page.waitForTimeout(300);
   }
 }
+
+export async function adminLogin(page: Page, email = "test.organiser@startlineau.com"): Promise<void> {
+  await page.goto("/admin/login");
+  await page.waitForLoadState("networkidle");
+
+  await page.getByPlaceholder(/admin@startlineau/i).fill(email);
+  await page.locator('input[type="password"]').first().fill("password123");
+  await page.getByRole("button", { name: /sign in/i }).click();
+
+  await page.waitForURL("**/admin/dashboard**", { timeout: 10000 });
+}

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -9,13 +9,12 @@ test.describe("homepage", () => {
 
   test("shows main headings and navigation", async ({ page }) => {
     await goToHomepage(page);
-    await expect(page.getByRole("link", { name: /events/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: "EVENTS", exact: true })).toBeVisible();
     await expect(page.getByRole("link", { name: /organiser login/i })).toBeVisible();
   });
 
   test("event cards or empty state renders", async ({ page }) => {
     await goToHomepage(page);
-    // Either event cards render or an empty state message
     const hasCards = await page.locator('[class*="event"]').first().isVisible().catch(() => false);
     const hasContent = await page.locator("text").first().isVisible();
     expect(hasCards || hasContent).toBeTruthy();
@@ -23,7 +22,7 @@ test.describe("homepage", () => {
 
   test("navigates to about page", async ({ page }) => {
     await goToHomepage(page);
-    await page.getByRole("link", { name: /about/i }).click();
+    await page.getByRole("link", { name: "ABOUT", exact: true }).click();
     await expect(page).toHaveURL(/\/about/);
   });
 });

--- a/lib/amplify-server.ts
+++ b/lib/amplify-server.ts
@@ -102,12 +102,12 @@ export async function getAdminSession(): Promise<AdminSession | null> {
   if (!cognitoSession.groups.includes("admin-nonprod-users")) return null;
 
   try {
-    const admin = await prisma.admin.findUnique({
+    const admin = await prisma.admin.upsert({
       where:  { cognitoSub: cognitoSession.sub },
+      update: { email: cognitoSession.email },
+      create: { cognitoSub: cognitoSession.sub, email: cognitoSession.email },
       select: { id: true, email: true, name: true },
     });
-    if (!admin) return null;
-
     return { sub: admin.id, email: admin.email, name: admin.name };
   } catch {
     return null;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -68,6 +68,7 @@ async function main() {
       insuranceDeclared:       true,
       stripeAccountId:         "acct_seed_test_1234xyz",
       stripeOnboardingComplete: true,
+      photos:                  [],
     },
   });
 
@@ -89,6 +90,7 @@ async function main() {
       instagram:    "@coastal_trail",
       facebook:     "coastaltrailrunning",
       bio:          "Australia's premier trail running event organisers. From coastal paths to mountain peaks, we bring you the best trail running experiences on the east coast.",
+      photos:       [],
     },
   });
 
@@ -110,6 +112,7 @@ async function main() {
       instagram:    "@urban_fitness_events",
       facebook:     "urbanfitnessevents",
       bio:          "Bringing fitness to the city. We organise urban running events, park runs, and community fitness challenges across Australia's major cities.",
+      photos:       [],
     },
   });
 


### PR DESCRIPTION
## Fixes #16 — Admin account setup

The core admin event approval pipeline already existed, but had several robustness gaps. This PR hardens the admin flow:

### Changes
- **Fix chicken-and-egg bug in `getAdminSession`** — Changed from `findUnique` to `upsert` (matching `getOrganiserSession`). Previously, if the session endpoint call failed silently, the admin would get stuck in an infinite login redirect loop.
- **Add pagination to admin events API** — `page`/`limit` params (default 1/50, max 100), returns `{ events, total, page, totalPages }` with `Cache-Control: no-store`.
- **Add Prev/Next pagination to admin events page** — Client-side pagination controls in the events list.
- **Atomic review endpoint** — Wrapped event status update + notification creation in a `prisma.$transaction()` so both succeed or both rollback. Previously the DB update committed before the notification, risking silent data loss on crash.
- **Error handling on admin dashboard** — `try/catch` around stats queries so a DB error doesn't crash the page.
- **Fix seed script** — Added required `photos` field to all organiser creates.
- **15 E2E tests** covering admin login, dashboard, events page, approval flow, and organisers page.
- **Fix pre-existing homepage E2E test strictness** — Exact link name matching for EVENTS/ABOUT nav links.