### PR TITLE
feat: add per-environment S3 upload buckets

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -47,7 +47,20 @@ jobs:
           PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
         with:
           script: |
-            const body = `### Terraform plan\n\n\`\`\`\n${process.env.PLAN_STDOUT}\n\`\`\``;
+            const plan = process.env.PLAN_STDOUT;
+            const summary = plan.match(/Plan:.*?(?:\d.*?)?(?:to add|to change|to destroy|No changes).*/)?.[0].trim()
+              ?? plan.match(/No changes\./)?.[0]
+              ?? "See full plan below.";
+            const emoji = plan.includes("No changes") ? "✅" : "📋";
+            const body = `${emoji} **Terraform plan — ${summary}**
+
+<details><summary>Full plan output</summary>
+
+\`\`\`
+${plan}
+\`\`\`
+
+</details>`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -63,7 +63,7 @@ jobs:
               if (changes.length) {
                 const groups = {};
                 for (const r of changes) {
-                  const m = r.address.match(/^((?:[a-z][a-z0-9-]*\[?[^\]]*\]?\.)*)?([a-z]+_[a-z]+\.[a-zA-Z0-9_-]+)$/);
+                  const m = r.address.match(/^((?:[a-z][a-z0-9-]*\[?[^\]]*\]?\.)*)?([a-z][a-z0-9]*_[a-z0-9_]+\.[a-zA-Z0-9_-]+)$/);
                   const mod = m?.[1] ? m[1].replace(/\.$/, "") : "(root)";
                   const resource = m?.[2] ?? r.address;
                   if (!groups[mod]) groups[mod] = { create: [], update: [], delete: [], read: [] };

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: '1.10.0'
-          terraform_wrapper: false
 
       - run: terraform init
       - run: terraform fmt -check
@@ -43,30 +42,18 @@ jobs:
           TF_VAR_resend_api_key: ${{ secrets.RESEND_API_KEY }}
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
-      - run: terraform show -json tfplan > /tmp/tfplan.json
-        continue-on-error: true
-
-      - run: terraform show -no-color tfplan > /tmp/tfplan.txt
-        continue-on-error: true
-
-      - uses: liatrio/terraform-change-pr-commenter@v1.14.2
-        with:
-          json-file: /tmp/tfplan.json
-          github-token: ${{ github.token }}
-          expand-comment: 'true'
-
       - uses: actions/github-script@v7
+        env:
+          PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
         with:
           script: |
-            try {
-              const plan = require("fs").readFileSync("/tmp/tfplan.txt", "utf8");
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `<details><summary>Full terraform plan</summary>\n\n\`\`\`\n${plan}\n\`\`\`\n\n</details>`,
-              });
-            } catch {}
+            const body = `### Terraform plan\n\n\`\`\`\n${process.env.PLAN_STDOUT}\n\`\`\``;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
 
       - if: steps.plan.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -49,24 +49,51 @@ jobs:
       - run: terraform show -no-color tfplan > /tmp/tfplan.txt
         continue-on-error: true
 
-      - uses: liatrio/terraform-change-pr-commenter@v1.14.2
-        with:
-          json-file: /tmp/tfplan.json
-          github-token: ${{ github.token }}
-          expand-comment: 'true'
-
       - uses: actions/github-script@v7
         with:
           script: |
+            const fs = require("fs");
+
+            let table = "";
             try {
-              const plan = require("fs").readFileSync("/tmp/tfplan.txt", "utf8");
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `<details><summary>Full terraform plan</summary>\n\n\`\`\`\n${plan}\n\`\`\`\n\n</details>`,
-              });
+              const j = JSON.parse(fs.readFileSync("/tmp/tfplan.json", "utf8"));
+              const rc = j.resource_changes ?? [];
+              if (rc.length) {
+                const g = {};
+                for (const r of rc) {
+                  const m = r.address.match(/^((?:[a-z][a-z0-9-]*\[?[^\]]*\]?\.)*)?([a-z][a-z0-9]*_[a-z0-9_]+\.[a-zA-Z0-9_-]+)$/);
+                  const mod = m?.[1] ? m[1].replace(/\.$/, "") : "root";
+                  const res = m?.[2] ?? r.address;
+                  if (!g[mod]) g[mod] = { create: [], update: [], delete: [], read: [] };
+                  const a = r.change.actions;
+                       if (a.includes("create") && !a.includes("delete")) g[mod].create.push(res);
+                  else if (a.includes("delete") && !a.includes("create")) g[mod].delete.push(res);
+                  else if (a.includes("update"))                       g[mod].update.push(res);
+                  else if (a.includes("read"))                         g[mod].read.push(res);
+                }
+                const labels = { create: "🟢 + create", update: "🟡 ~ update", delete: "🔴 - delete", read: "🔵 read" };
+                for (const [mod, rows] of Object.entries(g)) {
+                  let t = "";
+                  for (const [action, label] of Object.entries(labels)) {
+                    if (rows[action].length) t += `| ${label} | ${rows[action].join("<br>")} |\n`;
+                  }
+                  if (t) table += `### ${mod}\n| Action | Resource |\n|--------|----------|\n${t}\n`;
+                }
+              }
             } catch {}
