### PR TITLE
Email verification UX + new-listing wizard fixes

### DIFF
--- a/app/(user)/auth/verify-email/page.tsx
+++ b/app/(user)/auth/verify-email/page.tsx
@@ -1,218 +1,40 @@
 "use client";
 
-import { useState, Suspense } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import Image from "next/image";
-import Link from "next/link";
-import { Mail, ArrowRight, RotateCcw, Check } from "lucide-react";
-import { confirmSignUp, resendSignUpCode, autoSignIn } from "aws-amplify/auth";
-import { useAuthContext } from "@/context/AuthContext";
+import VerifyEmailForm from "@/components/VerifyEmailForm";
 
-function VerifyEmailForm() {
-  const router       = useRouter();
-  const searchParams = useSearchParams();
-  const emailParam   = searchParams.get("email") ?? "";
-  const { refresh }  = useAuthContext();
+const config = {
+  logoHref: "/",
+  sessionEndpoint: "/api/user/auth/session",
+  redirectPath: "/",
+  emailPlaceholder: "you@example.com",
+  inputIdPrefix: "verify",
+  verifiedSubtext: "Taking you to Startline…",
+  submitButtonLabel: "Verify & sign in",
+  bottomLinkText: "Already verified?",
+  bottomLinkHref: "/",
+  bottomLinkLabel: "Back to home",
+};
 
-  const [email,     setEmail]     = useState(emailParam);
-  const [code,      setCode]      = useState("");
-  const [error,     setError]     = useState("");
-  const [success,   setSuccess]   = useState("");
-  const [loading,   setLoading]   = useState(false);
-  const [resending, setResending] = useState(false);
-  const [verified,  setVerified]  = useState(false);
-
-  const applyPendingProfile = async () => {
-    try {
-      const pendingName     = sessionStorage.getItem("startline_pending_name");
-      const pendingUsername = sessionStorage.getItem("startline_pending_username");
-      if (pendingName || pendingUsername) {
-        await fetch("/api/user/profile", {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            ...(pendingName     ? { name: pendingName }        : {}),
-            ...(pendingUsername ? { username: pendingUsername } : {}),
-          }),
-        });
-      }
-    } finally {
-      sessionStorage.removeItem("startline_pending_name");
-      sessionStorage.removeItem("startline_pending_dob");
-      sessionStorage.removeItem("startline_pending_phone");
-      sessionStorage.removeItem("startline_pending_username");
+const applyPendingProfile = async () => {
+  try {
+    const pendingName = sessionStorage.getItem("startline_pending_name");
+    const pendingUsername = sessionStorage.getItem("startline_pending_username");
+    if (pendingName || pendingUsername) {
+      await fetch("/api/user/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...(pendingName ? { name: pendingName } : {}),
+          ...(pendingUsername ? { username: pendingUsername } : {}),
+        }),
+      });
     }
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError("");
-    setLoading(true);
-    try {
-      await confirmSignUp({ username: email, confirmationCode: code.trim() });
-
-      // Seamlessly sign the user in — falls back to a manual sign-in prompt
-      // if the auto sign-in session isn't available (e.g. verified on another device).
-      try {
-        const result = await autoSignIn();
-        if (result.nextStep.signInStep === "DONE") {
-          await fetch("/api/user/auth/session", { method: "POST" });
-          await applyPendingProfile();
-          await refresh();
-          setVerified(true);
-          setLoading(false);
-          setTimeout(() => router.push("/"), 1400);
-          return;
-        }
-      } catch {
-        // fall through to manual sign-in redirect below
-      }
-
-      router.push("/?verified=1");
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "";
-      if (msg.includes("CodeMismatchException")) {
-        setError("That code is incorrect. Please check and try again.");
-      } else if (msg.includes("ExpiredCodeException")) {
-        setError("That code has expired. Use the resend button below.");
-      } else if (msg.includes("AliasExistsException")) {
-        setError("This email is already verified. Try signing in.");
-      } else {
-        setError("Verification failed. Please try again.");
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleResend = async () => {
-    if (!email) { setError("Enter your email address first."); return; }
-    setError(""); setSuccess("");
-    setResending(true);
-    try {
-      await resendSignUpCode({ username: email });
-      setSuccess("A new code has been sent. Check your inbox and spam folder — look for an email from Amazon Cognito or no-reply@verificationemail.com.");
-    } catch (err: unknown) {
-      const errName = (err as { name?: string })?.name ?? "";
-      const msg = err instanceof Error ? err.message : "";
-      if (errName === "LimitExceededException" || msg.includes("LimitExceededException")) {
-        setError("Too many attempts. Wait a few minutes, then try resend again.");
-      } else if (errName === "InvalidParameterException" || msg.includes("User is already confirmed")) {
-        setError("This email is already verified. Try signing in instead.");
-      } else if (errName === "UserNotFoundException") {
-        setError("No account found for that email. Sign up again or check the address is correct.");
-      } else {
-        setError(msg || "Could not resend the code. Please try again.");
-      }
-    } finally {
-      setResending(false);
-    }
-  };
-
-  return (
-    <main className="min-h-screen bg-dark-darker flex items-center justify-center px-6">
-      <div className="w-full max-w-[480px] page-in">
-        <Link href="/">
-          <Image src="/images/logo-title.svg" alt="Startline" width={160} height={40} className="h-10 w-auto mx-auto mb-12 opacity-80" />
-        </Link>
-
-        {verified ? (
-          <>
-            <div className="w-16 h-16 rounded-full bg-green-500/10 border border-green-500/30 flex items-center justify-center mx-auto mb-6">
-              <Check className="w-7 h-7 text-green-400" />
-            </div>
-            <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
-              You&apos;re all set
-            </div>
-            <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
-              Verified &amp;<br /><span className="text-primary">signed in.</span>
-            </h1>
-            <p className="text-muted text-[15px] leading-relaxed text-center">
-              Taking you to Startline…
-            </p>
-          </>
-        ) : (
-          <>
-            <div className="w-16 h-16 rounded-full bg-primary/10 border border-primary/30 flex items-center justify-center mx-auto mb-6">
-              <Mail className="w-7 h-7 text-primary" />
-            </div>
-
-            <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
-              Verify your email
-            </div>
-            <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
-              Enter your<br /><span className="text-primary">6-digit code.</span>
-            </h1>
-            <p className="text-muted text-[15px] leading-relaxed mb-4 text-center">
-              We sent a verification code to{" "}
-              {email ? <strong className="text-light">{email}</strong> : "your email"}.
-              Enter it below to activate your account.
-            </p>
-            <p className="text-muted text-[12px] leading-relaxed mb-8 text-center">
-              This code is sent by AWS Cognito (not Resend). Check spam/junk, and allow a minute or two for delivery.
-            </p>
-
-            {error && (
-              <div className="mb-5 px-4 py-3 rounded-md bg-red-900/20 border border-red-500/30 text-red-400 font-headline text-[13px]">
-                {error}
-              </div>
-            )}
-            {success && (
-              <div className="mb-5 px-4 py-3 rounded-md bg-green-900/20 border border-green-500/30 text-green-400 font-headline text-[13px]">
-                {success}
-              </div>
-            )}
-
-            <form onSubmit={handleSubmit} className="space-y-4">
-              {!emailParam && (
-                <div>
-                  <label htmlFor="verify-email-input" className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Email address</label>
-                  <input id="verify-email-input" type="email" required value={email} onChange={(e) => setEmail(e.target.value)}
-                    placeholder="you@example.com"
-                    className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[15px] text-light placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors" />
-                </div>
-              )}
-
-              <div>
-                <label htmlFor="verify-code-input" className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Verification code</label>
-                <input
-                  id="verify-code-input"
-                  type="text" inputMode="numeric" pattern="[0-9]*" maxLength={6} required
-                  value={code} onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
-                  placeholder="000000"
-                  className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[22px] text-light tracking-[0.5em] text-center placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors font-headline font-black"
-                />
-              </div>
-
-              <button type="submit" disabled={loading || code.length < 6}
-                className="bg-machined shadow-machined w-full text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 rounded-md flex items-center justify-center gap-2 hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform disabled:opacity-50 disabled:cursor-not-allowed">
-                {loading ? <><span className="w-2 h-2 bg-dark rounded-full animate-pulse-dot" /> Verifying…</> : <>Verify & sign in <ArrowRight className="w-4 h-4" /></>}
-              </button>
-            </form>
-
-            <div className="mt-6 text-center">
-              <button onClick={handleResend} disabled={resending}
-                className="inline-flex items-center gap-2 font-headline text-[12px] uppercase tracking-widest text-muted hover:text-primary transition-colors disabled:opacity-50">
-                <RotateCcw className="w-3.5 h-3.5" />
-                {resending ? "Sending…" : "Resend code"}
-              </button>
-            </div>
-
-            <p className="mt-4 text-center font-headline text-[12px] uppercase tracking-widest text-muted">
-              Already verified?{" "}
-              <Link href="/" className="text-primary hover:underline">Back to home</Link>
-            </p>
-          </>
-        )}
-      </div>
-    </main>
-  );
-}
+  } finally {
+    sessionStorage.removeItem("startline_pending_name");
+    sessionStorage.removeItem("startline_pending_username");
+  }
+};
 
 export default function UserVerifyEmailPage() {
-  return (
-    <Suspense>
-      <VerifyEmailForm />
-    </Suspense>
-  );
+  return <VerifyEmailForm config={config} onVerified={applyPendingProfile} />;
 }

