### PR TITLE
feat: add Mailpit for local email testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ AWS_SECRET_ACCESS_KEY="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 # ── Email (Resend) ──────────────────────────────────────────────────────────────
 RESEND_API_KEY="re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+# SMTP settings for Mailpit in local dev (docker-compose)
+SMTP_HOST="localhost"
+SMTP_PORT="1025"
+SMTP_USER=""
+SMTP_PASS=""
 
 # ── Stripe (Connect) ────────────────────────────────────────────────────────────
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_xxxxxxxxxxxxxxxxxxxx"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,5 +19,19 @@ services:
       timeout: 5s
       retries: 5
 
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: startline-mailpit
+    restart: unless-stopped
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    environment:
+      MP_MAX_MESSAGES: 5000
+      MP_DATA_FILE: /data/mailpit.db
+    volumes:
+      - mailpit_data:/data
+
 volumes:
   postgres_data:
+  mailpit_data:


### PR DESCRIPTION
## Summary

Adds Mailpit to the local development stack for catching and inspecting emails during development.

## Changes

- **docker-compose.yml**: Added Mailpit container on ports 1025 (SMTP) and 8025 (web UI)
- **.env.example**: Added `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` env vars

## Usage

After `docker compose up -d`, access Mailpit at http://localhost:8025 to view all emails sent via SMTP to localhost:1025.