+
+            let raw = "";
+            try { raw = fs.readFileSync("/tmp/tfplan.txt", "utf8"); } catch {}
+
+            const header = !raw.includes("No changes") ? "📋 **Terraform plan**" : "✅ **Terraform plan — no changes**";
+            const body = `${header}\n\n${table}\n<details><summary>Full plan output</summary>\n\n\`\`\`\n${raw}\n\`\`\`\n\n</details>`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
 
       - if: steps.plan.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: '1.10.0'
+          terraform_wrapper: false
 
       - run: terraform init
       - run: terraform fmt -check
@@ -42,18 +43,18 @@ jobs:
           TF_VAR_resend_api_key: ${{ secrets.RESEND_API_KEY }}
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
-      - uses: actions/github-script@v7
-        env:
-          PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
+      - run: terraform show -no-color tfplan > /tmp/terraform.text
+        continue-on-error: true
+
+      - run: terraform show -json tfplan > /tmp/terraform.json
+        continue-on-error: true
+
+      - uses: ahmadnassri/action-terraform-report@v4
         with:
-          script: |
-            const body = `### Terraform plan\n\n\`\`\`\n${process.env.PLAN_STDOUT}\n\`\`\``;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body,
-            });
+          terraform-text: /tmp/terraform.text
+          terraform-json: /tmp/terraform.json
+          github-token: ${{ github.token }}
+          show-diff: true
 
       - if: steps.plan.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -42,57 +42,12 @@ jobs:
           TF_VAR_resend_api_key: ${{ secrets.RESEND_API_KEY }}
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
-      - run: terraform show -json tfplan > /tmp/tfplan.json
-        continue-on-error: true
-
       - uses: actions/github-script@v7
         env:
           PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
         with:
           script: |
-            const fs = require("fs");
-            const plan = process.env.PLAN_STDOUT;
-            const summary = plan.match(/Plan:.*?(?:\d.*?)?(?:to add|to change|to destroy|No changes).*/)?.[0].trim()
-              ?? plan.match(/No changes\./)?.[0]
-              ?? "See full plan below.";
-
-            let body = "";
-            try {
-              const j = JSON.parse(fs.readFileSync("/tmp/tfplan.json", "utf8"));
-              const changes = j.resource_changes ?? [];
-              if (changes.length) {
-                const groups = {};
-                for (const r of changes) {
-                  const m = r.address.match(/^((?:[a-z][a-z0-9-]*\[?[^\]]*\]?\.)*)?([a-z][a-z0-9]*_[a-z0-9_]+\.[a-zA-Z0-9_-]+)$/);
-                  const mod = m?.[1] ? m[1].replace(/\.$/, "") : "(root)";
-                  const resource = m?.[2] ?? r.address;
-                  if (!groups[mod]) groups[mod] = { create: [], update: [], delete: [], read: [] };
-                  const a = r.change.actions;
-                       if (a.includes("create") && !a.includes("delete")) groups[mod].create.push(resource);
-                  else if (a.includes("delete") && !a.includes("create")) groups[mod].delete.push(resource);
-                  else if (a.includes("update"))                       groups[mod].update.push(resource);
-                  else if (a.includes("read"))                         groups[mod].read.push(resource);
-                }
-                for (const [mod, rows] of Object.entries(groups)) {
-                  let table = "";
-                  for (const [action, label] of [["create", "🟢 **+ create**"], ["update", "🟡 **~ update**"], ["delete", "🔴 **- delete**"], ["read", "🔵 **read**"]]) {
-                    if (rows[action].length) {
-                      table += `| ${label} | ${rows[action].join("<br>")} |\n`;
-                    }
-                  }
-                  if (table) {
-                    body += `### ${mod}\n| Action | Resource |\n|--------|----------|\n${table}\n\n`;
-                  }
-                }
-              }
-            } catch (e) { body += `_Plan parse failed: ${e.message}_\n\n`; }
-
-            const hasChanges = plan.includes("to add") || plan.includes("to change") || plan.includes("to destroy");
-            const emoji = !hasChanges ? "✅" : "📋";
-
-            body = `${emoji} **Terraform plan \u2014 ${summary}**\n\n${body}`;
-            body += `<details><summary>Full plan output</summary>\n\n\`\`\`\n${plan}\n\`\`\`\n\n</details>`;
-
+            const body = `### Terraform plan\n\n\`\`\`\n${process.env.PLAN_STDOUT}\n\`\`\``;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -52,15 +52,7 @@ jobs:
               ?? plan.match(/No changes\./)?.[0]
               ?? "See full plan below.";
             const emoji = plan.includes("No changes") ? "✅" : "📋";
