### PR TITLE
chore: migrate from deprecated AWS API MCP to AWS MCP Server

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -12,11 +12,8 @@
     },
     "aws": {
       "type": "local",
-      "command": ["uvx", "awslabs.aws-api-mcp-server@latest"],
-      "env": {
-        "AWS_REGION": "ap-southeast-2",
-        "AWS_PROFILE": "mcp-server"
-      }
+      "command": ["uvx", "mcp-proxy-for-aws@1.6.3", "https://aws-mcp.us-east-1.api.aws/mcp", "--metadata", "AWS_REGION=ap-southeast-2", "--profile", "mcp-server"],
+      "timeout": 100000
     },
     "cloudflare": {
       "type": "local",


### PR DESCRIPTION
## Description

Migrate MCP config from `awslabs.aws-api-mcp-server` to the managed `mcp-proxy-for-aws` per the [AWS deprecation notice](https://health.aws.amazon.com/health/home?region=us-east-1#/event-log?eventID=arn:aws:health:global::event/MCP/AWS_MCP_OPERATIONAL_NOTIFICATION/AWS_MCP_OPERATIONAL_NOTIFICATION_34573d592eb0a65a2a5326d5a554e6145ef3499918046f7ae9f098af88df8b9f).

Changes:
- Replaced `uvx awslabs.aws-api-mcp-server@latest` with `uvx mcp-proxy-for-aws@1.6.3`
- Region and profile moved from `env` block to `--metadata AWS_REGION=...` and `--profile` args
- Added `timeout: 100000` per migration guide
- Proxy version pinned for supply-chain safety

Closes the AWS Health operational notification received July 14, 2026.