### PR TITLE
Fix e2e tests: seed DB in CI, Stripe webhook 400, add missing migration, switch to tsx, update AGENTS.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: npx prisma generate
       - run: pnpm test
 
   e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
       - run: npx playwright install chromium
       - run: npx prisma generate
       - run: npx prisma migrate deploy
+      - run: npx prisma db seed
       - name: Start Next.js dev server
         run: |
           pnpm dev -p 3002 &

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,29 +196,47 @@ When creating a pull request, always:
 When creating GitHub issues, always:
 - Add relevant **labels** (create new ones if they don't exist). Available labels: `bug`, `enhancement`, `documentation`, `auth`, `ci`, `infrastructure`, `ui`, `payments`, `maps`, `video`, `dashboard`, `registrations`, `question`, `help wanted`, `good first issue`
 - Set the native **issue type** — `Bug`, `Feature`, or `Task` (not a label, a proper field)
-- Set **Priority** and **Effort** issue fields using the GraphQL API (`setIssueFieldValue` mutation) — `gh issue create` has no native flags for these
+- Set **Priority** and **Effort** issue fields using the GraphQL API — `gh issue create` has no native flags for these
 - Assign a **milestone** if one exists for the relevant sprint/release
 - Assign to a **project** if one exists
 - Use the issue template at `.github/ISSUE_TEMPLATE/issue.yml` — it enforces Type, Priority, and Effort as required fields
-- Use `gh issue create --repo StartlineAU/startline --label "<label1,label2>" --type "<Bug|Feature|Task>" --assignee "@me"` for new issues
 - Cross-reference **related issues** in the body (`**Related to:** #N`) and use `--add-blocking`/`--add-blocked-by` for dependency relationships
 - Use `--add-sub-issue` and `--parent` for parent-child issue hierarchies
-- After creation, set Priority/Effort via GraphQL — `gh issue create` has no native flags for these. Steps:
-  1. Get the issue's GraphQL node ID: `gh issue view <N> --json id --jq '.id'`
-  2. Get field option IDs (one-time discovery):
-     ```
-     Priority options: IFSSO_kgDOBFZBjQ(Urgent), IFSSO_kgDOBFZBjg(High), IFSSO_kgDOBFZBjw(Medium), IFSSO_kgDOBFZBkA(Low)
-     Effort options:   IFSSO_kgDOBFZBkQ(High),   IFSSO_kgDOBFZBkg(Medium), IFSSO_kgDOBFZBkw(Low)
-     ```
-  3. Set fields via mutation:
-     ```bash
-     gh api graphql -f query='
-       mutation {
-         p: updateIssueFieldValue(input: { issueId: "<NODE_ID>", issueField: { fieldId: "IFSS_kgDOAnp8Qg", singleSelectOptionId: "<OPTION_ID>" } }) { issue { number } }
-         e: updateIssueFieldValue(input: { issueId: "<NODE_ID>", issueField: { fieldId: "IFSS_kgDOAnp8RQ", singleSelectOptionId: "<OPTION_ID>" } }) { issue { number } }
-       }'
-     ```
-  Available fields: **Priority** (Urgent/High/Medium/Low), **Effort** (High/Medium/Low), **Start date**, **Target date**
+
+#### Setting issue type (simple)
+```bash
+gh issue edit <N> --repo StartlineAU/startline --type "Bug|Feature|Task"
+```
+
+#### Setting Priority & Effort (GraphQL)
+
+Field IDs (never change):
+- Priority field: `IFSS_kgDOAnp8Qg`
+- Effort field: `IFSS_kgDOAnp8RQ`
+
+| Field | Option | Option ID |
+|---|---|---|
+| Priority | Urgent | `IFSSO_kgDOBFZBjQ` |
+| Priority | High | `IFSSO_kgDOBFZBjg` |
+| Priority | Medium | `IFSSO_kgDOBFZBjw` |
+| Priority | Low | `IFSSO_kgDOBFZBkA` |
+| Effort | High | `IFSSO_kgDOBFZBkQ` |
+| Effort | Medium | `IFSSO_kgDOBFZBkg` |
+| Effort | Low | `IFSSO_kgDOBFZBkw` |
+
+Steps:
+1. Get the issue's GraphQL node ID: `gh issue view <N> --repo StartlineAU/startline --json id --jq '.id'`
+2. Set fields via batch mutation (copy-paste this, replace `<NODE_ID>`, `<PRI_OPT>`, `<EFF_OPT>`):
+   ```bash
+   gh api graphql -f query='
+     mutation {
+       p: updateIssueFieldValue(input: { issueId: "<NODE_ID>", issueField: { fieldId: "IFSS_kgDOAnp8Qg", singleSelectOptionId: "<PRI_OPT>" } }) { issue { number } }
+       e: updateIssueFieldValue(input: { issueId: "<NODE_ID>", issueField: { fieldId: "IFSS_kgDOAnp8RQ", singleSelectOptionId: "<EFF_OPT>" } }) { issue { number } }
+     }'
+   ```
+3. To verify: `gh issue view <N> --repo StartlineAU/startline --json id --jq '.id'` then query the GraphQL node manually if needed.
+
+> **Note:** Priority/Effort are separate from the issue body template fields. Setting them in the body template does NOT set the GraphQL-level custom fields. You must use the GraphQL mutation above.
 
 ## MCP servers
 

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -14,10 +14,11 @@ export async function POST(req: NextRequest) {
     const body = await req.text();
     const signature = req.headers.get("stripe-signature") ?? "";
 
-    const stripe = getStripe();
+    let stripe: Stripe;
     let event: Stripe.Event;
 
     try {
+      stripe = getStripe();
       event = stripe.webhooks.constructEvent(body, signature, getWebhookSecret());
     } catch {
       return NextResponse.json({ error: "Invalid signature." }, { status: 400 });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:e2e": "playwright test",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev --name init",
-    "prisma:seed": "npx ts-node --project tsconfig.json prisma/seed.ts"
+    "prisma:seed": "npx tsx prisma/seed.ts"
   },
   "dependencies": {
     "@aws-amplify/adapter-nextjs": "^1.7.2",
@@ -58,7 +58,7 @@
     ]
   },
   "prisma": {
-    "seed": "npx ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
+    "seed": "npx tsx prisma/seed.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",

--- a/prisma/migrations/20260705111856_add_user_city_state/migration.sql
+++ b/prisma/migrations/20260705111856_add_user_city_state/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "city" TEXT;
+ALTER TABLE "users" ADD COLUMN "state" TEXT;


### PR DESCRIPTION
## Changes

### 🐛 E2E test fixes
- **Seed DB in CI** — added `npx prisma db seed` to CI workflow. Without it, admin events/organisers tests found no data.
- **Fix Stripe webhook returning 500** — moved `getStripe()` inside the inner try-catch so missing Stripe env vars return 400 instead of crashing.
- **Switch seed script from ts-node to tsx** — `ts-node` is incompatible with the project's `"module": "bundler"` tsconfig. Used `tsx` which handles it natively.
- **Add missing migration** — schema had `city`/`state` on User model but no migration. Created `add_user_city_state` migration.

### 📝 Docs
- **AGENTS.md** — table format for Priority/Effort option IDs, working batch GraphQL mutation, note that body template fields don't set GraphQL-level custom fields. Added `gh issue edit --type` for setting issue types.

**All 41 e2e tests pass locally.**