-            const body = `${emoji} **Terraform plan — ${summary}**
-
-<details><summary>Full plan output</summary>
-
-\`\`\`
-${plan}
-\`\`\`
-
-</details>`;
+            const body = `${emoji} **Terraform plan \u2014 ${summary}**\n\n<details><summary>Full plan output</summary>\n\n\`\`\`\n${plan}\n\`\`\`\n\n</details>`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -42,17 +42,49 @@ jobs:
           TF_VAR_resend_api_key: ${{ secrets.RESEND_API_KEY }}
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
+      - run: terraform show -json tfplan > /tmp/tfplan.json
+        continue-on-error: true
+
       - uses: actions/github-script@v7
         env:
           PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
         with:
           script: |
+            const fs = require("fs");
             const plan = process.env.PLAN_STDOUT;
             const summary = plan.match(/Plan:.*?(?:\d.*?)?(?:to add|to change|to destroy|No changes).*/)?.[0].trim()
               ?? plan.match(/No changes\./)?.[0]
               ?? "See full plan below.";
-            const emoji = plan.includes("No changes") ? "✅" : "📋";
-            const body = `${emoji} **Terraform plan \u2014 ${summary}**\n\n<details><summary>Full plan output</summary>\n\n\`\`\`\n${plan}\n\`\`\`\n\n</details>`;
+
+            let table = "";
+            try {
+              const j = JSON.parse(fs.readFileSync("/tmp/tfplan.json", "utf8"));
+              const changes = j.resource_changes ?? [];
+              if (changes.length) {
+                const rows = { create: [], update: [], delete: [], read: [] };
+                for (const r of changes) {
+                  const a = r.change.actions;
+                       if (a.includes("create") && !a.includes("delete")) rows.create.push(r.address);
+                  else if (a.includes("delete") && !a.includes("create")) rows.delete.push(r.address);
+                  else if (a.includes("update"))                       rows.update.push(r.address);
+                  else if (a.includes("read"))                         rows.read.push(r.address);
+                }
+                for (const [action, label] of [["create", "🟢 **+ create**"], ["update", "🟡 **~ update**"], ["delete", "🔴 **- delete**"], ["read", "🔵 **read**"]]) {
+                  if (rows[action].length) {
+                    table += `| ${label} | ${rows[action].join("<br>")} |\n`;
+                  }
+                }
+                if (table) table = `| Action | Resource |\n|--------|----------|\n${table}`;
+              }
+            } catch {}
+
+            const hasChanges = plan.includes("to add") || plan.includes("to change") || plan.includes("to destroy");
+            const emoji = !hasChanges ? "✅" : "📋";
+
+            let body = `${emoji} **Terraform plan \u2014 ${summary}**\n\n`;
+            if (table) body += `${table}\n\n`;
+            body += `<details><summary>Full plan output</summary>\n\n\`\`\`\n${plan}\n\`\`\`\n\n</details>`;
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -46,11 +46,27 @@ jobs:
       - run: terraform show -json tfplan > /tmp/tfplan.json
         continue-on-error: true
 
+      - run: terraform show -no-color tfplan > /tmp/tfplan.txt
+        continue-on-error: true
+
       - uses: liatrio/terraform-change-pr-commenter@v1.14.2
         with:
           json-file: /tmp/tfplan.json
           github-token: ${{ github.token }}
           expand-comment: 'true'
+
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const plan = require("fs").readFileSync("/tmp/tfplan.txt", "utf8");
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `<details><summary>Full terraform plan</summary>\n\n\`\`\`\n${plan}\n\`\`\`\n\n</details>`,
+              });
+            } catch {}
 
       - if: steps.plan.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -46,7 +46,7 @@ jobs:
       - run: terraform show -json tfplan > /tmp/tfplan.json
         continue-on-error: true
 
