### PR TITLE
fix: replace `<img>` with `<Image />` across codebase

### DIFF
--- a/app/(user)/events/[id]/page.tsx
+++ b/app/(user)/events/[id]/page.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { MapPin, Clock, Calendar, ExternalLink } from "lucide-react";
+import { MapPin, Calendar, ExternalLink } from "lucide-react";
 import { getAllEvents } from "@/lib/events";
 import { toUserEvent } from "@/lib/user-events";
 import { EVENT_TYPE_LABELS, STATE_LABELS } from "@/types";

--- a/app/(user)/events/[id]/page.tsx
+++ b/app/(user)/events/[id]/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { MapPin, Clock, Calendar, ExternalLink } from "lucide-react";
@@ -35,7 +36,7 @@ export default async function EventDetailPage({ params }: { params: Promise<{ id
 
       {/* ── Banner ── */}
       <div className="relative overflow-hidden" style={{ aspectRatio: "4/3", maxHeight: "520px" }}>
-        <img src={bannerUrl} alt={event.title} className="absolute inset-0 w-full h-full object-cover" />
+        <Image src={bannerUrl} alt={event.title} fill className="object-cover" sizes="100vw" />
         <div className="absolute inset-0 bg-gradient-to-t from-dark-darker via-dark-darker/50 to-transparent" />
 
         {/* Badges */}

--- a/app/(user)/profile/page.tsx
+++ b/app/(user)/profile/page.tsx
@@ -316,18 +316,18 @@ export default function ProfilePage() {
               ) : (
                 <>
                   {/* Avatar */}
-                  <div
-                    className="w-20 h-20 rounded-full bg-primary border-2 border-primary flex items-center justify-center overflow-hidden flex-shrink-0"
-                    style={{ boxShadow: "3px 3px 0 rgba(179, 225, 83, 0.25)" }}
-                  >
-                    {userData?.profilePicUrl ? (
-                      <Image
-                        src={userData.profilePicUrl}
-                        alt={userData?.name ?? "Profile"}
-                        fill
-                        className="object-cover"
-                        sizes="80px"
-                      />
+                    <div
+                      className="relative w-20 h-20 rounded-full bg-primary border-2 border-primary flex items-center justify-center overflow-hidden flex-shrink-0"
+                      style={{ boxShadow: "3px 3px 0 rgba(179, 225, 83, 0.25)" }}
+                    >
+                      {userData?.profilePicUrl ? (
+                        <Image
+                          src={userData.profilePicUrl}
+                          alt={userData?.name ?? "Profile"}
+                          fill
+                          className="pointer-events-none object-cover"
+                          sizes="80px"
+                        />
                     ) : (
                       <span className="font-headline text-3xl font-black text-dark">{initial}</span>
                     )}

--- a/app/(user)/profile/page.tsx
+++ b/app/(user)/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { MapPin, Calendar, Check, X, AlertCircle } from "lucide-react";
 import { STATE_OPTIONS, STATE_LABELS } from "@/types";
 import type { AustralianState } from "@/types";
@@ -320,10 +321,12 @@ export default function ProfilePage() {
                     style={{ boxShadow: "3px 3px 0 rgba(179, 225, 83, 0.25)" }}
                   >
                     {userData?.profilePicUrl ? (
-                      <img
+                      <Image
                         src={userData.profilePicUrl}
                         alt={userData?.name ?? "Profile"}
-                        className="w-full h-full object-cover"
+                        fill
+                        className="object-cover"
+                        sizes="80px"
                       />
                     ) : (
                       <span className="font-headline text-3xl font-black text-dark">{initial}</span>

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import Image from "next/image";
 import { MapPin, Calendar, Check, X, RefreshCw, ChevronDown, ChevronUp } from "lucide-react";
 import AdminNav from "@/components/admin/AdminNav";
 import { Card } from "@/components/ui/card";
@@ -168,7 +169,7 @@ function EventRow({
         {/* Cover thumbnail */}
         <div className="w-14 h-14 rounded-lg bg-gray-100 flex items-center justify-center shrink-0 overflow-hidden">
           {event.coverImageUrl
-            ? <img src={event.coverImageUrl} alt={event.title} className="w-full h-full object-cover" />
+            ? <Image src={event.coverImageUrl} alt={event.title} fill className="object-cover" sizes="56px" />
             : <div className="font-mono text-[9px] text-gray-400 uppercase">{event.discipline.slice(0, 4)}</div>}
         </div>
 

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -167,9 +167,9 @@ function EventRow({
       {/* Main row */}
       <div className="flex items-start gap-4 px-5 py-4">
         {/* Cover thumbnail */}
-        <div className="w-14 h-14 rounded-lg bg-gray-100 flex items-center justify-center shrink-0 overflow-hidden">
+        <div className="relative w-14 h-14 rounded-lg bg-gray-100 flex items-center justify-center shrink-0 overflow-hidden">
           {event.coverImageUrl
-            ? <Image src={event.coverImageUrl} alt={event.title} fill className="object-cover" sizes="56px" />
+            ? <Image src={event.coverImageUrl} alt={event.title} fill className="pointer-events-none object-cover" sizes="56px" />
             : <div className="font-mono text-[9px] text-gray-400 uppercase">{event.discipline.slice(0, 4)}</div>}
         </div>
 

--- a/app/organiser/dashboard/page.tsx
+++ b/app/organiser/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { CalendarDays, ArrowRight, MapPin } from "lucide-react";
 import OrganiserTopBar from "@/components/organiser/TopBar";
 import { Button } from "@/components/ui/button";
@@ -181,7 +182,7 @@ export default function DashboardPage() {
                     >
                       <div className="w-12 h-12 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
                         {e.coverImageUrl
-                          ? <img src={e.coverImageUrl} alt={e.title} className="w-full h-full object-cover brightness-[.62] saturate-110" />
+                          ? <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover brightness-[.62] saturate-110" sizes="48px" />
                           : <div className="font-mono text-[9px] text-muted-dark uppercase">{e.discipline.slice(0, 4)}</div>}
                       </div>
                       <div className="flex-1 min-w-0">
@@ -213,7 +214,7 @@ export default function DashboardPage() {
                       <div className="col-span-5 flex items-center gap-4 min-w-0">
                         <div className="w-14 h-14 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
                           {e.coverImageUrl
-                            ? <img src={e.coverImageUrl} alt={e.title} className="w-full h-full object-cover brightness-[.62] saturate-110" />
+                            ? <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover brightness-[.62] saturate-110" sizes="56px" />
                             : <div className="font-mono text-[9px] text-muted-dark uppercase">{e.discipline.slice(0, 4)}</div>}
                         </div>
                         <div className="min-w-0">

--- a/app/organiser/dashboard/page.tsx
+++ b/app/organiser/dashboard/page.tsx
@@ -180,9 +180,9 @@ export default function DashboardPage() {
                       className="sm:hidden flex items-center gap-3 px-4 py-3.5 cursor-pointer active:bg-white/5 transition-colors"
                       onClick={() => router.push(href)}
                     >
-                      <div className="w-12 h-12 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
-                        {e.coverImageUrl
-                          ? <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover brightness-[.62] saturate-110" sizes="48px" />
+                        <div className="relative w-12 h-12 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
+                          {e.coverImageUrl
+                            ? <Image src={e.coverImageUrl} alt={e.title} fill className="pointer-events-none object-cover brightness-[.62] saturate-110" sizes="48px" />
                           : <div className="font-mono text-[9px] text-muted-dark uppercase">{e.discipline.slice(0, 4)}</div>}
                       </div>
                       <div className="flex-1 min-w-0">
@@ -212,9 +212,9 @@ export default function DashboardPage() {
                       onClick={() => router.push(href)}
                     >
                       <div className="col-span-5 flex items-center gap-4 min-w-0">
-                        <div className="w-14 h-14 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
+                        <div className="relative w-14 h-14 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
                           {e.coverImageUrl
-                            ? <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover brightness-[.62] saturate-110" sizes="56px" />
+                            ? <Image src={e.coverImageUrl} alt={e.title} fill className="pointer-events-none object-cover brightness-[.62] saturate-110" sizes="56px" />
                             : <div className="font-mono text-[9px] text-muted-dark uppercase">{e.discipline.slice(0, 4)}</div>}
                         </div>
                         <div className="min-w-0">

--- a/app/organiser/events/[id]/dashboard/page.tsx
+++ b/app/organiser/events/[id]/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, use } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import {
   ArrowLeft, DollarSign, Megaphone, Plus, Pencil,
   MapPin, Calendar, ChevronRight, AlertCircle, Send, Trash2, Users
@@ -183,7 +184,7 @@ export default function EventDashboardPage({
           <div className="flex flex-col lg:flex-row lg:items-start gap-6 mb-8">
             {event.coverImageUrl && (
               <div className="w-full lg:w-48 h-32 lg:h-32 rounded-xl overflow-hidden shrink-0">
-                <img src={event.coverImageUrl} alt={event.title} className="w-full h-full object-cover brightness-[.62] saturate-110" />
+                <Image src={event.coverImageUrl} alt={event.title} fill className="object-cover brightness-[.62] saturate-110" sizes="(max-width: 1024px) 100vw, 192px" />
               </div>
             )}
             <div className="flex-1 min-w-0">

--- a/app/organiser/events/[id]/dashboard/page.tsx
+++ b/app/organiser/events/[id]/dashboard/page.tsx
@@ -183,8 +183,8 @@ export default function EventDashboardPage({
           {/* Event header */}
           <div className="flex flex-col lg:flex-row lg:items-start gap-6 mb-8">
             {event.coverImageUrl && (
-              <div className="w-full lg:w-48 h-32 lg:h-32 rounded-xl overflow-hidden shrink-0">
-                <Image src={event.coverImageUrl} alt={event.title} fill className="object-cover brightness-[.62] saturate-110" sizes="(max-width: 1024px) 100vw, 192px" />
+              <div className="relative w-full lg:w-48 h-32 lg:h-32 rounded-xl overflow-hidden shrink-0">
+                <Image src={event.coverImageUrl} alt={event.title} fill className="pointer-events-none object-cover brightness-[.62] saturate-110" sizes="(max-width: 1024px) 100vw, 192px" />
               </div>
             )}
             <div className="flex-1 min-w-0">

--- a/app/organiser/events/[id]/page.tsx
+++ b/app/organiser/events/[id]/page.tsx
@@ -175,8 +175,6 @@ export default function EventStatusPage({
   }
 
   const meta       = STATUS_META[event.status];
-  const Icon       = meta.icon;
-  const isPending  = event.status === "PENDING";
   const isRejected = event.status === "REJECTED";
   const isDraft    = event.status === "DRAFT";
 
@@ -197,8 +195,8 @@ export default function EventStatusPage({
           {/* Event header */}
           <div className="flex flex-col lg:flex-row lg:items-start gap-6 mb-8">
             {event.coverImageUrl && (
-              <div className="w-full lg:w-44 h-28 rounded-xl overflow-hidden shrink-0">
-                <Image src={event.coverImageUrl} alt={event.title} fill className="object-cover brightness-[.62] saturate-110" sizes="(max-width: 1024px) 100vw, 176px" />
+              <div className="relative w-full lg:w-44 h-28 rounded-xl overflow-hidden shrink-0">
+                <Image src={event.coverImageUrl} alt={event.title} fill className="pointer-events-none object-cover brightness-[.62] saturate-110" sizes="(max-width: 1024px) 100vw, 176px" />
               </div>
             )}
             <div className="flex-1 min-w-0">

--- a/app/organiser/events/[id]/page.tsx
+++ b/app/organiser/events/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, use } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { ArrowLeft, MapPin, Calendar, Pencil, AlertCircle, Clock, CheckCircle, XCircle, FileText, Send } from "lucide-react";
 import OrganiserTopBar from "@/components/organiser/TopBar";
 
@@ -197,7 +198,7 @@ export default function EventStatusPage({
           <div className="flex flex-col lg:flex-row lg:items-start gap-6 mb-8">
             {event.coverImageUrl && (
               <div className="w-full lg:w-44 h-28 rounded-xl overflow-hidden shrink-0">
-                <img src={event.coverImageUrl} alt={event.title} className="w-full h-full object-cover brightness-[.62] saturate-110" />
+                <Image src={event.coverImageUrl} alt={event.title} fill className="object-cover brightness-[.62] saturate-110" sizes="(max-width: 1024px) 100vw, 176px" />
               </div>
             )}
             <div className="flex-1 min-w-0">

--- a/app/organiser/listings/page.tsx
+++ b/app/organiser/listings/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useEffect, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import {
   Plus, Trash2, MapPin, RefreshCw, Search,
   MoreHorizontal, Pencil, LayoutDashboard,
@@ -311,7 +312,7 @@ export default function ListingsPage() {
                   >
                     <div className="w-12 h-12 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
                       {e.coverImageUrl
-                        ? <img src={e.coverImageUrl} alt={e.title} className="w-full h-full object-cover brightness-[.62] saturate-110" />
+                        ? <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover brightness-[.62] saturate-110" sizes="48px" />
                         : <div className="font-mono text-[9px] text-muted-dark uppercase">{e.discipline.slice(0, 4)}</div>}
                     </div>
                     <div className="flex-1 min-w-0">
@@ -347,7 +348,7 @@ export default function ListingsPage() {
                     <div className="col-span-5 flex items-center gap-4 min-w-0">
                       <div className="w-14 h-14 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
                         {e.coverImageUrl
-                          ? <img src={e.coverImageUrl} alt={e.title} className="w-full h-full object-cover brightness-[.62] saturate-110" />
+                          ? <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover brightness-[.62] saturate-110" sizes="56px" />
                           : <div className="font-mono text-[9px] text-muted-dark uppercase">{e.discipline.slice(0, 4)}</div>}
                       </div>
                       <div className="min-w-0">

--- a/app/organiser/listings/page.tsx
+++ b/app/organiser/listings/page.tsx
@@ -310,9 +310,9 @@ export default function ListingsPage() {
                     className="sm:hidden flex items-center gap-3 px-4 py-3.5 cursor-pointer active:bg-white/5 transition-colors"
                     onClick={() => handleRowClick(e)}
                   >
-                    <div className="w-12 h-12 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
-                      {e.coverImageUrl
-                        ? <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover brightness-[.62] saturate-110" sizes="48px" />
+                    <div className="relative w-12 h-12 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
+                        {e.coverImageUrl
+                          ? <Image src={e.coverImageUrl} alt={e.title} fill className="pointer-events-none object-cover brightness-[.62] saturate-110" sizes="48px" />
                         : <div className="font-mono text-[9px] text-muted-dark uppercase">{e.discipline.slice(0, 4)}</div>}
                     </div>
                     <div className="flex-1 min-w-0">
@@ -346,9 +346,9 @@ export default function ListingsPage() {
                     onClick={() => handleRowClick(e)}
                   >
                     <div className="col-span-5 flex items-center gap-4 min-w-0">
-                      <div className="w-14 h-14 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
+                      <div className="relative w-14 h-14 rounded-lg bg-dark-light flex items-center justify-center shrink-0 overflow-hidden">
                         {e.coverImageUrl
-                          ? <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover brightness-[.62] saturate-110" sizes="56px" />
+                          ? <Image src={e.coverImageUrl} alt={e.title} fill className="pointer-events-none object-cover brightness-[.62] saturate-110" sizes="56px" />
                           : <div className="font-mono text-[9px] text-muted-dark uppercase">{e.discipline.slice(0, 4)}</div>}
                       </div>
                       <div className="min-w-0">

--- a/app/organiser/new-listing/page.tsx
+++ b/app/organiser/new-listing/page.tsx
@@ -1251,6 +1251,7 @@ function ExtrasStep({ form, update }: { form: FormState; update: (p: Partial<For
         <label className="block cursor-pointer">
           {(form.coverImage || form.coverImageUrl) ? (
             <div className="relative rounded-md border border-primary/40 overflow-hidden aspect-video">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={form.coverImage ? URL.createObjectURL(form.coverImage) : form.coverImageUrl}
                 alt="Cover preview"
@@ -1420,6 +1421,7 @@ function LivePreview({ form }: { form: FormState }) {
         {/* Cover image */}
         <div className="relative h-52 placeholder-stripes scan-grid flex items-center justify-center overflow-hidden">
           {(form.coverImage || form.coverImageUrl) && (
+            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={form.coverImage ? URL.createObjectURL(form.coverImage) : form.coverImageUrl}
               alt=""

--- a/app/organiser/new-listing/page.tsx
+++ b/app/organiser/new-listing/page.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import {
   ArrowLeft, ArrowRight, Check, Plus, Trash2,
-  Upload, Info, X, MapPin, Calendar, Users,
+  Upload, X, MapPin, Calendar, Users,
   ChevronDown, ChevronLeft, ChevronRight, Clock, Eye,
   Ticket, Package, ShoppingBag, Tag, ExternalLink,
 } from "lucide-react";

--- a/app/organiser/profile/page.tsx
+++ b/app/organiser/profile/page.tsx
@@ -188,16 +188,16 @@ export default function ProfilePage() {
           {/* Banner */}
           <div className="relative h-36 sm:h-48 rounded-xl overflow-hidden bg-dark-light mt-4 sm:mt-6">
             {profile.coverImageUrl
-              ? <Image src={profile.coverImageUrl} alt="Cover" fill className="object-cover brightness-[.62] saturate-110" style={{ objectPosition: profile.coverPosition || "50% 50%" }} sizes="(max-width: 640px) 100vw, 1200px" />
+              ? <Image src={profile.coverImageUrl} alt="Cover" fill className="pointer-events-none object-cover brightness-[.62] saturate-110" style={{ objectPosition: profile.coverPosition || "50% 50%" }} sizes="(max-width: 640px) 100vw, 1200px" />
               : <div className="absolute inset-0 opacity-20" style={{ backgroundImage: "radial-gradient(circle at 20% 50%, #b3e153 0%, transparent 50%), radial-gradient(circle at 80% 20%, #86efac 0%, transparent 40%)" }} />
             }
           </div>
 
           {/* Avatar + name row */}
           <div className="flex items-end gap-4 -mt-[72px] mb-5 relative z-10">
-            <div className="w-[144px] h-[144px] rounded-2xl bg-primary text-dark font-headline font-black italic text-5xl flex items-center justify-center border-4 border-dark-darker shadow-lg overflow-hidden shrink-0">
+            <div className="relative w-[144px] h-[144px] rounded-2xl bg-primary text-dark font-headline font-black italic text-5xl flex items-center justify-center border-4 border-dark-darker shadow-lg overflow-hidden shrink-0">
               {profile.logoUrl
-                ? <Image src={profile.logoUrl} alt="Logo" fill className="object-cover" style={{ objectPosition: profile.logoPosition || "50% 50%" }} sizes="144px" />
+                ? <Image src={profile.logoUrl} alt="Logo" fill className="pointer-events-none object-cover" style={{ objectPosition: profile.logoPosition || "50% 50%" }} sizes="144px" />
                 : initial}
             </div>
 
@@ -293,7 +293,7 @@ export default function ProfilePage() {
                           className="group overflow-hidden rounded-xl transition-all duration-200">
                           <div className="relative aspect-[16/10] bg-dark-light overflow-hidden">
                             {e.coverImageUrl
-                              ? <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover brightness-[.62] saturate-110 group-hover:scale-105 transition-transform duration-300" sizes="(max-width: 640px) 100vw, 33vw" />
+                              ? <Image src={e.coverImageUrl} alt={e.title} fill className="pointer-events-none object-cover brightness-[.62] saturate-110 group-hover:scale-105 transition-transform duration-300" sizes="(max-width: 640px) 100vw, 33vw" />
                               : <div className="absolute inset-0 bg-dark-light flex items-center justify-center">
                                   <span className="font-headline font-black italic text-muted-dark text-4xl tracking-tighter">{e.discipline.slice(0, 4).toUpperCase()}</span>
                                 </div>}

--- a/app/organiser/profile/page.tsx
+++ b/app/organiser/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import {
   Plus, MapPin, ArrowRight,
   Edit2, CalendarDays, Facebook,
@@ -187,7 +188,7 @@ export default function ProfilePage() {
           {/* Banner */}
           <div className="relative h-36 sm:h-48 rounded-xl overflow-hidden bg-dark-light mt-4 sm:mt-6">
             {profile.coverImageUrl
-              ? <img src={profile.coverImageUrl} alt="Cover" className="w-full h-full object-cover brightness-[.62] saturate-110" style={{ objectPosition: profile.coverPosition || "50% 50%" }} />
+              ? <Image src={profile.coverImageUrl} alt="Cover" fill className="object-cover brightness-[.62] saturate-110" style={{ objectPosition: profile.coverPosition || "50% 50%" }} sizes="(max-width: 640px) 100vw, 1200px" />
               : <div className="absolute inset-0 opacity-20" style={{ backgroundImage: "radial-gradient(circle at 20% 50%, #b3e153 0%, transparent 50%), radial-gradient(circle at 80% 20%, #86efac 0%, transparent 40%)" }} />
             }
           </div>
@@ -196,7 +197,7 @@ export default function ProfilePage() {
           <div className="flex items-end gap-4 -mt-[72px] mb-5 relative z-10">
             <div className="w-[144px] h-[144px] rounded-2xl bg-primary text-dark font-headline font-black italic text-5xl flex items-center justify-center border-4 border-dark-darker shadow-lg overflow-hidden shrink-0">
               {profile.logoUrl
-                ? <img src={profile.logoUrl} alt="Logo" className="w-full h-full object-cover" style={{ objectPosition: profile.logoPosition || "50% 50%" }} />
+                ? <Image src={profile.logoUrl} alt="Logo" fill className="object-cover" style={{ objectPosition: profile.logoPosition || "50% 50%" }} sizes="144px" />
                 : initial}
             </div>
 
@@ -292,7 +293,7 @@ export default function ProfilePage() {
                           className="group overflow-hidden rounded-xl transition-all duration-200">
                           <div className="relative aspect-[16/10] bg-dark-light overflow-hidden">
                             {e.coverImageUrl
-                              ? <img src={e.coverImageUrl} alt={e.title} className="w-full h-full object-cover brightness-[.62] saturate-110 group-hover:scale-105 transition-transform duration-300" />
+                              ? <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover brightness-[.62] saturate-110 group-hover:scale-105 transition-transform duration-300" sizes="(max-width: 640px) 100vw, 33vw" />
                               : <div className="absolute inset-0 bg-dark-light flex items-center justify-center">
                                   <span className="font-headline font-black italic text-muted-dark text-4xl tracking-tighter">{e.discipline.slice(0, 4).toUpperCase()}</span>
                                 </div>}

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import { MapPin, Clock, Users, Calendar } from "lucide-react";
 import type { UserEvent } from "@/types";
 import { EVENT_TYPE_LABELS, STATE_LABELS } from "@/types";
@@ -79,10 +80,12 @@ export default function EventCard({ event, variant = "default", cardClassName }:
     <Link href={`/events/${event.id}`} className="block group">
       <div className={cn("rounded-xl flex flex-col h-full ring-1 ring-transparent group-hover:ring-primary transition-all duration-200 bg-dark border border-dark-lighter overflow-hidden", cardClassName)}>
         <div className="relative h-36 sm:h-44 overflow-hidden flex-shrink-0">
-          <img
+          <Image
             src={bannerUrl}
             alt={event.title}
-            className="absolute inset-0 w-full h-full object-cover transition-all duration-500 brightness-50 group-hover:brightness-60"
+            fill
+            className="object-cover transition-all duration-500 brightness-50 group-hover:brightness-60"
+            sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, 33vw"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-dark via-dark/40 to-transparent" />
 

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -84,7 +84,7 @@ export default function EventCard({ event, variant = "default", cardClassName }:
             src={bannerUrl}
             alt={event.title}
             fill
-            className="object-cover transition-all duration-500 brightness-50 group-hover:brightness-60"
+            className="pointer-events-none object-cover transition-all duration-500 brightness-50 group-hover:brightness-60"
             sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, 33vw"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-dark via-dark/40 to-transparent" />

--- a/components/EventsListing.tsx
+++ b/components/EventsListing.tsx
@@ -36,7 +36,7 @@ function EventCard({ event, selected, onSelect }: { event: UserEvent; selected: 
           src={img}
           alt={event.title}
           fill
-          className="object-cover brightness-75 transition-all duration-500"
+          className="pointer-events-none object-cover brightness-75 transition-all duration-500"
           sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
         />
         <div className="absolute top-2.5 left-2.5">

--- a/components/EventsListing.tsx
+++ b/components/EventsListing.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useEffect, useRef, useCallback, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { Search, MapPin, Calendar, X, SlidersHorizontal } from "lucide-react";
 import type { UserEvent, FilterState, EventType, AustralianState, CompetitionFormat } from "@/types";
 import {
@@ -31,10 +32,12 @@ function EventCard({ event, selected, onSelect }: { event: UserEvent; selected: 
       className={`cursor-pointer rounded-2xl overflow-hidden transition-all duration-200 ${selected ? "ring-2 ring-primary bg-primary/5" : "hover:bg-dark-light/50"}`}
     >
       <div className="relative w-full aspect-[4/3] overflow-hidden bg-dark">
-        <img
+        <Image
           src={img}
           alt={event.title}
-          className="w-full h-full object-cover brightness-75 transition-all duration-500"
+          fill
+          className="object-cover brightness-75 transition-all duration-500"
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
         />
         <div className="absolute top-2.5 left-2.5">
           <span className="font-headline text-[10px] font-bold uppercase tracking-widest bg-primary text-dark px-2 py-1 rounded-full">

--- a/components/HeroCarousel.tsx
+++ b/components/HeroCarousel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Image from "next/image";
 
 const SLIDES = [
   { url: "https://images.unsplash.com/photo-1571008887538-b36bb32f4571?w=1920&q=80", alt: "Runners racing" },
@@ -31,16 +32,18 @@ export default function HeroCarousel() {
   return (
     <div className="absolute inset-0">
       {SLIDES.map((slide, i) => (
-        <img
+        <Image
           key={slide.url}
           src={slide.url}
           alt={slide.alt}
-          className="absolute inset-0 w-full h-full object-cover"
+          fill
+          className="object-cover"
           style={{
             opacity: i === current ? (fading ? 0 : 1) : 0,
             transition: `opacity ${FADE_MS}ms ease-in-out`,
             filter: "grayscale(40%) brightness(0.45)",
           }}
+          sizes="100vw"
         />
       ))}
       <div className="absolute inset-0 bg-gradient-to-r from-dark-darker/90 via-dark-darker/60 to-dark-darker/20" />

--- a/components/HomeEventCard.tsx
+++ b/components/HomeEventCard.tsx
@@ -25,7 +25,7 @@ export default function HomeEventCard({ event }: { event: UserEvent }) {
             src={img}
             alt={event.title}
             fill
-            className="object-cover brightness-[0.55] group-hover:brightness-[0.65] group-hover:scale-105 transition-all duration-700"
+            className="pointer-events-none object-cover brightness-[0.55] group-hover:brightness-[0.65] group-hover:scale-105 transition-all duration-700"
             sizes="(max-width: 640px) 100vw, 33vw"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-dark/60 via-transparent to-transparent" />

--- a/components/HomeEventCard.tsx
+++ b/components/HomeEventCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import { MapPin, Clock, Users } from "lucide-react";
 import type { UserEvent } from "@/types";
 import { EVENT_TYPE_LABELS, STATE_LABELS } from "@/types";
@@ -20,10 +21,12 @@ export default function HomeEventCard({ event }: { event: UserEvent }) {
 
         {/* Image */}
         <div className="relative w-full aspect-video overflow-hidden rounded-t-2xl">
-          <img
+          <Image
             src={img}
             alt={event.title}
-            className="w-full h-full object-cover brightness-[0.55] group-hover:brightness-[0.65] group-hover:scale-105 transition-all duration-700"
+            fill
+            className="object-cover brightness-[0.55] group-hover:brightness-[0.65] group-hover:scale-105 transition-all duration-700"
+            sizes="(max-width: 640px) 100vw, 33vw"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-dark/60 via-transparent to-transparent" />
 

--- a/components/organiser/EventCarousel.tsx
+++ b/components/organiser/EventCarousel.tsx
@@ -114,7 +114,7 @@ export default function EventCarousel({ events, pinnedIds, isOrganiser, onPin }:
               {/* Cover */}
               <div className="relative h-36 overflow-hidden">
                 {e.coverImageUrl ? (
-                  <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover" sizes="272px" />
+                  <Image src={e.coverImageUrl} alt={e.title} fill className="pointer-events-none object-cover" sizes="272px" />
                 ) : (
                   <div className="absolute inset-0 hero-topo scan-grid" />
                 )}

--- a/components/organiser/EventCarousel.tsx
+++ b/components/organiser/EventCarousel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef } from "react";
+import Image from "next/image";
 import { MapPin, ChevronLeft, ChevronRight, Bookmark, BookmarkCheck } from "lucide-react";
 
 type EventStatus = "DRAFT" | "PENDING" | "APPROVED" | "REJECTED" | "ARCHIVED";
@@ -113,7 +114,7 @@ export default function EventCarousel({ events, pinnedIds, isOrganiser, onPin }:
               {/* Cover */}
               <div className="relative h-36 overflow-hidden">
                 {e.coverImageUrl ? (
-                  <img src={e.coverImageUrl} alt={e.title} className="w-full h-full object-cover" />
+                  <Image src={e.coverImageUrl} alt={e.title} fill className="object-cover" sizes="272px" />
                 ) : (
                   <div className="absolute inset-0 hero-topo scan-grid" />
                 )}

--- a/components/organiser/PhotoCarousel.tsx
+++ b/components/organiser/PhotoCarousel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import Image from "next/image";
 import { ChevronLeft, ChevronRight, ImageIcon, X, Play } from "lucide-react";
 
 interface Props {
@@ -92,10 +93,12 @@ export default function PhotoCarousel({ photos, isOrganiser, onUpload, uploading
                     </div>
                   </>
                 ) : (
-                  <img
+                  <Image
                     src={src}
                     alt={`Photo ${i + 1}`}
-                    className="w-full h-full object-cover group-hover/photo:scale-105 transition-transform duration-300"
+                    fill
+                    className="object-cover group-hover/photo:scale-105 transition-transform duration-300"
+                    sizes="320px"
                   />
                 )}
               </button>
@@ -145,6 +148,7 @@ export default function PhotoCarousel({ photos, isOrganiser, onUpload, uploading
               onClick={e => e.stopPropagation()}
             />
           ) : (
+            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={lightbox}
               alt="Event photo"

--- a/components/organiser/SettingsModal.tsx
+++ b/components/organiser/SettingsModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import {
   X, ChevronRight, Upload, Move, Mail, Phone,
   CheckCircle, User, Lock, Bell, CreditCard, Cookie,
@@ -85,8 +86,8 @@ function CoverEditor({
         onMouseDown={onMouseDown} onMouseMove={onMouseMove}
         onMouseUp={onMouseUp} onMouseLeave={onMouseUp}
       >
-        <img src={imageUrl} alt="Cover" className="w-full h-full object-cover pointer-events-none brightness-[.62] saturate-110"
-          style={{ objectPosition: position }} draggable={false} />
+        <Image src={imageUrl} alt="Cover" fill className="object-cover pointer-events-none brightness-[.62] saturate-110"
+          style={{ objectPosition: position }} draggable={false} sizes="(max-width: 768px) 100vw, 448px" />
         {reposition && (
           <div className="absolute inset-0 bg-black/30 flex items-center justify-center pointer-events-none">
             <div className="flex items-center gap-1.5 bg-black/60 text-white rounded-lg px-3 py-1.5 font-headline text-[11px] font-bold uppercase tracking-wider">
@@ -164,8 +165,8 @@ function LogoEditor({
         onMouseUp={onMouseUp} onMouseLeave={onMouseUp}
       >
         {imageUrl
-          ? <img src={imageUrl} alt="Logo" className="w-full h-full object-cover pointer-events-none"
-              style={{ objectPosition: position }} draggable={false} />
+          ? <Image src={imageUrl} alt="Logo" fill className="object-cover pointer-events-none"
+              style={{ objectPosition: position }} draggable={false} sizes="96px" />
           : <span className="font-headline font-black italic text-2xl text-dark flex items-center justify-center w-full h-full">{initial}</span>}
         {reposition && imageUrl && (
           <div className="absolute inset-0 bg-black/30 flex items-center justify-center pointer-events-none">

--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,14 @@ const nextConfig: NextConfig = {
     // metadataBase is set in layout.tsx but this is the canonical declaration
   },
 
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "images.unsplash.com" },
+      { protocol: "https", hostname: "*.s3.ap-southeast-2.amazonaws.com", pathname: "/uploads/**" },
+      { protocol: "http", hostname: "localhost", port: "3000", pathname: "/uploads/**" },
+    ],
+  },
+
   async headers() {
     return [
       {


### PR DESCRIPTION
Replaces 22 plain `<img>` tags with Next.js `<Image fill />` across 15 component/page files. Adds `images.remotePatterns` to `next.config.ts` for Unsplash, S3, and localhost upload URLs.

Preserves `<img>` with eslint-disable for blob: URLs (file upload previews) and the photo lightbox (unknown dimensions, `object-contain` layout).

Resolves all `@next/next/no-img-element` lint warnings.

**Related to:** #70