--- a/app/(user)/auth/verify-email/page.tsx
+++ b/app/(user)/auth/verify-email/page.tsx
@@ -4,13 +4,15 @@ import { useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import { Mail, ArrowRight, RotateCcw } from "lucide-react";
-import { confirmSignUp, resendSignUpCode } from "aws-amplify/auth";
+import { Mail, ArrowRight, RotateCcw, Check } from "lucide-react";
+import { confirmSignUp, resendSignUpCode, autoSignIn } from "aws-amplify/auth";
+import { useAuthContext } from "@/context/AuthContext";
 
 function VerifyEmailForm() {
   const router       = useRouter();
   const searchParams = useSearchParams();
   const emailParam   = searchParams.get("email") ?? "";
+  const { refresh }  = useAuthContext();
 
   const [email,     setEmail]     = useState(emailParam);
   const [code,      setCode]      = useState("");
@@ -18,6 +20,29 @@ function VerifyEmailForm() {
   const [success,   setSuccess]   = useState("");
   const [loading,   setLoading]   = useState(false);
   const [resending, setResending] = useState(false);
+  const [verified,  setVerified]  = useState(false);
+
+  const applyPendingProfile = async () => {
+    try {
+      const pendingName     = sessionStorage.getItem("startline_pending_name");
+      const pendingUsername = sessionStorage.getItem("startline_pending_username");
+      if (pendingName || pendingUsername) {
+        await fetch("/api/user/profile", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ...(pendingName     ? { name: pendingName }        : {}),
+            ...(pendingUsername ? { username: pendingUsername } : {}),
+          }),
+        });
+      }
+    } finally {
+      sessionStorage.removeItem("startline_pending_name");
+      sessionStorage.removeItem("startline_pending_dob");
+      sessionStorage.removeItem("startline_pending_phone");
+      sessionStorage.removeItem("startline_pending_username");
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -25,6 +50,24 @@ function VerifyEmailForm() {
     setLoading(true);
     try {
       await confirmSignUp({ username: email, confirmationCode: code.trim() });
+
+      // Seamlessly sign the user in — falls back to a manual sign-in prompt
+      // if the auto sign-in session isn't available (e.g. verified on another device).
+      try {
+        const result = await autoSignIn();
+        if (result.nextStep.signInStep === "DONE") {
+          await fetch("/api/user/auth/session", { method: "POST" });
+          await applyPendingProfile();
+          await refresh();
+          setVerified(true);
+          setLoading(false);
+          setTimeout(() => router.push("/"), 1400);
+          return;
+        }
+      } catch {
+        // fall through to manual sign-in redirect below
+      }
+
       router.push("/?verified=1");
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "";
@@ -73,74 +116,94 @@ function VerifyEmailForm() {
           <Image src="/images/logo-title.svg" alt="Startline" width={160} height={40} className="h-10 w-auto mx-auto mb-12 opacity-80" />
         </Link>
 
-        <div className="w-16 h-16 rounded-full bg-primary/10 border border-primary/30 flex items-center justify-center mx-auto mb-6">
-          <Mail className="w-7 h-7 text-primary" />
-        </div>
-
-        <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
-          Verify your email
-        </div>
-        <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
-          Enter your<br /><span className="text-primary">6-digit code.</span>
-        </h1>
-        <p className="text-muted text-[15px] leading-relaxed mb-4 text-center">
-          We sent a verification code to{" "}
-          {email ? <strong className="text-light">{email}</strong> : "your email"}.
-          Enter it below to activate your account.
-        </p>
-        <p className="text-muted text-[12px] leading-relaxed mb-8 text-center">
-          This code is sent by AWS Cognito (not Resend). Check spam/junk, and allow a minute or two for delivery.
-        </p>
-
-        {error && (
-          <div className="mb-5 px-4 py-3 rounded-md bg-red-900/20 border border-red-500/30 text-red-400 font-headline text-[13px]">
-            {error}
-          </div>
-        )}
-        {success && (
-          <div className="mb-5 px-4 py-3 rounded-md bg-green-900/20 border border-green-500/30 text-green-400 font-headline text-[13px]">
-            {success}
-          </div>
-        )}
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {!emailParam && (
-            <div>
-              <label className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Email address</label>
-              <input type="email" required value={email} onChange={(e) => setEmail(e.target.value)}
-                placeholder="you@example.com"
-                className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[15px] text-light placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors" />
+        {verified ? (
+          <>
+            <div className="w-16 h-16 rounded-full bg-green-500/10 border border-green-500/30 flex items-center justify-center mx-auto mb-6">
+              <Check className="w-7 h-7 text-green-400" />
             </div>
-          )}
+            <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
+              You&apos;re all set
+            </div>
+            <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
+              Verified &amp;<br /><span className="text-primary">signed in.</span>
+            </h1>
+            <p className="text-muted text-[15px] leading-relaxed text-center">
+              Taking you to Startline…
+            </p>
+          </>
+        ) : (
+          <>
+            <div className="w-16 h-16 rounded-full bg-primary/10 border border-primary/30 flex items-center justify-center mx-auto mb-6">
+              <Mail className="w-7 h-7 text-primary" />
+            </div>
 
-          <div>
-            <label className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Verification code</label>
-            <input
-              type="text" inputMode="numeric" pattern="[0-9]*" maxLength={6} required
-              value={code} onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
-              placeholder="000000"
-              className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[22px] text-light tracking-[0.5em] text-center placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors font-headline font-black"
-            />
-          </div>
+            <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
+              Verify your email
+            </div>
+            <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
+              Enter your<br /><span className="text-primary">6-digit code.</span>
+            </h1>
+            <p className="text-muted text-[15px] leading-relaxed mb-4 text-center">
+              We sent a verification code to{" "}
+              {email ? <strong className="text-light">{email}</strong> : "your email"}.
+              Enter it below to activate your account.
+            </p>
+            <p className="text-muted text-[12px] leading-relaxed mb-8 text-center">
+              This code is sent by AWS Cognito (not Resend). Check spam/junk, and allow a minute or two for delivery.
+            </p>
 
-          <button type="submit" disabled={loading || code.length < 6}
-            className="bg-machined shadow-machined w-full text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 rounded-md flex items-center justify-center gap-2 hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform disabled:opacity-50 disabled:cursor-not-allowed">
-            {loading ? <><span className="w-2 h-2 bg-dark rounded-full animate-pulse-dot" /> Verifying…</> : <>Verify & sign in <ArrowRight className="w-4 h-4" /></>}
-          </button>
-        </form>
+            {error && (
+              <div className="mb-5 px-4 py-3 rounded-md bg-red-900/20 border border-red-500/30 text-red-400 font-headline text-[13px]">
+                {error}
+              </div>
+            )}
+            {success && (
+              <div className="mb-5 px-4 py-3 rounded-md bg-green-900/20 border border-green-500/30 text-green-400 font-headline text-[13px]">
+                {success}
+              </div>
+            )}
 
-        <div className="mt-6 text-center">
-          <button onClick={handleResend} disabled={resending}
-            className="inline-flex items-center gap-2 font-headline text-[12px] uppercase tracking-widest text-muted hover:text-primary transition-colors disabled:opacity-50">
-            <RotateCcw className="w-3.5 h-3.5" />
-            {resending ? "Sending…" : "Resend code"}
-          </button>
-        </div>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {!emailParam && (
+                <div>
+                  <label htmlFor="verify-email-input" className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Email address</label>
+                  <input id="verify-email-input" type="email" required value={email} onChange={(e) => setEmail(e.target.value)}
+                    placeholder="you@example.com"
+                    className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[15px] text-light placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors" />
+                </div>
+              )}
 
-        <p className="mt-4 text-center font-headline text-[12px] uppercase tracking-widest text-muted">
-          Already verified?{" "}
-          <Link href="/" className="text-primary hover:underline">Back to home</Link>
-        </p>
+              <div>
+                <label htmlFor="verify-code-input" className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Verification code</label>
+                <input
+                  id="verify-code-input"
+                  type="text" inputMode="numeric" pattern="[0-9]*" maxLength={6} required
+                  value={code} onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+                  placeholder="000000"
+                  className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[22px] text-light tracking-[0.5em] text-center placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors font-headline font-black"
+                />
+              </div>
+
+              <button type="submit" disabled={loading || code.length < 6}
+                className="bg-machined shadow-machined w-full text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 rounded-md flex items-center justify-center gap-2 hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform disabled:opacity-50 disabled:cursor-not-allowed">
+                {loading ? <><span className="w-2 h-2 bg-dark rounded-full animate-pulse-dot" /> Verifying…</> : <>Verify & sign in <ArrowRight className="w-4 h-4" /></>}
+              </button>
+            </form>
+
+            <div className="mt-6 text-center">
+              <button onClick={handleResend} disabled={resending}
+                className="inline-flex items-center gap-2 font-headline text-[12px] uppercase tracking-widest text-muted hover:text-primary transition-colors disabled:opacity-50">
+                <RotateCcw className="w-3.5 h-3.5" />
+                {resending ? "Sending…" : "Resend code"}
+              </button>
+            </div>
+
+            <p className="mt-4 text-center font-headline text-[12px] uppercase tracking-widest text-muted">
+              Already verified?{" "}
+              <Link href="/" className="text-primary hover:underline">Back to home</Link>
+            </p>
+          </>
+        )}
       </div>
     </main>
   );

--- a/app/(user)/page.tsx
+++ b/app/(user)/page.tsx
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import HeroCarousel from "@/components/HeroCarousel";
 import HeroSearch from "@/components/HeroSearch";
 import HomeEventCard from "@/components/HomeEventCard";
+import VerifiedBanner from "@/components/VerifiedBanner";
 import { ScrollCarousel } from "@/components/ui/ScrollCarousel";
 import type { UserEvent } from "@/types";
 
@@ -44,6 +45,7 @@ export default async function Home() {
 
   return (
     <main className="min-h-screen bg-dark-darker">
+      <VerifiedBanner />
 
       {/* ── Hero ── */}
       <section className="relative min-h-[520px] sm:min-h-[600px] flex items-end overflow-hidden">

--- a/app/api/organiser/events/[id]/route.ts
+++ b/app/api/organiser/events/[id]/route.ts
@@ -65,7 +65,7 @@ export async function PATCH(
         eventDate:         data.eventDate         ?? undefined,
         endDate:           data.endDate           ?? null,
         startTime:         data.startTime         ?? undefined,
-        endTime:           data.endTime           || null,
+        endTime:           data.endTime           ?? undefined,
         venue:             data.venue             ?? undefined,
         address:           data.address           ?? undefined,
         city:              data.city              ?? undefined,

--- a/app/api/organiser/events/route.ts
+++ b/app/api/organiser/events/route.ts
@@ -64,7 +64,7 @@ export async function POST(req: NextRequest) {
         eventDate:        body.eventDate         ?? "",
         endDate:          body.endDate           ?? null,
         startTime:        body.startTime         ?? "",
-        endTime:          body.endTime           || null,
+        endTime:          body.endTime           || "",
         venue:            body.venue             ?? "",
         address:          body.address           ?? null,
         city:             body.city              ?? "",

--- a/app/globals.css
+++ b/app/globals.css
@@ -34,7 +34,9 @@
 html,
 body {
   max-width: 100vw;
-  overflow-x: hidden;
+  /* `clip` prevents horizontal overflow without creating a scroll container —
+     `hidden` here silently disables every position:sticky descendant. */
+  overflow-x: clip;
 }
 
 body {

--- a/app/organiser/new-listing/page.tsx
+++ b/app/organiser/new-listing/page.tsx
@@ -1579,7 +1579,7 @@ export default function NewListingPage() {
     setStep(target);
   };
 
-  const submitToApi = async (asDraft: boolean, overrideTitle?: string): Promise<boolean> => {
+  const submitToApi = async (asDraft: boolean, overrideTitle?: string): Promise<void> => {
     setSaving(true); setApiError(""); setSubmitErrors([]);
     try {
       let coverImageUrl: string | null = null;
@@ -1588,7 +1588,7 @@ export default function NewListingPage() {
         fd.append("file", form.coverImage);
         fd.append("type", "cover");
         const uploadRes = await fetch("/api/upload", { method: "POST", body: fd });
-        if (!uploadRes.ok) { setApiError("Cover image upload failed. Please try again or remove the image."); return false; }
+        if (!uploadRes.ok) { setApiError("Cover image upload failed. Please try again or remove the image."); return; }
         const { fileUrl } = await uploadRes.json(); coverImageUrl = fileUrl;
       }
 
@@ -1598,7 +1598,7 @@ export default function NewListingPage() {
         fd.append("file", photo);
         fd.append("type", "photo");
         const uploadRes = await fetch("/api/upload", { method: "POST", body: fd });
-        if (!uploadRes.ok) { setApiError(`Gallery photo "${photo.name}" failed to upload. Please try again or remove it.`); return false; }
+        if (!uploadRes.ok) { setApiError(`Gallery photo "${photo.name}" failed to upload. Please try again or remove it.`); return; }
         const { fileUrl } = await uploadRes.json(); photoUrls.push(fileUrl);
       }
 
@@ -1644,10 +1644,8 @@ export default function NewListingPage() {
       if (!res.ok) { setApiError(data.error ?? "Something went wrong."); return false; }
       if (asDraft && !eventId && data.id) setEventId(data.id);
       router.push("/organiser/dashboard");
-      return true;
     } catch {
       setApiError("Something went wrong. Please check your connection and try again.");
-      return false;
     } finally {
       setSaving(false);
     }

--- a/app/organiser/new-listing/page.tsx
+++ b/app/organiser/new-listing/page.tsx
@@ -171,7 +171,9 @@ function DatePickerPopover({
     ? value
       ? rangeEnd && rangeEnd !== value ? `${fmtDateShort(value)} — ${fmtDateShort(rangeEnd)}`
         : rangeEnd && rangeEnd === value ? fmtDateShort(value) + " (1 day)"
-        : fmtDateShort(value) + " → pick end date"
+        // Only prompt for an end date while the picker is open — a closed
+        // picker with just a start date is a valid single-day event.
+        : open ? fmtDateShort(value) + " → pick end date" : fmtDateShort(value)
       : ""
     : value ? fmtDateShort(value) : "";
 
@@ -784,7 +786,8 @@ function TicketsStep({ form, update }: { form: FormState; update: (p: Partial<Fo
                   ) : (
                     <div className="relative">
                       <span className="absolute left-3 top-1/2 -translate-y-1/2 font-headline text-[13px] text-muted">A$</span>
-                      <input value={w.price} onChange={e => updateWave(i, { price: e.target.value })}
+                      <input value={w.price} inputMode="decimal"
+                        onChange={e => updateWave(i, { price: e.target.value.replace(/[^\d.]/g, "") })}
                         placeholder="129" className={`${inputCls} pl-9`} />
                     </div>
                   )}
@@ -1576,7 +1579,7 @@ export default function NewListingPage() {
     setStep(target);
   };
 
-  const submitToApi = async (asDraft: boolean, overrideTitle?: string) => {
+  const submitToApi = async (asDraft: boolean, overrideTitle?: string): Promise<boolean> => {
     setSaving(true); setApiError(""); setSubmitErrors([]);
     try {
       let coverImageUrl: string | null = null;
@@ -1585,7 +1588,8 @@ export default function NewListingPage() {
         fd.append("file", form.coverImage);
         fd.append("type", "cover");
         const uploadRes = await fetch("/api/upload", { method: "POST", body: fd });
-        if (uploadRes.ok) { const { fileUrl } = await uploadRes.json(); coverImageUrl = fileUrl; }
+        if (!uploadRes.ok) { setApiError("Cover image upload failed. Please try again or remove the image."); return false; }
+        const { fileUrl } = await uploadRes.json(); coverImageUrl = fileUrl;
       }
 
       const photoUrls: string[] = [...form.photoUrls];
@@ -1594,7 +1598,8 @@ export default function NewListingPage() {
         fd.append("file", photo);
         fd.append("type", "photo");
         const uploadRes = await fetch("/api/upload", { method: "POST", body: fd });
-        if (uploadRes.ok) { const { fileUrl } = await uploadRes.json(); photoUrls.push(fileUrl); }
+        if (!uploadRes.ok) { setApiError(`Gallery photo "${photo.name}" failed to upload. Please try again or remove it.`); return false; }
+        const { fileUrl } = await uploadRes.json(); photoUrls.push(fileUrl);
       }
 
       const payload = {
@@ -1635,10 +1640,14 @@ export default function NewListingPage() {
         res = await fetch("/api/organiser/events", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
       }
 
-      const data = await res.json();
-      if (!res.ok) { setApiError(data.error ?? "Something went wrong."); return; }
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) { setApiError(data.error ?? "Something went wrong."); return false; }
       if (asDraft && !eventId && data.id) setEventId(data.id);
       router.push("/organiser/dashboard");
+      return true;
+    } catch {
+      setApiError("Something went wrong. Please check your connection and try again.");
+      return false;
     } finally {
       setSaving(false);
     }
@@ -1824,7 +1833,7 @@ export default function NewListingPage() {
               Your event details haven&apos;t been saved yet. Save as a draft so you can come back and finish it later.
             </p>
             <div className="flex flex-col gap-3">
-              <button onClick={async () => { setShowCancelModal(false); await submitToApi(true, form.title.trim() || "Untitled draft"); router.push("/organiser/dashboard"); }}
+              <button onClick={async () => { await submitToApi(true, form.title.trim() || "Untitled draft"); setShowCancelModal(false); }}
                 disabled={saving}
                 className="w-full font-headline text-[13px] font-bold uppercase tracking-widest px-6 py-3.5 rounded-md border border-primary/40 bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-50 transition-colors flex items-center justify-center gap-2">
                 {saving ? "Saving…" : <><Check className="w-4 h-4" /> Save draft &amp; leave</>}

--- a/app/organiser/verify-email/page.tsx
+++ b/app/organiser/verify-email/page.tsx
@@ -1,193 +1,20 @@
 "use client";
 
-import { useState, Suspense } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import Image from "next/image";
-import Link from "next/link";
-import { Mail, ArrowRight, RotateCcw, Check } from "lucide-react";
-import { confirmSignUp, resendSignUpCode, autoSignIn } from "aws-amplify/auth";
-import { useAuthContext } from "@/context/AuthContext";
+import VerifyEmailForm from "@/components/VerifyEmailForm";
 
-function VerifyEmailForm() {
-  const router       = useRouter();
-  const searchParams = useSearchParams();
-  const emailParam   = searchParams.get("email") ?? "";
-  const { refresh }  = useAuthContext();
+const config = {
+  logoHref: "/organiser",
+  sessionEndpoint: "/api/organiser/auth/session",
+  redirectPath: "/organiser/dashboard",
+  emailPlaceholder: "events@yourorg.com.au",
+  inputIdPrefix: "org-verify",
+  verifiedSubtext: "Taking you to your dashboard…",
+  submitButtonLabel: "Verify email",
+  bottomLinkText: "Wrong email?",
+  bottomLinkHref: "/organiser",
+  bottomLinkLabel: "Go back",
+};
 
-  const [email,   setEmail]   = useState(emailParam);
-  const [code,    setCode]    = useState("");
-  const [error,   setError]   = useState("");
-  const [success, setSuccess] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [resending, setResending] = useState(false);
-  const [verified, setVerified] = useState(false);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError("");
-    setLoading(true);
-
-    try {
-      await confirmSignUp({ username: email, confirmationCode: code.trim() });
-
-      // Seamlessly sign the user in — falls back to a manual sign-in prompt
-      // if the auto sign-in session isn't available (e.g. verified on another device).
-      try {
-        const result = await autoSignIn();
-        if (result.nextStep.signInStep === "DONE") {
-          await fetch("/api/organiser/auth/session", { method: "POST" });
-          await refresh();
-          setVerified(true);
-          setLoading(false);
-          setTimeout(() => router.push("/organiser/dashboard"), 1400);
-          return;
-        }
-      } catch {
-        // fall through to manual sign-in redirect below
-      }
-
-      router.push("/organiser?verified=1");
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "";
-      if (msg.includes("CodeMismatchException")) {
-        setError("That code is incorrect. Please check and try again.");
-      } else if (msg.includes("ExpiredCodeException")) {
-        setError("That code has expired. Use the resend button below.");
-      } else if (msg.includes("AliasExistsException")) {
-        setError("This email is already verified. Try signing in.");
-      } else {
-        setError("Verification failed. Please try again.");
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleResend = async () => {
-    if (!email) { setError("Enter your email address first."); return; }
-    setError("");
-    setSuccess("");
-    setResending(true);
-    try {
-      await resendSignUpCode({ username: email });
-      setSuccess("A new code has been sent to your inbox.");
-    } catch {
-      setError("Could not resend the code. Please try again.");
-    } finally {
-      setResending(false);
-    }
-  };
-
-  return (
-    <main className="min-h-screen bg-dark-darker flex items-center justify-center px-6">
-      <div className="w-full max-w-[480px] page-in">
-        <Link href="/organiser">
-          <Image src="/images/logo-title.svg" alt="Startline" width={160} height={40} className="h-10 w-auto mx-auto mb-12 opacity-80" />
-        </Link>
-
-        {verified ? (
-          <>
-            <div className="w-16 h-16 rounded-full bg-green-500/10 border border-green-500/30 flex items-center justify-center mx-auto mb-6">
-              <Check className="w-7 h-7 text-green-400" />
-            </div>
-            <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
-              You&apos;re all set
-            </div>
-            <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
-              Verified &amp;<br /><span className="text-primary">signed in.</span>
-            </h1>
-            <p className="text-muted text-[15px] leading-relaxed text-center">
-              Taking you to your dashboard…
-            </p>
-          </>
-        ) : (
-          <>
-            <div className="w-16 h-16 rounded-full bg-primary/10 border border-primary/30 flex items-center justify-center mx-auto mb-6">
-              <Mail className="w-7 h-7 text-primary" />
-            </div>
-
-            <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
-              Verify your email
-            </div>
-            <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
-              Enter your<br /><span className="text-primary">6-digit code.</span>
-            </h1>
-            <p className="text-muted text-[15px] leading-relaxed mb-8 text-center">
-              We sent a verification code to{" "}
-              {email ? <strong className="text-light">{email}</strong> : "your email"}.
-              Enter it below to activate your account.
-            </p>
-
-            {error && (
-              <div className="mb-5 px-4 py-3 rounded-md bg-red-900/20 border border-red-500/30 text-red-400 font-headline text-[13px]">
-                {error}
-              </div>
-            )}
-            {success && (
-              <div className="mb-5 px-4 py-3 rounded-md bg-green-900/20 border border-green-500/30 text-green-400 font-headline text-[13px]">
-                {success}
-              </div>
-            )}
-
-            <form onSubmit={handleSubmit} className="space-y-4">
-              {/* Only show email field if it wasn't passed via query param */}
-              {!emailParam && (
-                <div>
-                  <label htmlFor="org-verify-email-input" className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Email address</label>
-                  <input id="org-verify-email-input" type="email" required value={email} onChange={(e) => setEmail(e.target.value)}
-                    placeholder="events@yourorg.com.au"
-                    className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[15px] text-light placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors" />
-                </div>
-              )}
-
-              <div>
-                <label htmlFor="org-verify-code-input" className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Verification code</label>
-                <input
-                  id="org-verify-code-input"
-                  type="text"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
-                  maxLength={6}
-                  required
-                  value={code}
-                  onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
-                  placeholder="000000"
-                  className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[22px] text-light tracking-[0.5em] text-center placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors font-headline font-black"
-                />
-              </div>
-
-              <button type="submit" disabled={loading || code.length < 6}
-                className="bg-machined shadow-machined w-full text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 rounded-md flex items-center justify-center gap-2 hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform disabled:opacity-50 disabled:cursor-not-allowed">
-                {loading ? <><span className="w-2 h-2 bg-dark rounded-full animate-pulse-dot" /> Verifying…</> : <>Verify email <ArrowRight className="w-4 h-4" /></>}
-              </button>
-            </form>
-
-            <div className="mt-6 text-center">
-              <button
-                onClick={handleResend}
-                disabled={resending}
-                className="inline-flex items-center gap-2 font-headline text-[12px] uppercase tracking-widest text-muted hover:text-primary transition-colors disabled:opacity-50"
-              >
-                <RotateCcw className="w-3.5 h-3.5" />
-                {resending ? "Sending…" : "Resend code"}
-              </button>
-            </div>
-
-            <p className="mt-4 text-center font-headline text-[12px] uppercase tracking-widest text-muted">
-              Wrong email?{" "}
-              <Link href="/organiser" className="text-primary hover:underline">Go back</Link>
-            </p>
-          </>
-        )}
-      </div>
-    </main>
-  );
-}
-
-export default function VerifyEmailPage() {
-  return (
-    <Suspense>
-      <VerifyEmailForm />
-    </Suspense>
-  );
+export default function OrganiserVerifyEmailPage() {
+  return <VerifyEmailForm config={config} />;
 }

--- a/app/organiser/verify-email/page.tsx
+++ b/app/organiser/verify-email/page.tsx
@@ -4,13 +4,15 @@ import { useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import { Mail, ArrowRight, RotateCcw } from "lucide-react";
-import { confirmSignUp, resendSignUpCode } from "aws-amplify/auth";
+import { Mail, ArrowRight, RotateCcw, Check } from "lucide-react";
+import { confirmSignUp, resendSignUpCode, autoSignIn } from "aws-amplify/auth";
+import { useAuthContext } from "@/context/AuthContext";
 
 function VerifyEmailForm() {
   const router       = useRouter();
   const searchParams = useSearchParams();
   const emailParam   = searchParams.get("email") ?? "";
+  const { refresh }  = useAuthContext();
 
   const [email,   setEmail]   = useState(emailParam);
   const [code,    setCode]    = useState("");
@@ -18,6 +20,7 @@ function VerifyEmailForm() {
   const [success, setSuccess] = useState("");
   const [loading, setLoading] = useState(false);
   const [resending, setResending] = useState(false);
+  const [verified, setVerified] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -26,8 +29,24 @@ function VerifyEmailForm() {
 
     try {
       await confirmSignUp({ username: email, confirmationCode: code.trim() });
-      // Verified — send to sign-in
-      router.push("/organiser");
+
+      // Seamlessly sign the user in — falls back to a manual sign-in prompt
+      // if the auto sign-in session isn't available (e.g. verified on another device).
+      try {
+        const result = await autoSignIn();
+        if (result.nextStep.signInStep === "DONE") {
+          await fetch("/api/organiser/auth/session", { method: "POST" });
+          await refresh();
+          setVerified(true);
+          setLoading(false);
+          setTimeout(() => router.push("/organiser/dashboard"), 1400);
+          return;
+        }
+      } catch {
+        // fall through to manual sign-in redirect below
+      }
+
+      router.push("/organiser?verified=1");
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "";
       if (msg.includes("CodeMismatchException")) {
@@ -66,80 +85,100 @@ function VerifyEmailForm() {
           <Image src="/images/logo-title.svg" alt="Startline" width={160} height={40} className="h-10 w-auto mx-auto mb-12 opacity-80" />
         </Link>
 
-        <div className="w-16 h-16 rounded-full bg-primary/10 border border-primary/30 flex items-center justify-center mx-auto mb-6">
-          <Mail className="w-7 h-7 text-primary" />
-        </div>
-
-        <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
-          Verify your email
-        </div>
-        <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
-          Enter your<br /><span className="text-primary">6-digit code.</span>
-        </h1>
-        <p className="text-muted text-[15px] leading-relaxed mb-8 text-center">
-          We sent a verification code to{" "}
-          {email ? <strong className="text-light">{email}</strong> : "your email"}.
-          Enter it below to activate your account.
-        </p>
-
-        {error && (
-          <div className="mb-5 px-4 py-3 rounded-md bg-red-900/20 border border-red-500/30 text-red-400 font-headline text-[13px]">
-            {error}
-          </div>
-        )}
-        {success && (
-          <div className="mb-5 px-4 py-3 rounded-md bg-green-900/20 border border-green-500/30 text-green-400 font-headline text-[13px]">
-            {success}
-          </div>
-        )}
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Only show email field if it wasn't passed via query param */}
-          {!emailParam && (
-            <div>
-              <label className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Email address</label>
-              <input type="email" required value={email} onChange={(e) => setEmail(e.target.value)}
-                placeholder="events@yourorg.com.au"
-                className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[15px] text-light placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors" />
+        {verified ? (
+          <>
+            <div className="w-16 h-16 rounded-full bg-green-500/10 border border-green-500/30 flex items-center justify-center mx-auto mb-6">
+              <Check className="w-7 h-7 text-green-400" />
             </div>
-          )}
+            <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
+              You&apos;re all set
+            </div>
+            <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
+              Verified &amp;<br /><span className="text-primary">signed in.</span>
+            </h1>
+            <p className="text-muted text-[15px] leading-relaxed text-center">
+              Taking you to your dashboard…
+            </p>
+          </>
+        ) : (
+          <>
+            <div className="w-16 h-16 rounded-full bg-primary/10 border border-primary/30 flex items-center justify-center mx-auto mb-6">
+              <Mail className="w-7 h-7 text-primary" />
+            </div>
 
-          <div>
-            <label className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Verification code</label>
-            <input
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              maxLength={6}
-              required
-              value={code}
-              onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
-              placeholder="000000"
-              className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[22px] text-light tracking-[0.5em] text-center placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors font-headline font-black"
-            />
-          </div>
+            <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
+              Verify your email
+            </div>
+            <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
+              Enter your<br /><span className="text-primary">6-digit code.</span>
+            </h1>
+            <p className="text-muted text-[15px] leading-relaxed mb-8 text-center">
+              We sent a verification code to{" "}
+              {email ? <strong className="text-light">{email}</strong> : "your email"}.
+              Enter it below to activate your account.
+            </p>
 
-          <button type="submit" disabled={loading || code.length < 6}
-            className="bg-machined shadow-machined w-full text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 rounded-md flex items-center justify-center gap-2 hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform disabled:opacity-50 disabled:cursor-not-allowed">
-            {loading ? <><span className="w-2 h-2 bg-dark rounded-full animate-pulse-dot" /> Verifying…</> : <>Verify email <ArrowRight className="w-4 h-4" /></>}
-          </button>
-        </form>
+            {error && (
+              <div className="mb-5 px-4 py-3 rounded-md bg-red-900/20 border border-red-500/30 text-red-400 font-headline text-[13px]">
+                {error}
+              </div>
+            )}
+            {success && (
+              <div className="mb-5 px-4 py-3 rounded-md bg-green-900/20 border border-green-500/30 text-green-400 font-headline text-[13px]">
+                {success}
+              </div>
+            )}
 
-        <div className="mt-6 text-center">
-          <button
-            onClick={handleResend}
-            disabled={resending}
-            className="inline-flex items-center gap-2 font-headline text-[12px] uppercase tracking-widest text-muted hover:text-primary transition-colors disabled:opacity-50"
-          >
-            <RotateCcw className="w-3.5 h-3.5" />
-            {resending ? "Sending…" : "Resend code"}
-          </button>
-        </div>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {/* Only show email field if it wasn't passed via query param */}
+              {!emailParam && (
+                <div>
+                  <label htmlFor="org-verify-email-input" className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Email address</label>
+                  <input id="org-verify-email-input" type="email" required value={email} onChange={(e) => setEmail(e.target.value)}
+                    placeholder="events@yourorg.com.au"
+                    className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[15px] text-light placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors" />
+                </div>
+              )}
 
-        <p className="mt-4 text-center font-headline text-[12px] uppercase tracking-widest text-muted">
-          Wrong email?{" "}
-          <Link href="/organiser/register" className="text-primary hover:underline">Go back</Link>
-        </p>
+              <div>
+                <label htmlFor="org-verify-code-input" className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Verification code</label>
+                <input
+                  id="org-verify-code-input"
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  maxLength={6}
+                  required
+                  value={code}
+                  onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+                  placeholder="000000"
+                  className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[22px] text-light tracking-[0.5em] text-center placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors font-headline font-black"
+                />
+              </div>
+
+              <button type="submit" disabled={loading || code.length < 6}
+                className="bg-machined shadow-machined w-full text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 rounded-md flex items-center justify-center gap-2 hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform disabled:opacity-50 disabled:cursor-not-allowed">
+                {loading ? <><span className="w-2 h-2 bg-dark rounded-full animate-pulse-dot" /> Verifying…</> : <>Verify email <ArrowRight className="w-4 h-4" /></>}
+              </button>
+            </form>
+
+            <div className="mt-6 text-center">
+              <button
+                onClick={handleResend}
+                disabled={resending}
+                className="inline-flex items-center gap-2 font-headline text-[12px] uppercase tracking-widest text-muted hover:text-primary transition-colors disabled:opacity-50"
+              >
+                <RotateCcw className="w-3.5 h-3.5" />
+                {resending ? "Sending…" : "Resend code"}
+              </button>
+            </div>
+
+            <p className="mt-4 text-center font-headline text-[12px] uppercase tracking-widest text-muted">
+              Wrong email?{" "}
+              <Link href="/organiser" className="text-primary hover:underline">Go back</Link>
+            </p>
+          </>
+        )}
       </div>
     </main>
   );

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -191,8 +191,6 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
             }),
           });
           sessionStorage.removeItem("startline_pending_name");
-          sessionStorage.removeItem("startline_pending_dob");
-          sessionStorage.removeItem("startline_pending_phone");
           sessionStorage.removeItem("startline_pending_username");
         }
       } catch {}

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -117,6 +117,14 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email }),
       });
+      if (!res.ok) {
+        // Existence check unavailable (e.g. server lacks Cognito admin perms).
+        // Fall through to the password step — signIn() itself will report
+        // "no account" / "wrong password" accurately.
+        setUserExists(true);
+        setUserStatus("CONFIRMED");
+        return;
+      }
       const data = await res.json();
       if (!data.exists) {
         setUserExists(false);
@@ -124,15 +132,19 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
       } else {
         setUserExists(true);
         setUserStatus(data.status);
-        if (data.status === "CONFIRMED") {
-          // Show password field — signInStep is implicitly "password" via userExists + userStatus
+        if (data.status === "CONFIRMED" || data.status === "UNCONFIRMED") {
+          // Show password field — for UNCONFIRMED users signIn() throws
+          // UserNotConfirmedException, which routes them to verify-email.
+          if (data.status === "UNCONFIRMED") setUserStatus("CONFIRMED");
         } else {
           // FORCE_CHANGE_PASSWORD or RESET_REQUIRED → start reset flow
           setNewPwStep("initial");
         }
       }
     } catch {
-      setError("Could not verify email. Please try again.");
+      // Network failure reaching our own API — same graceful fallback.
+      setUserExists(true);
+      setUserStatus("CONFIRMED");
     } finally {
       setCheckingEmail(false);
     }
@@ -148,10 +160,10 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
       const result = await signIn({ username: email, password });
 
       if (result.nextStep.signInStep === "CONFIRM_SIGN_UP") {
-        onClose(); router.push("/customer/verify-email?email=" + encodeURIComponent(email)); return;
+        onClose(); router.push("/auth/verify-email?email=" + encodeURIComponent(email)); return;
       }
       if (result.nextStep.signInStep === "RESET_PASSWORD") {
-        onClose(); router.push("/customer/forgot-password?email=" + encodeURIComponent(email)); return;
+        onClose(); router.push("/auth/forgot-password?email=" + encodeURIComponent(email)); return;
       }
       if (result.nextStep.signInStep === "CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED") {
         setPassword("");
@@ -194,7 +206,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
       if (errName === "NotAuthorizedException" || msg.includes("Incorrect username or password")) {
         setError("Incorrect email or password.");
       } else if (errName === "UserNotConfirmedException") {
-        onClose(); router.push("/customer/verify-email?email=" + encodeURIComponent(email));
+        onClose(); router.push("/auth/verify-email?email=" + encodeURIComponent(email));
       } else if (errName === "UserNotFoundException") {
         setError("No account found with that email.");
       } else {
@@ -358,6 +370,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
             phone_number: e164Phone,
             birthdate:    isoDate,
           },
+          autoSignIn: true,
         },
       });
       try {
@@ -388,7 +401,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
       try { sessionStorage.setItem("startline_pending_username", username.trim().toLowerCase()); } catch {}
     }
     onClose();
-    router.push("/customer/verify-email?email=" + encodeURIComponent(email));
+    router.push("/auth/verify-email?email=" + encodeURIComponent(email));
   };
 
   const switchView = (v: "signin" | "signup") => {
@@ -466,10 +479,11 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
 
             <form onSubmit={(e) => { e.preventDefault(); handleCheckEmail(); }} className="space-y-4">
               <div>
-                <label className={labelCls}>Email</label>
+                <label htmlFor="signin-email" className={labelCls}>Email</label>
                 <div className="relative">
                   <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
                   <input
+                    id="signin-email"
                     type="email"
                     required
                     value={email}
@@ -537,12 +551,13 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
             <form onSubmit={handleSignIn} className="space-y-4">
               <div>
                 <div className="flex items-center justify-between mb-1">
-                  <label className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted">Password</label>
-                  <Link href="/customer/forgot-password" onClick={onClose} className="font-headline text-[11px] uppercase tracking-widest text-muted hover:text-primary transition-colors">Forgot?</Link>
+                  <label htmlFor="signin-password" className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted">Password</label>
+                  <Link href="/auth/forgot-password" onClick={onClose} className="font-headline text-[11px] uppercase tracking-widest text-muted hover:text-primary transition-colors">Forgot?</Link>
                 </div>
                 <div className="relative">
                   <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
                   <input
+                    id="signin-password"
                     type={showPw ? "text" : "password"}
                     required
                     value={password}
@@ -592,10 +607,11 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
             {newPwStep === "sent" && (
               <form onSubmit={(e) => { e.preventDefault(); handleCompleteReset(); }} className="space-y-3">
                 <div>
-                  <label className={labelCls}>Verification Code</label>
+                  <label htmlFor="reset-code" className={labelCls}>Verification Code</label>
                   <div className="relative">
                     <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
                     <input
+                      id="reset-code"
                       type="text"
                       inputMode="numeric"
                       required
@@ -609,10 +625,11 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
                   <p className="font-headline text-[10px] uppercase tracking-widest text-muted-dark mt-1">Enter the 6-digit code sent to {email}</p>
                 </div>
                 <div>
-                  <label className={labelCls}>New Password</label>
+                  <label htmlFor="reset-new-password" className={labelCls}>New Password</label>
                   <div className="relative">
                     <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
                     <input
+                      id="reset-new-password"
                       type={showPw ? "text" : "password"}
                       required
                       value={newPassword}
@@ -626,10 +643,11 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
                   </div>
                 </div>
                 <div>
-                  <label className={labelCls}>Confirm Password</label>
+                  <label htmlFor="reset-confirm-password" className={labelCls}>Confirm Password</label>
                   <div className="relative">
                     <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
                     <input
+                      id="reset-confirm-password"
                       type={showPw ? "text" : "password"}
                       required
                       value={newPwConfirm}
@@ -686,10 +704,11 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
 
             <form onSubmit={(e) => { e.preventDefault(); handleConfirmNewPassword(); }} className="space-y-3">
               <div>
-                <label className={labelCls}>New Password</label>
+                <label htmlFor="challenge-new-password" className={labelCls}>New Password</label>
                 <div className="relative">
                   <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
                   <input
+                    id="challenge-new-password"
                     type={showPw ? "text" : "password"}
                     required
                     value={newPassword}
@@ -704,10 +723,11 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
                 </div>
               </div>
               <div>
-                <label className={labelCls}>Confirm Password</label>
+                <label htmlFor="challenge-confirm-password" className={labelCls}>Confirm Password</label>
                 <div className="relative">
                   <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
                   <input
+                    id="challenge-confirm-password"
                     type={showPw ? "text" : "password"}
                     required
                     value={newPwConfirm}
@@ -739,27 +759,27 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
 
             <form onSubmit={handleSignUp} className="space-y-3">
               <div>
-                <label className={labelCls}>Email</label>
+                <label htmlFor="signup-email" className={labelCls}>Email</label>
                 <div className="relative">
                   <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
-                  <input type="email" required value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@example.com" className={inputCls} />
+                  <input id="signup-email" type="email" required value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@example.com" className={inputCls} />
                 </div>
               </div>
               <div>
-                <label className={labelCls}>Password</label>
+                <label htmlFor="signup-password" className={labelCls}>Password</label>
                 <div className="relative">
                   <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
-                  <input type={showPw ? "text" : "password"} required value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Min 8 characters" className={inputCls + " pr-11"} />
+                  <input id="signup-password" type={showPw ? "text" : "password"} required value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Min 8 characters" className={inputCls + " pr-11"} />
                   <button type="button" onClick={() => setShowPw(s => !s)} className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-dark hover:text-primary transition-colors">
                     {showPw ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                   </button>
                 </div>
               </div>
               <div>
-                <label className={labelCls}>Confirm Password</label>
+                <label htmlFor="signup-confirm-password" className={labelCls}>Confirm Password</label>
                 <div className="relative">
                   <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
-                  <input type={showPw ? "text" : "password"} required value={confirm} onChange={(e) => setConfirm(e.target.value)} placeholder="Re-enter password" className={inputCls} />
+                  <input id="signup-confirm-password" type={showPw ? "text" : "password"} required value={confirm} onChange={(e) => setConfirm(e.target.value)} placeholder="Re-enter password" className={inputCls} />
                 </div>
               </div>
               <button type="submit" disabled={loading} className={btnCls}>
@@ -786,25 +806,25 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
               {/* First / Last name */}
               <div className="grid grid-cols-2 gap-2">
                 <div>
-                  <label className={labelCls}>First Name</label>
+                  <label htmlFor="onboarding-first-name" className={labelCls}>First Name</label>
                   <div className="relative">
                     <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
-                    <input autoFocus type="text" required value={firstName} onChange={(e) => setFirstName(e.target.value)} placeholder="First" className={inputCls} />
+                    <input id="onboarding-first-name" autoFocus type="text" required value={firstName} onChange={(e) => setFirstName(e.target.value)} placeholder="First" className={inputCls} />
                   </div>
                 </div>
                 <div>
-                  <label className={labelCls}>Last Name</label>
+                  <label htmlFor="onboarding-last-name" className={labelCls}>Last Name</label>
                   <div className="relative">
                     <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
-                    <input type="text" required value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Last" className={inputCls} />
+                    <input id="onboarding-last-name" type="text" required value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Last" className={inputCls} />
                   </div>
                 </div>
               </div>
 
               {/* Date of birth — three text inputs */}
               <div>
-                <label className={labelCls}>Date of Birth</label>
-                <div className="grid grid-cols-3 gap-2">
+                <label id="onboarding-dob-label" className={labelCls}>Date of Birth</label>
+                <div className="grid grid-cols-3 gap-2" role="group" aria-labelledby="onboarding-dob-label">
                   <div>
                     <input
                       ref={dobDayRef}
@@ -818,6 +838,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
                         if (v.length === 2) dobMonthRef.current?.focus();
                       }}
                       placeholder="DD"
+                      aria-label="Day"
                       className={dobInputCls}
                     />
                   </div>
@@ -834,6 +855,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
                         if (v.length === 2) dobYearRef.current?.focus();
                       }}
                       placeholder="MM"
+                      aria-label="Month"
                       className={dobInputCls}
                     />
                   </div>
@@ -846,6 +868,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
                       value={dobYear}
                       onChange={(e) => setDobYear(e.target.value.replace(/\D/g, ""))}
                       placeholder="YYYY"
+                      aria-label="Year"
                       className={dobInputCls}
                     />
                   </div>
@@ -854,10 +877,10 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
 
               {/* Phone */}
               <div>
-                <label className={labelCls}>Phone Number</label>
+                <label htmlFor="onboarding-phone" className={labelCls}>Phone Number</label>
                 <div className="relative">
                   <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
-                  <input type="tel" required value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="+61 400 000 000" className={inputCls} />
+                  <input id="onboarding-phone" type="tel" required value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="+61 400 000 000" className={inputCls} />
                 </div>
               </div>
 
@@ -937,10 +960,11 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
 
             <div className="space-y-4">
               <div>
-                <label className={labelCls}>Username</label>
+                <label htmlFor="username-input" className={labelCls}>Username</label>
                 <div className="relative">
                   <AtSign className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-dark" />
                   <input
+                    id="username-input"
                     autoFocus
                     type="text"
                     value={username}

--- a/components/VerifiedBanner.tsx
+++ b/components/VerifiedBanner.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState, Suspense } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { Check, X } from "lucide-react";
+
+function Banner() {
+  const searchParams = useSearchParams();
+  const router        = useRouter();
+  const pathname       = usePathname();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed || searchParams.get("verified") !== "1") return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    router.replace(pathname);
+  };
+
+  return (
+    <div className="bg-green-900/20 border-b border-green-500/30">
+      <div className="max-w-[1440px] mx-auto px-4 sm:px-6 py-3 flex items-center justify-center gap-3">
+        <Check className="w-4 h-4 text-green-400 flex-shrink-0" />
+        <p className="text-green-400 font-headline text-[13px] text-center">
+          Email verified — sign in below to continue.
+        </p>
+        <button onClick={dismiss} aria-label="Dismiss" className="text-green-400/60 hover:text-green-400 transition-colors flex-shrink-0">
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function VerifiedBanner() {
+  return (
+    <Suspense>
+      <Banner />
+    </Suspense>
+  );
+}

--- a/components/VerifyEmailForm.tsx
+++ b/components/VerifyEmailForm.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import { Mail, ArrowRight, RotateCcw, Check } from "lucide-react";
+import { confirmSignUp, resendSignUpCode, autoSignIn } from "aws-amplify/auth";
+import { useAuthContext } from "@/context/AuthContext";
+
+interface VerifyEmailConfig {
+  logoHref: string;
+  sessionEndpoint: string;
+  redirectPath: string;
+  emailPlaceholder: string;
+  inputIdPrefix: string;
+  verifiedSubtext: string;
+  submitButtonLabel: string;
+  bottomLinkText: string;
+  bottomLinkHref: string;
+  bottomLinkLabel: string;
+}
+
+interface Props {
+  config: VerifyEmailConfig;
+  onVerified?: () => Promise<void>;
+}
+
+function VerifyEmailFormInner({ config, onVerified }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const emailParam = searchParams.get("email") ?? "";
+  const { refresh } = useAuthContext();
+
+  const [email, setEmail] = useState(emailParam);
+  const [code, setCode] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [verified, setVerified] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      await confirmSignUp({ username: email, confirmationCode: code.trim() });
+
+      try {
+        const result = await autoSignIn();
+        if (result.nextStep.signInStep === "DONE") {
+          await fetch(config.sessionEndpoint, { method: "POST" });
+          await onVerified?.();
+          await refresh();
+          setVerified(true);
+          setLoading(false);
+          setTimeout(() => router.push(config.redirectPath), 1400);
+          return;
+        }
+      } catch {}
+
+      router.push(config.bottomLinkHref + "?verified=1");
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "";
+      if (msg.includes("CodeMismatchException")) {
+        setError("That code is incorrect. Please check and try again.");
+      } else if (msg.includes("ExpiredCodeException")) {
+        setError("That code has expired. Use the resend button below.");
+      } else if (msg.includes("AliasExistsException")) {
+        setError("This email is already verified. Try signing in.");
+      } else {
+        setError("Verification failed. Please try again.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (!email) { setError("Enter your email address first."); return; }
+    setError(""); setSuccess("");
+    setResending(true);
+    try {
+      await resendSignUpCode({ username: email });
+      setSuccess("A new code has been sent. Check your inbox and spam folder — look for an email from Amazon Cognito or no-reply@verificationemail.com.");
+    } catch (err: unknown) {
+      const errName = (err as { name?: string })?.name ?? "";
+      const msg = err instanceof Error ? err.message : "";
+      if (errName === "LimitExceededException" || msg.includes("LimitExceededException")) {
+        setError("Too many attempts. Wait a few minutes, then try resend again.");
+      } else if (errName === "InvalidParameterException" || msg.includes("User is already confirmed")) {
+        setError("This email is already verified. Try signing in instead.");
+      } else if (errName === "UserNotFoundException") {
+        setError("No account found for that email. Sign up again or check the address is correct.");
+      } else {
+        setError(msg || "Could not resend the code. Please try again.");
+      }
+    } finally {
+      setResending(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-dark-darker flex items-center justify-center px-6">
+      <div className="w-full max-w-[480px] page-in">
+        <Link href={config.logoHref}>
+          <Image src="/images/logo-title.svg" alt="Startline" width={160} height={40} className="h-10 w-auto mx-auto mb-12 opacity-80" />
+        </Link>
+
+        {verified ? (
+          <>
+            <div className="w-16 h-16 rounded-full bg-green-500/10 border border-green-500/30 flex items-center justify-center mx-auto mb-6">
+              <Check className="w-7 h-7 text-green-400" />
+            </div>
+            <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
+              You&apos;re all set
+            </div>
+            <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
+              Verified &amp;<br /><span className="text-primary">signed in.</span>
+            </h1>
+            <p className="text-muted text-[15px] leading-relaxed text-center">
+              {config.verifiedSubtext}
+            </p>
+          </>
+        ) : (
+          <>
+            <div className="w-16 h-16 rounded-full bg-primary/10 border border-primary/30 flex items-center justify-center mx-auto mb-6">
+              <Mail className="w-7 h-7 text-primary" />
+            </div>
+
+            <div className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary mb-4 text-center">
+              Verify your email
+            </div>
+            <h1 className="font-headline text-4xl font-black italic tracking-tighter text-light mb-4 text-center">
+              Enter your<br /><span className="text-primary">6-digit code.</span>
+            </h1>
+            <p className="text-muted text-[15px] leading-relaxed mb-4 text-center">
+              We sent a verification code to{" "}
+              {email ? <strong className="text-light">{email}</strong> : "your email"}.
+              Enter it below to activate your account.
+            </p>
+            <p className="text-muted text-[12px] leading-relaxed mb-8 text-center">
+              This code is sent by AWS Cognito (not Resend). Check spam/junk, and allow a minute or two for delivery.
+            </p>
+
+            {error && (
+              <div className="mb-5 px-4 py-3 rounded-md bg-red-900/20 border border-red-500/30 text-red-400 font-headline text-[13px]">
+                {error}
+              </div>
+            )}
+            {success && (
+              <div className="mb-5 px-4 py-3 rounded-md bg-green-900/20 border border-green-500/30 text-green-400 font-headline text-[13px]">
+                {success}
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {!emailParam && (
+                <div>
+                  <label htmlFor={`${config.inputIdPrefix}-email-input`} className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Email address</label>
+                  <input id={`${config.inputIdPrefix}-email-input`} type="email" required value={email} onChange={(e) => setEmail(e.target.value)}
+                    placeholder={config.emailPlaceholder}
+                    className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[15px] text-light placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors" />
+                </div>
+              )}
+
+              <div>
+                <label htmlFor={`${config.inputIdPrefix}-code-input`} className="font-headline text-[11px] font-bold uppercase tracking-widest text-muted block mb-2">Verification code</label>
+                <input
+                  id={`${config.inputIdPrefix}-code-input`}
+                  type="text" inputMode="numeric" pattern="[0-9]*" maxLength={6} required
+                  value={code} onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+                  placeholder="000000"
+                  className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[22px] text-light tracking-[0.5em] text-center placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors font-headline font-black"
+                />
+              </div>
+
+              <button type="submit" disabled={loading || code.length < 6}
+                className="bg-machined shadow-machined w-full text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 rounded-md flex items-center justify-center gap-2 hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform disabled:opacity-50 disabled:cursor-not-allowed">
+                {loading ? <><span className="w-2 h-2 bg-dark rounded-full animate-pulse-dot" /> Verifying…</> : <>{config.submitButtonLabel} <ArrowRight className="w-4 h-4" /></>}
+              </button>
+            </form>
+
+            <div className="mt-6 text-center">
+              <button onClick={handleResend} disabled={resending}
+                className="inline-flex items-center gap-2 font-headline text-[12px] uppercase tracking-widest text-muted hover:text-primary transition-colors disabled:opacity-50">
+                <RotateCcw className="w-3.5 h-3.5" />
+                {resending ? "Sending…" : "Resend code"}
+              </button>
+            </div>
+
+            <p className="mt-4 text-center font-headline text-[12px] uppercase tracking-widest text-muted">
+              {config.bottomLinkText}{" "}
+              <Link href={config.bottomLinkHref} className="text-primary hover:underline">{config.bottomLinkLabel}</Link>
+            </p>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export default function VerifyEmailForm(props: Props) {
+  return (
+    <Suspense>
+      <VerifyEmailFormInner {...props} />
+    </Suspense>
+  );
+}

--- a/components/ui/AddressAutocomplete.tsx
+++ b/components/ui/AddressAutocomplete.tsx
@@ -126,19 +126,19 @@ export default function AddressAutocomplete({
       />
       {loading && (
         <div className="absolute right-3 top-1/2 -translate-y-1/2">
-          <div className="w-4 h-4 border-2 border-lime-500 border-t-transparent rounded-full animate-spin" />
+          <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
         </div>
       )}
       {open && suggestions.length > 0 && (
         <div ref={listRef} id="address-suggestions"
-          className="absolute top-full left-0 mt-1 z-50 w-full bg-white border border-gray-200 rounded-xl shadow-xl overflow-y-auto max-h-64 modal-in">
+          className="absolute top-full left-0 mt-1 z-50 w-full bg-dark border border-dark-lighter rounded-xl shadow-xl overflow-y-auto max-h-64 modal-in">
           {suggestions.map((item, i) => (
             <button key={item.placeId} type="button"
               onClick={() => select(item)}
               onMouseEnter={() => setActiveIdx(i)}
               className={`w-full px-4 py-3 text-left transition-colors
-                ${i === activeIdx ? "bg-lime-50" : "hover:bg-gray-50"}`}>
-              <span className={`font-headline text-[14px] ${i === activeIdx ? "text-lime-700" : "text-gray-900"}`}>
+                ${i === activeIdx ? "bg-primary/10" : "hover:bg-white/5"}`}>
+              <span className={`font-headline text-[14px] ${i === activeIdx ? "text-primary" : "text-light"}`}>
                 {item.label}
               </span>
             </button>

--- a/components/ui/SuburbAutocomplete.tsx
+++ b/components/ui/SuburbAutocomplete.tsx
@@ -112,19 +112,19 @@ export default function SuburbAutocomplete({
       />
       {loading && (
         <div className="absolute right-3 top-1/2 -translate-y-1/2">
-          <div className="w-4 h-4 border-2 border-lime-500 border-t-transparent rounded-full animate-spin" />
+          <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
         </div>
       )}
       {open && suggestions.length > 0 && (
         <div ref={listRef} id="suburb-suggestions"
-          className="absolute top-full left-0 mt-1 z-50 w-full bg-white border border-gray-200 rounded-xl shadow-xl overflow-hidden modal-in">
+          className="absolute top-full left-0 mt-1 z-50 w-full bg-dark border border-dark-lighter rounded-xl shadow-xl overflow-hidden modal-in">
           {suggestions.map((item, i) => (
             <button key={item.placeId} type="button"
               onClick={() => select(item)}
               onMouseEnter={() => setActiveIdx(i)}
               className={`w-full px-4 py-3 text-left flex items-center gap-2.5 transition-colors
-                ${i === activeIdx ? "bg-lime-50" : "hover:bg-gray-50"}`}>
-              <span className={`font-headline text-[14px] ${i === activeIdx ? "text-lime-700" : "text-gray-900"}`}>
+                ${i === activeIdx ? "bg-primary/10" : "hover:bg-white/5"}`}>
+              <span className={`font-headline text-[14px] ${i === activeIdx ? "text-primary" : "text-light"}`}>
                 {item.label}
               </span>
             </button>

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+import { goToHomepage } from "./helpers";
+
+async function openSignInModal(page: import("@playwright/test").Page) {
+  await goToHomepage(page);
+  await page.getByRole("button", { name: "SIGN IN" }).click();
+  await page.waitForSelector('[role="dialog"]');
+}
+
+test.describe("auth modal — sign in", () => {
+  test("unknown email never dead-ends: 'no account found' or password fallback", async ({ page }) => {
+    await openSignInModal(page);
+    await page.getByPlaceholder("you@example.com").fill(`nobody.${Date.now()}@example.com`);
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+
+    // Two valid outcomes: with Cognito admin perms the exists-check says
+    // "no account found"; without them the modal falls back to the password
+    // step and signIn() itself reports the truth. Either way, never a dead end.
+    const noAccount = page.getByRole("heading", { name: "No account found." });
+    const passwordStep = page.locator("#signin-password");
+    await expect(noAccount.or(passwordStep)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole("button", { name: "Use a different email" })).toBeVisible();
+
+    if (await passwordStep.isVisible()) {
+      // Fallback path: a wrong password must produce a truthful Cognito error.
+      await passwordStep.fill("WrongPass999!");
+      await page.getByRole("button", { name: "Sign in", exact: true }).click();
+      await expect(
+        page.getByText(/incorrect email or password|no account found with that email/i)
+      ).toBeVisible({ timeout: 15000 });
+    }
+  });
+
+  test("Email label is associated with its input (a11y)", async ({ page }) => {
+    await openSignInModal(page);
+    await page.getByText("Email", { exact: true }).click();
+    const focused = await page.evaluate(() => document.activeElement?.id);
+    expect(focused).toBe("signin-email");
+  });
+});
+
+test.describe("auth modal — sign up", () => {
+  test("rejects mismatched passwords before hitting the network", async ({ page }) => {
+    await openSignInModal(page);
+    await page.getByRole("button", { name: "Create Account", exact: true }).click();
+    await page.getByPlaceholder("you@example.com").fill(`ux.${Date.now()}@example.com`);
+    await page.getByPlaceholder("Min 8 characters").fill("Password123!");
+    await page.getByPlaceholder("Re-enter password").fill("Different123!");
+    await page.getByRole("button", { name: "Create account", exact: true }).click();
+    await expect(page.getByText("Passwords do not match.")).toBeVisible();
+  });
+
+  test("rejects a too-short password", async ({ page }) => {
+    await openSignInModal(page);
+    await page.getByRole("button", { name: "Create Account", exact: true }).click();
+    await page.getByPlaceholder("you@example.com").fill(`ux.${Date.now()}@example.com`);
+    await page.getByPlaceholder("Min 8 characters").fill("abc123");
+    await page.getByPlaceholder("Re-enter password").fill("abc123");
+    await page.getByRole("button", { name: "Create account", exact: true }).click();
+    await expect(page.getByText("Password must be at least 8 characters.")).toBeVisible();
+  });
+
+  test("onboarding rejects an under-13 date of birth", async ({ page }) => {
+    await openSignInModal(page);
+    await page.getByRole("button", { name: "Create Account", exact: true }).click();
+    await page.getByPlaceholder("you@example.com").fill(`ux.${Date.now()}@example.com`);
+    await page.getByPlaceholder("Min 8 characters").fill("Password123!");
+    await page.getByPlaceholder("Re-enter password").fill("Password123!");
+    await page.getByRole("button", { name: "Create account", exact: true }).click();
+    await page.waitForSelector("text=Tell us a bit about yourself");
+
+    await page.getByPlaceholder("First").fill("Too");
+    await page.getByPlaceholder("Last").fill("Young");
+    const today = new Date();
+    await page.locator('input[aria-label="Day"]').fill(String(today.getDate()).padStart(2, "0"));
+    await page.locator('input[aria-label="Month"]').fill(String(today.getMonth() + 1).padStart(2, "0"));
+    await page.locator('input[aria-label="Year"]').fill(String(today.getFullYear() - 5));
+    await page.getByPlaceholder("+61 400 000 000").fill("0400123456");
+    await page.locator('input[type="checkbox"]').check({ force: true });
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+
+    await expect(page.getByText("You must be at least 13 years old to create an account.")).toBeVisible();
+  });
+
+  test("completing signup lands on the verify-email page, not a 404", async ({ page }) => {
+    const email = `ux.e2e.${Date.now()}@example.com`;
+
+    await openSignInModal(page);
+    await page.getByRole("button", { name: "Create Account", exact: true }).click();
+    await page.getByPlaceholder("you@example.com").fill(email);
+    await page.getByPlaceholder("Min 8 characters").fill("Password123!");
+    await page.getByPlaceholder("Re-enter password").fill("Password123!");
+    await page.getByRole("button", { name: "Create account", exact: true }).click();
+    await page.waitForSelector("text=Tell us a bit about yourself");
+
+    await page.getByPlaceholder("First").fill("Ux");
+    await page.getByPlaceholder("Last").fill("Tester");
+    await page.locator('input[aria-label="Day"]').fill("15");
+    await page.locator('input[aria-label="Month"]').fill("06");
+    await page.locator('input[aria-label="Year"]').fill("1995");
+    await page.getByPlaceholder("+61 400 000 000").fill("0400123456");
+    await page.locator('input[type="checkbox"]').check({ force: true });
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+
+    // signUp() hits real Cognito — give it real network time
+    await page.waitForSelector("text=Choose your", { timeout: 20000 });
+    await page.getByRole("button", { name: "Skip for now" }).click();
+
+    await page.waitForURL("**/auth/verify-email**", { timeout: 20000 });
+    await expect(page).not.toHaveURL(/\/customer\//);
+    await expect(page.getByText("This page could not be found.")).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: /6-digit code/i })).toBeVisible();
+    await expect(page.getByText(email)).toBeVisible();
+
+    // A wrong code must show an error and NOT redirect/auto-sign-in.
+    // (The auto-sign-in success path itself can't be exercised here — Cognito
+    // emails a real 6-digit code to an inbox this suite has no access to.
+    // Verify that path manually with a real mailbox after touching this flow.)
+    await page.locator("#verify-code-input").fill("000000");
+    await page.getByRole("button", { name: /verify & sign in/i }).click();
+    await expect(page.getByText(/verification failed|code is incorrect/i)).toBeVisible({ timeout: 10000 });
+    await expect(page).toHaveURL(/\/auth\/verify-email/);
+  });
+});
+
+test.describe("forgot-password route", () => {
+  test("/auth/forgot-password renders (not a 404)", async ({ page }) => {
+    await page.goto("/auth/forgot-password");
+    await expect(page.getByText("This page could not be found.")).not.toBeVisible();
+    await expect(page.getByRole("button", { name: /send reset code/i })).toBeVisible();
+  });
+});

--- a/e2e/new-listing.spec.ts
+++ b/e2e/new-listing.spec.ts
@@ -140,6 +140,80 @@ test.describe("new listing wizard", () => {
     // ponytail: API save may fail in test env; wizard UX is what's being tested
   });
 
+  test("step rail stays pinned while scrolling", async ({ page }) => {
+    await organiserLogin(page);
+    await page.goto("/organiser/new-listing");
+    await page.waitForLoadState("networkidle");
+
+    await page.mouse.wheel(0, 800);
+    await page.waitForTimeout(400);
+    const scrollY = await page.evaluate(() => window.scrollY);
+    expect(scrollY).toBeGreaterThan(0);
+    // Regression: overflow-x on html/body used to disable position:sticky
+    // site-wide, so the rail scrolled out of view.
+    const rail = await page.locator("div.sticky.top-16").boundingBox();
+    expect(rail).not.toBeNull();
+    expect(rail!.y).toBeGreaterThanOrEqual(0);
+  });
+
+  test("single-day date reads clean after closing the picker", async ({ page }) => {
+    await organiserLogin(page);
+    await page.goto("/organiser/new-listing");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByPlaceholder(/Apex Throwdown/i).fill("Single Day Test");
+    await page.getByRole("button", { name: /continue/i }).click();
+    await expect(page.getByText(/when and where/i).first()).toBeVisible();
+
+    await page.getByText("Pick start date").click();
+    await page.getByRole("button", { name: /today/i }).click();
+    // Close the popover with only a start date picked — a valid single-day event.
+    await page.locator("h1").click();
+    const dateField = page.locator("button", { hasText: /\d{4}/ }).first();
+    await expect(dateField).not.toContainText(/pick end date/i);
+  });
+
+  test("price input strips non-numeric characters", async ({ page }) => {
+    await organiserLogin(page);
+    await page.goto("/organiser/new-listing");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByPlaceholder(/Apex Throwdown/i).fill("Price Test");
+    await page.getByRole("button", { name: /continue/i }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    const price = page.locator('input[placeholder="129"]');
+    await price.fill("abc");
+    await expect(price).toHaveValue("");
+    await price.fill("12.50");
+    await expect(price).toHaveValue("12.50");
+  });
+
+  test("draft without a cut-off time saves without a silent failure", async ({ page }) => {
+    await organiserLogin(page);
+    await page.goto("/organiser/new-listing");
+    await page.waitForLoadState("networkidle");
+
+    // Minimal draft: title only, endTime left empty (it's optional).
+    // Regression: the API used to coerce empty endTime to null, which the
+    // required schema column rejected — every such save 500ed.
+    await page.getByPlaceholder(/Apex Throwdown/i).fill("E2E No Cutoff Draft");
+    await page.getByRole("button", { name: /save draft/i }).click();
+
+    // Success navigates to the dashboard; if the test env lacks an organiser
+    // profile the API errors instead — either way the user must see an
+    // outcome, never stay stuck on a silently-failed save.
+    const errorBanner = page.getByText(/unauthorised|failed to save|went wrong/i).first();
+    await expect
+      .poll(
+        async () =>
+          page.url().includes("/organiser/dashboard") ||
+          (await errorBanner.isVisible().catch(() => false)),
+        { timeout: 20000 },
+      )
+      .toBe(true);
+  });
+
   test("shows validation errors on empty submit", async ({ page }) => {
     await organiserLogin(page);
     await page.goto("/organiser/new-listing");

--- a/lib/athlete-accounts.ts
+++ b/lib/athlete-accounts.ts
@@ -56,7 +56,13 @@ export async function getCognitoUserStatus(email: string): Promise<{ exists: boo
       Username: normalized,
     }));
     return { exists: true, status: result.UserStatus ?? null };
-  } catch {
-    return { exists: false, status: null };
+  } catch (err) {
+    // Only a definitive "no such user" means the account doesn't exist.
+    // Anything else (AccessDenied, throttling, network) must propagate —
+    // otherwise real account holders get told they have no account.
+    if ((err as { name?: string }).name === "UserNotFoundException") {
+      return { exists: false, status: null };
+    }
+    throw err;
   }
 }

--- a/terraform/iam-policies.tf
+++ b/terraform/iam-policies.tf
@@ -56,6 +56,7 @@ resource "aws_iam_policy" "mcp_server" {
           "cognito-idp:CreateUserPoolClient",
           "cognito-idp:UpdateUserPoolClient",
           "cognito-idp:DeleteUserPoolClient",
+          "cognito-idp:AdminGetUser",
           "cognito-idp:AdminCreateUser",
           "cognito-idp:AdminSetUserPassword",
           "cognito-idp:AdminAddUserToGroup",


### PR DESCRIPTION
## Description

Two related batches of platform fixes from a full pass over the email-verification flow and the organiser new-listing wizard.

### Email verification UX

- Overhauled the user and organiser verify-email pages
- Added a dismissible "Email verified — sign in below to continue" banner on the homepage after verification
- `SignInModal` now handles the Cognito-unavailable fallback paths cleanly
- `getCognitoUserStatus` only treats `UserNotFoundException` as "no account" — `AccessDenied`/throttling/network errors now propagate instead of telling real account holders they have no account
- Terraform: granted `cognito-idp:AdminGetUser` to the `mcp_server` IAM policy (fixes the 503 on `/api/user/exists`)
- New `e2e/auth.spec.ts` covering the sign-in/sign-up modal flows

### New-listing wizard fixes

- **Save/publish 500**: an empty (optional) cut-off time was coerced to `null`, which the required `endTime` column rejects — every save or publish without a cut-off time failed. Fixed in both POST and PATCH event routes.
- **Sticky positioning was disabled site-wide**: `overflow-x: hidden` on `html, body` made `body` a scroll container, so every `position: sticky` element (wizard step rail, live-preview sidebar) scrolled out of view. Now `overflow-x: clip`.
- **Silent failures**: failed cover/gallery uploads now abort the save with a visible error instead of silently saving the listing without images; network/non-JSON save failures now surface an error instead of rejecting unhandled.
- **Data loss**: the cancel modal's "Save draft & leave" no longer navigates to the dashboard when the save failed.
- Closed date field no longer reads "→ pick end date" for valid single-day events
- Price input strips non-numeric characters (previously accepted "abc", shown as "From A$abc")
- Address/Suburb autocomplete dropdowns restyled from light theme to the dark design system

## Testing

- `pnpm lint` — 0 errors
- `pnpm test` — 66/66 pass
- Full Playwright run across all 8 suites — passing, plus 4 new regression tests in `e2e/new-listing.spec.ts` (sticky rail, single-day date display, price sanitising, no-cut-off draft save). Known pre-existing flake: `organiserLogin` races under parallel workers; all affected tests pass with `--workers=1`.

## Notes

- Upload and address-autocomplete flows still need manual verification once the remaining IAM permissions (S3 `PutObject`, GeoPlaces) land — the wizard now surfaces those failures instead of hiding them.
- "Organiser Terms" / "Event Listing Policy" in the review step are styled as links but have no destination pages yet — needs content.