-      - uses: liatrio/terraform-change-pr-commenter@v1
+      - uses: liatrio/terraform-change-pr-commenter@v1.14.2
         with:
           json-file: /tmp/tfplan.json
           github-token: ${{ github.token }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -47,7 +47,10 @@ jobs:
           PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
         with:
           script: |
-            const body = `### Terraform plan\n\n\`\`\`\n${process.env.PLAN_STDOUT}\n\`\`\``;
+            const plan = process.env.PLAN_STDOUT;
+            const summary = plan.match(/Plan:.*?(?:\d.*?)?(?:to add|to change|to destroy|No changes).*/)?.[0]?.trim()
+              ?? "See full plan below.";
+            const body = `<details><summary>${summary}</summary>\n\n\`\`\`\n${plan}\n\`\`\`\n\n</details>`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -56,33 +56,41 @@ jobs:
               ?? plan.match(/No changes\./)?.[0]
               ?? "See full plan below.";
 
-            let table = "";
+            let body = "";
             try {
               const j = JSON.parse(fs.readFileSync("/tmp/tfplan.json", "utf8"));
               const changes = j.resource_changes ?? [];
               if (changes.length) {
-                const rows = { create: [], update: [], delete: [], read: [] };
+                const groups = {};
                 for (const r of changes) {
+                  const m = r.address.match(/^((?:[a-z][a-z0-9-]*\[?[^\]]*\]?\.)*)?([a-z]+_[a-z]+\.[a-zA-Z0-9_-]+)$/);
+                  const mod = m?.[1] ? m[1].replace(/\.$/, "") : "(root)";
+                  const resource = m?.[2] ?? r.address;
+                  if (!groups[mod]) groups[mod] = { create: [], update: [], delete: [], read: [] };
                   const a = r.change.actions;
-                       if (a.includes("create") && !a.includes("delete")) rows.create.push(r.address);
-                  else if (a.includes("delete") && !a.includes("create")) rows.delete.push(r.address);
-                  else if (a.includes("update"))                       rows.update.push(r.address);
-                  else if (a.includes("read"))                         rows.read.push(r.address);
+                       if (a.includes("create") && !a.includes("delete")) groups[mod].create.push(resource);
+                  else if (a.includes("delete") && !a.includes("create")) groups[mod].delete.push(resource);
+                  else if (a.includes("update"))                       groups[mod].update.push(resource);
+                  else if (a.includes("read"))                         groups[mod].read.push(resource);
                 }
-                for (const [action, label] of [["create", "🟢 **+ create**"], ["update", "🟡 **~ update**"], ["delete", "🔴 **- delete**"], ["read", "🔵 **read**"]]) {
-                  if (rows[action].length) {
-                    table += `| ${label} | ${rows[action].join("<br>")} |\n`;
+                for (const [mod, rows] of Object.entries(groups)) {
+                  let table = "";
+                  for (const [action, label] of [["create", "🟢 **+ create**"], ["update", "🟡 **~ update**"], ["delete", "🔴 **- delete**"], ["read", "🔵 **read**"]]) {
+                    if (rows[action].length) {
+                      table += `| ${label} | ${rows[action].join("<br>")} |\n`;
+                    }
+                  }
+                  if (table) {
+                    body += `### ${mod}\n| Action | Resource |\n|--------|----------|\n${table}\n\n`;
                   }
                 }
-                if (table) table = `| Action | Resource |\n|--------|----------|\n${table}`;
               }
-            } catch {}
+            } catch (e) { body += `_Plan parse failed: ${e.message}_\n\n`; }
 
             const hasChanges = plan.includes("to add") || plan.includes("to change") || plan.includes("to destroy");
             const emoji = !hasChanges ? "✅" : "📋";
 
-            let body = `${emoji} **Terraform plan \u2014 ${summary}**\n\n`;
-            if (table) body += `${table}\n\n`;
+            body = `${emoji} **Terraform plan \u2014 ${summary}**\n\n${body}`;
             body += `<details><summary>Full plan output</summary>\n\n\`\`\`\n${plan}\n\`\`\`\n\n</details>`;
 
             github.rest.issues.createComment({

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -49,51 +49,24 @@ jobs:
       - run: terraform show -no-color tfplan > /tmp/tfplan.txt
         continue-on-error: true
 
+      - uses: liatrio/terraform-change-pr-commenter@v1.14.2
+        with:
+          json-file: /tmp/tfplan.json
+          github-token: ${{ github.token }}
+          expand-comment: 'true'
+
       - uses: actions/github-script@v7
         with:
           script: |
-            const fs = require("fs");
-
-            let table = "";
             try {
-              const j = JSON.parse(fs.readFileSync("/tmp/tfplan.json", "utf8"));
-              const rc = j.resource_changes ?? [];
-              if (rc.length) {
-                const g = {};
-                for (const r of rc) {
-                  const m = r.address.match(/^((?:[a-z][a-z0-9-]*\[?[^\]]*\]?\.)*)?([a-z][a-z0-9]*_[a-z0-9_]+\.[a-zA-Z0-9_-]+)$/);
-                  const mod = m?.[1] ? m[1].replace(/\.$/, "") : "root";
-                  const res = m?.[2] ?? r.address;
-                  if (!g[mod]) g[mod] = { create: [], update: [], delete: [], read: [] };
-                  const a = r.change.actions;
-                       if (a.includes("create") && !a.includes("delete")) g[mod].create.push(res);
-                  else if (a.includes("delete") && !a.includes("create")) g[mod].delete.push(res);
-                  else if (a.includes("update"))                       g[mod].update.push(res);
-                  else if (a.includes("read"))                         g[mod].read.push(res);
-                }
-                const labels = { create: "🟢 + create", update: "🟡 ~ update", delete: "🔴 - delete", read: "🔵 read" };
-                for (const [mod, rows] of Object.entries(g)) {
-                  let t = "";
-                  for (const [action, label] of Object.entries(labels)) {
-                    if (rows[action].length) t += `| ${label} | ${rows[action].join("<br>")} |\n`;
-                  }
-                  if (t) table += `### ${mod}\n| Action | Resource |\n|--------|----------|\n${t}\n`;
-                }
-              }
+              const plan = require("fs").readFileSync("/tmp/tfplan.txt", "utf8");
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `<details><summary>Full terraform plan</summary>\n\n\`\`\`\n${plan}\n\`\`\`\n\n</details>`,
+              });
             } catch {}
