### PR TITLE
feat: add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,91 @@
+name: Issue
+description: Create a new issue
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Fields marked with * are required.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description *
+      description: Clear context, background, and motivation
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist of requirements to close this issue
+      placeholder: |
+        - [ ]
+        - [ ]
+    validations:
+      required: false
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type *
+      options:
+        - Bug
+        - Feature
+        - Task
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority *
+      description: Set via the Priority field (not a label)
+      options:
+        - Urgent
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort *
+      description: Set via the Effort field (not a label)
+      options:
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: labels
+    attributes:
+      label: Labels
+      description: Select all that apply (set via GitHub label, not just text)
+      options:
+        - label: bug
+        - label: enhancement
+        - label: documentation
+        - label: auth
+        - label: ci
+        - label: infrastructure
+        - label: ui
+        - label: payments
+        - label: maps
+        - label: video
+        - label: dashboard
+        - label: registrations
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related issues
+      description: Link related issues (e.g. #123)
+      placeholder: "Related to:"
+    validations:
+      required: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,12 +170,14 @@ When creating a pull request, always scan open GitHub issues and link any that t
 When creating GitHub issues, always:
 - Add relevant **labels** (create new ones if they don't exist). Available labels: `bug`, `enhancement`, `documentation`, `auth`, `ci`, `infrastructure`, `ui`, `payments`, `maps`, `video`, `dashboard`, `registrations`, `question`, `help wanted`, `good first issue`
 - Set the native **issue type** — `Bug`, `Feature`, or `Task` (not a label, a proper field)
+- Set **Priority** and **Effort** issue fields using the GraphQL API (`setIssueFieldValue` mutation) — `gh issue create` has no native flags for these
 - Assign a **milestone** if one exists for the relevant sprint/release
 - Assign to a **project** if one exists
-- Write a descriptive **body** with clear context, requirements, and acceptance criteria
+- Use the issue template at `.github/ISSUE_TEMPLATE/issue.yml` — it enforces Type, Priority, and Effort as required fields
 - Use `gh issue create --repo StartlineAU/startline --label "<label1,label2>" --type "<Bug|Feature|Task>" --assignee "@me"` for new issues
 - Cross-reference **related issues** in the body (`**Related to:** #N`) and use `--add-blocking`/`--add-blocked-by` for dependency relationships
 - Use `--add-sub-issue` and `--parent` for parent-child issue hierarchies
+- After creation, set Priority/Effort via GraphQL — use the issue's GraphQL node ID (`gh issue view <N> --json id`) then `setIssueFieldValue` with field IDs. Available fields: **Priority** (Urgent/High/Medium/Low), **Effort** (High/Medium/Low), **Start date**, **Target date**
 
 ## MCP servers
 


### PR DESCRIPTION
Adds a GitHub issue template with required Type (Bug/Feature/Task), Priority (Urgent/High/Medium/Low), and Effort (High/Medium/Low) dropdowns, plus labels checkboxes and related issues field.

Also updates AGENTS.md with instructions for using the template and setting Priority/Effort via GraphQL after creation.