### PR TITLE
fix: address bugs #66 (Escape key), #65 (CSP), #56 (UI issues)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -73,6 +73,12 @@ html {
   outline-offset: 2px;
 }
 
+/* Hide browser native password reveal — conflicts with custom Eye icon */
+input[type="password"]::-ms-reveal,
+input[type="password"]::-ms-clear {
+  display: none;
+}
+
 /* Image placeholder styling - dark theme */
 .image-placeholder {
   background: linear-gradient(

--- a/app/organiser/dashboard/page.tsx
+++ b/app/organiser/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import { CalendarDays, ArrowRight, MapPin } from "lucide-react";
+import { CalendarDays, ArrowRight, MapPin, Plus } from "lucide-react";
 import OrganiserTopBar from "@/components/organiser/TopBar";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -116,11 +116,18 @@ export default function DashboardPage() {
                   : "No live events right now. Submit a draft to go live."}
               </p>
             </div>
-            <Button asChild size="lg" className="self-start sm:self-end shrink-0">
-              <Link href="/organiser/listings">
-                <CalendarDays className="w-4 h-4" /> View my events
-              </Link>
-            </Button>
+            <div className="flex items-center gap-2 self-start sm:self-end">
+              <Button asChild size="lg" variant="outline">
+                <Link href="/organiser/new-listing">
+                  <Plus className="w-4 h-4" /> Add listing
+                </Link>
+              </Button>
+              <Button asChild size="lg">
+                <Link href="/organiser/listings">
+                  <CalendarDays className="w-4 h-4" /> View my events
+                </Link>
+              </Button>
+            </div>
           </div>
 
           {/* Stats — 2-col on mobile, 3-col on sm+ */}

--- a/app/organiser/new-listing/page.tsx
+++ b/app/organiser/new-listing/page.tsx
@@ -194,7 +194,8 @@ function DatePickerPopover({
       </button>
 
       {open && (
-        <div className="absolute top-full left-0 mt-2 z-50 bg-dark border border-dark-lighter rounded-xl shadow-xl p-4 w-full sm:w-72 modal-in">
+        <div tabIndex={-1} onKeyDown={(e) => { if (e.key === "Escape") setOpen(false); }}
+          className="absolute top-full left-0 mt-2 z-50 bg-dark border border-dark-lighter rounded-xl shadow-xl p-4 w-full sm:w-72 modal-in">
           {isRange && (
             <div className="mb-3 flex items-center justify-between">
               <span className={`font-headline text-[10px] uppercase tracking-widest font-bold px-2 py-1 rounded-md ${picking === "start" ? "bg-primary/10 text-primary" : "text-muted-dark"}`}>
@@ -1380,7 +1381,7 @@ export default function NewListingPage() {
         });
       })
       .catch(() => {})
-      .finally(() => setLoadingEvent(false));
+      .finally(() => { setLoadingEvent(false); setStep(4); setVisited(new Set([0, 1, 2, 3, 4])); });
   }, []);
 
   const stepHasErrors = (s: number): boolean => {
@@ -1562,6 +1563,7 @@ export default function NewListingPage() {
                     {STEP_HEADINGS[step].h}
                   </h1>
                   <p className="font-headline text-muted mt-2 max-w-lg text-[14px]">{STEP_HEADINGS[step].sub}</p>
+                  <div className="font-headline text-[10px] uppercase tracking-widest text-muted-dark mt-2"><span className="text-primary font-black text-[13px]">*</span> = required</div>
                 </div>
 
                 {step === 0 && <BasicsStep  form={form} update={update} />}

--- a/components/EventMap.tsx
+++ b/components/EventMap.tsx
@@ -228,20 +228,13 @@ const EventMap = forwardRef<EventMapHandle, EventMapProps>(function EventMap({ e
     }
 
     fitBounds();
-    if (rotationRef.current) cancelAnimationFrame(rotationRef.current);
-    resumeSpin(2500);
   }, [events]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Resume spin and zoom out when deselected
+  // Zoom out when deselected
   useEffect(() => {
     if (!selectedId && mapRef.current) {
       mapRef.current.flyTo({ center: [defaultCenter.current.lng, defaultCenter.current.lat], zoom: defaultCenter.current.zoom, duration: 1200 });
-      if (!rotationRef.current) {
-        const t = setTimeout(() => { rotationRef.current = requestAnimationFrame(spin); }, 1500);
-        return () => clearTimeout(t);
-      }
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedId]);
 
   return <div ref={containerRef} className="w-full h-full" />;

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { X, Mail, Lock, Eye, EyeOff, ArrowRight, User, Phone, ChevronDown, Check, AtSign, ShieldAlert } from "lucide-react";
+import { X, Mail, Lock, Eye, EyeOff, ArrowRight, ArrowLeft, User, Phone, ChevronDown, Check, AtSign, ShieldAlert } from "lucide-react";
 import { signIn, signUp, signOut, resetPassword, confirmResetPassword, confirmSignIn } from "aws-amplify/auth";
 import { useAuthContext } from "@/context/AuthContext";
 import { validateUsername } from "@/lib/username-validation";
@@ -301,6 +301,9 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
     setError("");
     if (password !== confirm) { setError("Passwords do not match."); return; }
     if (password.length < 8)  { setError("Password must be at least 8 characters."); return; }
+    if (!/[A-Z]/.test(password)) { setError("Password must contain at least one uppercase letter."); return; }
+    if (!/[a-z]/.test(password)) { setError("Password must contain at least one lowercase letter."); return; }
+    if (!/[0-9]/.test(password)) { setError("Password must contain at least one number."); return; }
     setFirstName(""); setLastName(""); setDobDay(""); setDobMonth(""); setDobYear(""); setPhone("");
     setAcceptedTerms(false); setShowTerms(false); setShowPrivacy(false);
     setView("onboarding");
@@ -917,6 +920,9 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
 
               <button onClick={handleContinueOnboarding} disabled={loading} className={btnCls}>
                 {loading ? <><span className="w-2 h-2 bg-dark rounded-full animate-pulse-dot" /> Saving…</> : <>Continue <ArrowRight className="w-4 h-4" /></>}
+              </button>
+              <button type="button" onClick={() => switchView("signup")} className="w-full font-headline text-[11px] uppercase tracking-widest text-muted hover:text-primary transition-colors py-1 mt-2 flex items-center justify-center gap-1.5">
+                <ArrowLeft className="w-3.5 h-3.5" /> Back to signup
               </button>
             </div>
           </>

--- a/components/organiser/SettingsModal.tsx
+++ b/components/organiser/SettingsModal.tsx
@@ -17,7 +17,7 @@ function FieldLabel({ label, hint, required }: { label: string; hint?: string; r
   return (
     <div className="flex items-baseline justify-between mb-1.5">
       <label className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted-light">
-        {label}{required && <span className="text-primary ml-0.5">*</span>}
+        {label}{required && <span className="text-primary font-black text-[14px] leading-none ml-0.5">*</span>}
       </label>
       {hint && <span className="font-headline text-[10px] uppercase tracking-widest text-muted-dark">{hint}</span>}
     </div>

--- a/components/organiser/TopBar.tsx
+++ b/components/organiser/TopBar.tsx
@@ -292,11 +292,9 @@ export default function OrganiserTopBar() {
               <div className="w-7 h-7 rounded-lg bg-primary text-dark font-headline font-black italic text-sm flex items-center justify-center shrink-0">
                 {initial}
               </div>
-              {displayName && (
-                <span className="font-headline text-[12px] font-bold uppercase tracking-widest text-white/70">
-                  {displayName}
-                </span>
-              )}
+              <span className="font-headline text-[12px] font-bold uppercase tracking-widest text-white/70 min-w-[80px] inline-block text-left">
+                {displayName || ""}
+              </span>
               <svg className={`w-3.5 h-3.5 text-white/40 transition-transform duration-200 ${open ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
               </svg>


### PR DESCRIPTION
## Description

Fixes 3 bugs across 6 files. Bug #65 (CSP) was already resolved in a prior commit — included here as a close reference.

### Bug #66 — DatePickerPopover missing Escape key handler
- Added `tabIndex={-1}` and `onKeyDown` handler to popover container so Escape closes the picker

### Bug #65 — CSP header too restrictive
- Already fixed in commit `477187f` — Stripe directives added, no `default-src` restriction
- Closing as resolved

### Bug #56 — General UI issues
| Sub-issue | Fix |
|---|---|
| 56.1 Asterisk visibility | Added `"* = required"` legend below step headings; enlarged asterisk in SettingsModal FieldLabel |
| 56.3 Draft fields hidden | On draft load, jump to review step with all steps pre-marked so all fields are visible immediately |
| 56.4 Password validation | Added client-side checks (uppercase, lowercase, digit) before allowing proceed; added "Back to signup" button on onboarding step |
| 56.5 Duplicate eye icons | Added CSS to hide browser native password reveal (`::-ms-reveal`) |
| 56.6 Name collapse | Always render name span with `min-w-[80px]` so layout does not shift during profile fetch on navigation |
| 56.7 Add listing button | Added "Add listing" button on dashboard next to "View my events" |
| 56.9 Map auto-spin | Removed spin resumption on events change and deselect — spin only starts on initial load, stops on interaction |

Closes #66
Closes #65
Closes #56