-
-            let raw = "";
-            try { raw = fs.readFileSync("/tmp/tfplan.txt", "utf8"); } catch {}
-
-            const header = !raw.includes("No changes") ? "📋 **Terraform plan**" : "✅ **Terraform plan — no changes**";
-            const body = `${header}\n\n${table}\n<details><summary>Full plan output</summary>\n\n\`\`\`\n${raw}\n\`\`\`\n\n</details>`;
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body,
-            });
 
       - if: steps.plan.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -43,18 +43,14 @@ jobs:
           TF_VAR_resend_api_key: ${{ secrets.RESEND_API_KEY }}
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
-      - run: terraform show -no-color tfplan > /tmp/terraform.text
+      - run: terraform show -json tfplan > /tmp/tfplan.json
         continue-on-error: true
 
-      - run: terraform show -json tfplan > /tmp/terraform.json
-        continue-on-error: true
-
-      - uses: ahmadnassri/action-terraform-report@v4
+      - uses: liatrio/terraform-change-pr-commenter@v1
         with:
-          terraform-text: /tmp/terraform.text
-          terraform-json: /tmp/terraform.json
+          json-file: /tmp/tfplan.json
           github-token: ${{ github.token }}
-          show-diff: true
+          expand-comment: 'true'
 
       - if: steps.plan.outcome == 'failure'
         run: exit 1

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,6 +62,7 @@ locals {
       database_skip_final_snapshot = false
       database_deletion_protection = true
       cognito_deletion_protection  = true
+      bucket_cors_allowed_origins  = ["https://startlineau.com", "https://organiser.startlineau.com"]
     }
     nonprod = {
       branch_name                  = "non-production"
@@ -71,6 +72,7 @@ locals {
       database_skip_final_snapshot = true
       database_deletion_protection = false
       cognito_deletion_protection  = false
+      bucket_cors_allowed_origins  = ["*"]
     }
   }
 }
@@ -134,6 +136,8 @@ module "env" {
   database_secret_recovery_window_days  = var.database_secret_recovery_window_days
 
   cognito_deletion_protection = each.value.cognito_deletion_protection
+
+  bucket_cors_allowed_origins = each.value.bucket_cors_allowed_origins
 }
 
 # Custom apex domain attaches only to the prod branch. Route 53 records that

