### PR TITLE
organiser-first signup flow from organiser portal

### DIFF
--- a/app/(user)/auth/verify-email/page.tsx
+++ b/app/(user)/auth/verify-email/page.tsx
@@ -2,10 +2,17 @@
 
 import VerifyEmailForm from "@/components/VerifyEmailForm";
 
+const redirectPath = () => {
+  try {
+    if (sessionStorage.getItem("startline_intent_organiser")) return "/organiser-setup";
+  } catch {}
+  return "/";
+};
+
 const config = {
   logoHref: "/",
   sessionEndpoint: "/api/user/auth/session",
-  redirectPath: "/",
+  redirectPath: redirectPath(),
   emailPlaceholder: "you@example.com",
   inputIdPrefix: "verify",
   verifiedSubtext: "Taking you to Startline…",
@@ -32,6 +39,7 @@ const applyPendingProfile = async () => {
   } finally {
     sessionStorage.removeItem("startline_pending_name");
     sessionStorage.removeItem("startline_pending_username");
+    sessionStorage.removeItem("startline_intent_organiser");
   }
 };
 

--- a/app/(user)/organiser-setup/page.tsx
+++ b/app/(user)/organiser-setup/page.tsx
@@ -15,6 +15,7 @@ export default function OrganiserSetupPage() {
   const [error, setError] = useState("");
 
   if (status === "unauthenticated") {
+    try { sessionStorage.setItem("startline_intent_organiser", "true"); } catch {}
     return (
       <main className="min-h-screen bg-dark-darker flex items-center justify-center pt-20">
         <div className="text-center max-w-md px-6">
@@ -22,9 +23,12 @@ export default function OrganiserSetupPage() {
           <h1 className="font-headline text-3xl font-black italic tracking-tighter text-light mb-2">
             Sign in to continue
           </h1>
-          <p className="text-muted text-sm mb-6">You need to be signed in to set up an organiser profile.</p>
-          <Link href="/" className="font-headline text-xs font-bold uppercase tracking-widest text-primary hover:underline">
-            Back to home
+          <p className="text-muted text-sm mb-8">You need to be signed in to set up an organiser profile. If you don&apos;t have an account yet, create one first — we&apos;ll guide you back here.</p>
+          <Link
+            href="/?signin=true"
+            className="bg-machined shadow-machined inline-flex items-center gap-2 text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 px-8 rounded-md hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform"
+          >
+            Sign in or create account <ArrowRight className="w-4 h-4" />
           </Link>
         </div>
       </main>

--- a/app/organiser-landing/page.tsx
+++ b/app/organiser-landing/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { Building2, ArrowRight } from "lucide-react";
 
+const CUSTOMER_URL = process.env.NODE_ENV === "development" ? "/" : "https://startlineau.com";
+
 export default function OrganiserLandingPage() {
   return (
     <main className="min-h-screen bg-dark-darker flex items-center justify-center px-6">
@@ -9,16 +11,16 @@ export default function OrganiserLandingPage() {
           <Building2 className="w-8 h-8 text-primary" />
         </div>
         <h1 className="font-headline text-4xl font-black italic tracking-tighter leading-[0.9] text-light mb-4">
-          Organiser<br /><span className="text-primary">Portal</span>
+          Become an<br /><span className="text-primary">Organiser.</span>
         </h1>
         <p className="text-muted text-[15px] leading-relaxed mb-8">
-          Sign in to your user account, then switch to your organiser profile from the dropdown menu.
+          Sign up for a free user account, then set up your organiser profile to start publishing events on Australia&apos;s fitness calendar.
         </p>
         <Link
-          href="https://startlineau.com"
+          href={`${CUSTOMER_URL}organiser-setup`}
           className="bg-machined shadow-machined inline-flex items-center gap-2 text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 px-8 rounded-md hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform"
         >
-          Go to Startline <ArrowRight className="w-4 h-4" />
+          Get started <ArrowRight className="w-4 h-4" />
         </Link>
         <p className="mt-6 font-headline text-[11px] uppercase tracking-widest text-muted">
           Already have an organiser profile?{" "}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -96,6 +96,13 @@ export default function NavBar() {
   const userRef  = useRef<HTMLDivElement>(null);
   const navRef   = useRef<HTMLDivElement>(null);
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("signin") === "true" && status !== "authenticated") {
+      startTransition(() => setIsSignInOpen(true));
+    }
+  }, [status]);
+
   const fetchName = useCallback(async () => {
     if (role === "organiser") {
       try {

--- a/e2e/organiser.spec.ts
+++ b/e2e/organiser.spec.ts
@@ -13,8 +13,8 @@ test.describe("organiser login", () => {
     await page.waitForLoadState("networkidle");
 
     await expect(page.getByRole("heading", { name: /organiser/i })).toBeVisible();
-    await expect(page.getByText(/sign in to your user account/i)).toBeVisible();
-    await expect(page.getByRole("link", { name: /go to startline/i })).toBeVisible();
+    await expect(page.getByText(/sign up for a free user account/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /get started/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /go to dashboard/i })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Makes the organiser portal a viable entry point for new organisers. Users can sign up without leaving the organiser flow — they create a regular user account first, then immediately set up their organiser profile.

## Changes

| File | Change |
|------|--------|
| `app/organiser-landing/page.tsx` | 'Become an Organiser' CTA → `/organiser-setup` |
| `app/(user)/organiser-setup/page.tsx` | Sets `startline_intent_organiser` in sessionStorage; machined-shadow 'Sign in or create account' button |
| `app/(user)/auth/verify-email/page.tsx` | After verification, redirects to `/organiser-setup` instead of `/` when intent flag is set |
| `components/NavBar.tsx` | Opens sign-in modal on `?signin=true` query param |

## User flow

```
organiser.startlineau.com
  → "Become an Organiser" → /organiser-setup
    → "Sign in or create account" → /?signin=true
      → sign up → /auth/verify-email
        → verify → auto-redirect to /organiser-setup
          → enter org name → /organiser/dashboard ✅
```

## Related

Closes #34