--- a/terraform/modules/environment/main.tf
+++ b/terraform/modules/environment/main.tf
@@ -263,8 +263,82 @@ resource "aws_amplify_branch" "this" {
 
   environment_variables = merge(
     {
-      DATABASE_URL = local.database_url
+      DATABASE_URL                   = local.database_url
+      UPLOADS_BUCKET                 = aws_s3_bucket.uploads.id
+      UPLOADS_BUCKET_REGIONAL_DOMAIN = aws_s3_bucket.uploads.bucket_regional_domain_name
     },
     var.extra_branch_environment_variables,
   )
+}
+
+# ===== S3 upload bucket =====
+
+data "aws_iam_policy_document" "uploads_public_read" {
+  statement {
+    sid    = "PublicReadForImages"
+    effect = "Allow"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.uploads.arn}/images/*"]
+  }
+}
+
+resource "aws_s3_bucket" "uploads" {
+  bucket = "${var.project_name}-${var.name}-uploads"
+
+  force_destroy = var.name != "prod"
+
+  tags = {
+    Environment = var.name
+  }
+}
+
+resource "aws_s3_bucket_versioning" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+  versioning_configuration {
+    status = "Suspended"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  block_public_acls       = true
+  block_public_policy     = false
+  ignore_public_acls      = true
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "uploads_public_read" {
+  bucket = aws_s3_bucket.uploads.id
+  policy = data.aws_iam_policy_document.uploads_public_read.json
+}
+
+resource "aws_s3_bucket_cors_configuration" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  dynamic "cors_rule" {
+    for_each = [for i, v in var.bucket_cors_allowed_origins : {
+      origin = v
+    }]
+    content {
+      allowed_headers = ["*"]
+      allowed_methods = ["GET", "PUT", "POST", "DELETE"]
+      allowed_origins = [cors_rule.value.origin]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3600
+    }
+  }
 }

--- a/terraform/modules/environment/outputs.tf
+++ b/terraform/modules/environment/outputs.tf
@@ -50,3 +50,18 @@ output "cognito_app_client_secret" {
   value     = aws_cognito_user_pool_client.web.client_secret
   sensitive = true
 }
+
+output "uploads_bucket_id" {
+  description = "S3 bucket name for user-uploaded images."
+  value       = aws_s3_bucket.uploads.id
+}
+
+output "uploads_bucket_arn" {
+  description = "S3 bucket ARN for user-uploaded images."
+  value       = aws_s3_bucket.uploads.arn
+}
+
+output "uploads_bucket_regional_domain_name" {
+  description = "Regional domain name for the uploads bucket."
+  value       = aws_s3_bucket.uploads.bucket_regional_domain_name
+}

--- a/terraform/modules/environment/variables.tf
+++ b/terraform/modules/environment/variables.tf
@@ -114,3 +114,10 @@ variable "cognito_deletion_protection" {
   description = "Enable deletion protection on the User Pool."
   type        = bool
 }
+
+# --- S3 upload bucket ---
+
+variable "bucket_cors_allowed_origins" {
+  description = "CORS allowed origins for the uploads bucket."
+  type        = list(string)
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -99,3 +99,18 @@ output "github_actions_role_arn" {
   description = "Set as GitHub repo variable AWS_ROLE_ARN for the terraform workflows."
   value       = aws_iam_role.terraform_ci.arn
 }
+
+output "uploads_bucket_ids" {
+  description = "S3 upload bucket names per environment."
+  value       = { for k, m in module.env : k => m.uploads_bucket_id }
+}
+
+output "uploads_bucket_arns" {
+  description = "S3 upload bucket ARNs per environment."
+  value       = { for k, m in module.env : k => m.uploads_bucket_arn }
+}
+
+output "uploads_bucket_regional_domain_names" {
+  description = "S3 upload bucket regional domain names per environment."
+  value       = { for k, m in module.env : k => m.uploads_bucket_regional_domain_name }
+}


### PR DESCRIPTION
Adds per-environment S3 buckets for user-uploaded images (profile pics, banners, event images).

## What's included

- New bucket `startline-{env}-uploads` in each environment module
- Bucket policy granting public read for `images/*` prefix
- CORS rules: prod allows `startlineau.com` domains, nonprod allows all origins
- AES256 server-side encryption
- Block public ACLs but allow bucket policy
- Nonprod has `force_destroy = true` for easy cleanup
- Bucket name and regional domain injected into Amplify branch env vars
- Root-level outputs for all environments

## Skipped (ponytail:)

- CloudFront CDN — add if latency or bandwidth becomes an issue
- Upload API / presigned URL flow — that's the next step after the bucket exists

Closes #36