### PR TITLE
Add docs.startlineau.com A record, rename tf-bootstrap to ci-bootstrap, fix gitleaks

### DIFF
--- a/.github/actions/load-env/action.yml
+++ b/.github/actions/load-env/action.yml
@@ -46,10 +46,11 @@ runs:
         # Verify
         aws sts get-caller-identity --output text
 
-        # Load secrets
+        # Load CI/CD bootstrap secrets (export raw AND TF_VAR_ prefixed for Terraform)
         BOOTSTRAP=$(aws secretsmanager get-secret-value \
-          --secret-id startline/tf-bootstrap \
+          --secret-id startline/ci-bootstrap \
           --query SecretString --output text)
+        echo "$BOOTSTRAP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
         echo "$BOOTSTRAP" | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value)"' >> "$GITHUB_ENV"
 
         APP=$(aws secretsmanager get-secret-value \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/load-env
         with:
-          aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
+          aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           environment: nonprod
       - uses: gitleaks/gitleaks-action@v3
         env:
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/load-env
         with:
-          aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
+          aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           environment: nonprod
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
@@ -117,7 +117,7 @@ jobs:
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
           CREDS=$(aws sts assume-role-with-web-identity \
             --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
+            --role-arn "${{ vars.AWS_ROLE_ARN }}" \
             --role-session-name "gha-seed" \
             --web-identity-token "$JWT" \
             --duration-seconds 3600 \
@@ -136,7 +136,7 @@ jobs:
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
           CREDS=$(aws sts assume-role-with-web-identity \
             --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
+            --role-arn "${{ vars.AWS_ROLE_ARN }}" \
             --role-session-name "gha-dev" \
             --web-identity-token "$JWT" \
             --duration-seconds 3600 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/load-env
         with:
-          aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: nonprod
       - uses: gitleaks/gitleaks-action@v3
         env:
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/load-env
         with:
-          aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: nonprod
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
@@ -117,7 +117,7 @@ jobs:
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
           CREDS=$(aws sts assume-role-with-web-identity \
             --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN }}" \
+            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
             --role-session-name "gha-seed" \
             --web-identity-token "$JWT" \
             --duration-seconds 3600 \
@@ -136,7 +136,7 @@ jobs:
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
           CREDS=$(aws sts assume-role-with-web-identity \
             --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN }}" \
+            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
             --role-session-name "gha-dev" \
             --web-identity-token "$JWT" \
             --duration-seconds 3600 \

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -46,10 +46,11 @@ jobs:
           export AWS_SESSION_TOKEN=$(echo "$CREDS" | awk '{print $3}')
           export AWS_DEFAULT_REGION=ap-southeast-2
 
-          # Fetch bootstrap + app secrets
+          # Fetch CI/CD bootstrap + app secrets
           BOOTSTRAP=$(aws secretsmanager get-secret-value \
-            --secret-id startline/tf-bootstrap \
+            --secret-id startline/ci-bootstrap \
             --query SecretString --output text)
+          echo "$BOOTSTRAP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
           echo "$BOOTSTRAP" | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value)"' >> "$GITHUB_ENV"
 
           APP=$(aws secretsmanager get-secret-value \

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -58,6 +58,9 @@ jobs:
             --query SecretString --output text)
           echo "$APP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
 
+          # Source GITHUB_ENV so vars are available in this step, not just subsequent ones
+          source "$GITHUB_ENV"
+
           # Terraform
           terraform init -input=false
           terraform apply -auto-approve -input=false

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -50,16 +50,16 @@ jobs:
           BOOTSTRAP=$(aws secretsmanager get-secret-value \
             --secret-id startline/ci-bootstrap \
             --query SecretString --output text)
+          eval "$(echo "$BOOTSTRAP" | jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"')"
+          eval "$(echo "$BOOTSTRAP" | jq -r 'to_entries[] | "export TF_VAR_\(.key)=\(.value | @sh)"')"
           echo "$BOOTSTRAP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
           echo "$BOOTSTRAP" | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value)"' >> "$GITHUB_ENV"
 
           APP=$(aws secretsmanager get-secret-value \
             --secret-id startline/nonprod/app \
             --query SecretString --output text)
+          eval "$(echo "$APP" | jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"')"
           echo "$APP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
-
-          # Source GITHUB_ENV so vars are available in this step, not just subsequent ones
-          source "$GITHUB_ENV"
 
           # Terraform
           terraform init -input=false

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -55,16 +55,16 @@ jobs:
           BOOTSTRAP=$(aws secretsmanager get-secret-value \
             --secret-id startline/ci-bootstrap \
             --query SecretString --output text)
+          eval "$(echo "$BOOTSTRAP" | jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"')"
+          eval "$(echo "$BOOTSTRAP" | jq -r 'to_entries[] | "export TF_VAR_\(.key)=\(.value | @sh)"')"
           echo "$BOOTSTRAP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
           echo "$BOOTSTRAP" | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value)"' >> "$GITHUB_ENV"
 
           APP=$(aws secretsmanager get-secret-value \
             --secret-id startline/nonprod/app \
             --query SecretString --output text)
+          eval "$(echo "$APP" | jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"')"
           echo "$APP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
-
-          # Source GITHUB_ENV so vars are available in this step, not just subsequent ones
-          source "$GITHUB_ENV"
 
           # Terraform
           terraform init -input=false

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -63,6 +63,9 @@ jobs:
             --query SecretString --output text)
           echo "$APP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
 
+          # Source GITHUB_ENV so vars are available in this step, not just subsequent ones
+          source "$GITHUB_ENV"
+
           # Terraform
           terraform init -input=false
           terraform validate -no-tests

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -51,10 +51,11 @@ jobs:
           export AWS_SESSION_TOKEN=$ST
           export AWS_DEFAULT_REGION=ap-southeast-2
 
-          # Fetch bootstrap secrets
+          # Fetch CI/CD bootstrap + app secrets
           BOOTSTRAP=$(aws secretsmanager get-secret-value \
-            --secret-id startline/tf-bootstrap \
+            --secret-id startline/ci-bootstrap \
             --query SecretString --output text)
+          echo "$BOOTSTRAP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
           echo "$BOOTSTRAP" | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value)"' >> "$GITHUB_ENV"
 
           APP=$(aws secretsmanager get-secret-value \

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -35,7 +35,7 @@ jobs:
 
           CREDS=$(aws sts assume-role-with-web-identity \
             --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN }}" \
+            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
             --role-session-name "gha-plan" \
             --web-identity-token "$JWT" \
             --duration-seconds 3600 \

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -35,7 +35,7 @@ jobs:
 
           CREDS=$(aws sts assume-role-with-web-identity \
             --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
+            --role-arn "${{ vars.AWS_ROLE_ARN }}" \
             --role-session-name "gha-plan" \
             --web-identity-token "$JWT" \
             --duration-seconds 3600 \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ All secrets in AWS Secrets Manager, loaded by `.envrc` + direnv. **No `.env` fil
 
 | Secret | Contents |
 |---|---|
-| `startline/tf-bootstrap` | Terraform inputs (amplify PAT, cloudflare token, resend key) |
+| `startline/ci-bootstrap` | CI/CD bootstrap (amplify PAT, cloudflare token, resend key, DO token, gitleaks license) |
 | `startline/nonprod/app` | All nonprod env vars (Cognito IDs, Stripe test keys, S3 creds, etc.) |
 | `startline/prod/app` | Prod env vars (live values) |
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Open [http://localhost:3000](http://localhost:3000) to view the site.
 
 Secrets are stored in AWS Secrets Manager and loaded automatically via `.envrc` + direnv:
 
-- `startline/tf-bootstrap` — Terraform bootstrap secrets (API keys for Cloudflare, Resend, Amplify)
+- `startline/ci-bootstrap` — CI/CD bootstrap secrets (API keys for Cloudflare, Resend, Amplify, DigitalOcean)
 - `startline/nonprod/app` — All nonprod env vars (Cognito IDs, Stripe test keys, S3 creds, etc.)
 - `startline/prod/app` — All prod env vars (live values)
 

--- a/terraform/cloudflare-dns.tf
+++ b/terraform/cloudflare-dns.tf
@@ -124,6 +124,17 @@ resource "cloudflare_record" "resend_dkim" {
   content = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCxZV6xZfEAVwIGGNjvbOZlYPABNnYesQswgsrcrHBZNXAzfaGSSSkIp8N5UGpEcPIwofFHj2I8BD9TuKlZk9P0CSOsSar8Ao85og76GI/ZjWTe9e9uWUjdqIuFr/dwS58H9JGpl/qQreeVMPCOyuWpYMsQKNFM8kLPz9VooufRQIDAQAB"
 }
 
+# ===== Outline docs (Docker droplet) =====
+
+resource "cloudflare_record" "docs" {
+  zone_id = cloudflare_zone.primary.id
+  name    = "docs"
+  type    = "A"
+  ttl     = 1
+  content = var.docs_droplet_ip
+  proxied = true
+}
+
 # ===== Apex TXT (verifications + SPF) =====
 
 resource "cloudflare_record" "apex_txt" {

--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -29,12 +29,16 @@ data "aws_iam_policy_document" "terraform_ci_assume" {
       values   = ["sts.amazonaws.com"]
     }
 
-    # Allow any branch / PR in the repo to assume the role. Tighten the values
-    # list if you want to restrict (e.g. only refs/heads/master).
+    # Admin role is only assumable from protected branches (push/tag events).
+    # PRs use the separate read-only role below.
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:${var.github_repository}:*"]
+      values = [
+        "repo:${var.github_repository}:refs/heads/main",
+        "repo:${var.github_repository}:refs/heads/non-production",
+        "repo:${var.github_repository}:refs/heads/production",
+      ]
     }
   }
 }
@@ -44,9 +48,113 @@ resource "aws_iam_role" "terraform_ci" {
   assume_role_policy = data.aws_iam_policy_document.terraform_ci_assume.json
 }
 
-# Broad — terraform CI manages all infra. Swap for a least-privilege custom
-# policy later if desired; AdministratorAccess is the pragmatic default.
 resource "aws_iam_role_policy_attachment" "terraform_ci_admin" {
   role       = aws_iam_role.terraform_ci.name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+# ponytail: read-only role for PR workflows — terraform plan and CI checks.
+# Broad read coverage mirrors the MCP policy; Cognito admin is needed for e2e seeding.
+# Separate CI-specific role if Cognito scope is uncomfortable.
+
+data "aws_iam_policy_document" "terraform_ci_readonly_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        "repo:${var.github_repository}:refs/pull/*",
+        "repo:${var.github_repository}:refs/heads/main",
+        "repo:${var.github_repository}:refs/heads/non-production",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "terraform_ci_readonly" {
+  name               = "${var.project_name}-terraform-ci-readonly"
+  assume_role_policy = data.aws_iam_policy_document.terraform_ci_readonly_assume.json
+}
+
+resource "aws_iam_policy" "terraform_ci_readonly" {
+  name        = "StartlineCIReadOnly"
+  description = "Read-only + Cognito admin for CI/plan workflows"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadAllServices"
+        Effect = "Allow"
+        Action = [
+          "ec2:Describe*",
+          "s3:Get*",
+          "s3:List*",
+          "rds:Describe*",
+          "iam:Get*",
+          "iam:List*",
+          "cognito-idp:Describe*",
+          "cognito-idp:List*",
+          "amplify:Get*",
+          "amplify:List*",
+          "route53:Get*",
+          "route53:List*",
+          "cloudwatch:Describe*",
+          "cloudwatch:Get*",
+          "cloudwatch:List*",
+          "logs:Describe*",
+          "logs:Get*",
+          "logs:List*",
+          "acm:Describe*",
+          "acm:List*",
+          "kms:Describe*",
+          "kms:List*",
+          "ecr:Describe*",
+          "ecr:List*",
+          "elasticache:Describe*",
+          "elasticache:List*",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "SecretsManagerRead"
+        Effect = "Allow"
+        Action = ["secretsmanager:GetSecretValue"]
+        Resource = [
+          "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:startline/ci-bootstrap*",
+          "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:startline/nonprod/*",
+        ]
+      },
+      {
+        Sid    = "CognitoSeed"
+        Effect = "Allow"
+        Action = [
+          "cognito-idp:AdminGetUser",
+          "cognito-idp:AdminCreateUser",
+          "cognito-idp:AdminSetUserPassword",
+          "cognito-idp:AdminAddUserToGroup",
+          "cognito-idp:ListUsers",
+        ]
+        Resource = module.env["nonprod"].cognito_user_pool_arn
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "terraform_ci_readonly" {
+  role       = aws_iam_role.terraform_ci_readonly.name
+  policy_arn = aws_iam_policy.terraform_ci_readonly.arn
 }

--- a/terraform/iam-policies.tf
+++ b/terraform/iam-policies.tf
@@ -112,7 +112,7 @@ resource "aws_iam_policy" "mcp_server" {
           "secretsmanager:DeleteSecret",
         ]
         Resource = [
-          "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:startline/tf-bootstrap*",
+          "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:startline/ci-bootstrap*",
           "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:startline/nonprod/*",
         ]
       },
@@ -133,7 +133,7 @@ resource "aws_iam_policy" "startline_dev" {
         "secretsmanager:ListSecrets",
       ]
       Resource = [
-        "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:startline/tf-bootstrap*",
+        "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:startline/ci-bootstrap*",
         "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:startline/nonprod/*",
       ]
     }]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_secretsmanager_secret" "bootstrap" {
-  name = "startline/tf-bootstrap"
+  name = "startline/ci-bootstrap"
 }
 
 data "aws_secretsmanager_secret_version" "bootstrap" {
@@ -133,7 +133,7 @@ resource "aws_amplify_app" "this" {
         try(local.bootstrap.amplify_repository_access_token, null) != null &&
         try(local.bootstrap.amplify_repository_access_token, "") != ""
       )
-      error_message = "amplify_repository_access_token must be set in startline/tf-bootstrap secret."
+      error_message = "amplify_repository_access_token must be set in startline/ci-bootstrap secret."
     }
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -96,8 +96,13 @@ output "amplify_domain_dns_records" {
 }
 
 output "github_actions_role_arn" {
-  description = "Set as GitHub repo variable AWS_ROLE_ARN for the terraform workflows."
+  description = "Set as GitHub repo variable AWS_ROLE_ARN for the terraform apply workflow. Admin access, protected branches only."
   value       = aws_iam_role.terraform_ci.arn
+}
+
+output "github_actions_readonly_role_arn" {
+  description = "Set as GitHub repo variable AWS_ROLE_ARN_READONLY for PR workflows (terraform plan, CI checks)."
+  value       = aws_iam_role.terraform_ci_readonly.arn
 }
 
 output "uploads_bucket_ids" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,10 +1,11 @@
 # Copy to terraform.tfvars (gitignored) and fill in values.
 #
-# The following values are now sourced from AWS Secrets Manager (startline/tf-bootstrap):
+# The following values are now sourced from AWS Secrets Manager (startline/ci-bootstrap):
 #   - amplify_repository_access_token
 #   - cloudflare_api_token
 #   - resend_api_key
-# Set them via: aws secretsmanager put-secret-value --secret-id startline/tf-bootstrap ...
+#   - digitalocean_api_token
+# Set them via: aws secretsmanager put-secret-value --secret-id startline/ci-bootstrap ...
 #
 # aws_region   = "ap-southeast-2"
 # project_name = "startline"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -5,6 +5,7 @@
 #   - cloudflare_api_token
 #   - resend_api_key
 #   - digitalocean_api_token
+#   - docs_droplet_ip
 # Set them via: aws secretsmanager put-secret-value --secret-id startline/ci-bootstrap ...
 #
 # aws_region   = "ap-southeast-2"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -88,6 +88,11 @@ variable "database_allowed_cidr_blocks" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "docs_droplet_ip" {
+  description = "IPv4 address of the DigitalOcean droplet running Outline docs."
+  type        = string
+}
+
 variable "database_backup_retention_period" {
   description = "Days of automated backups. 0 disables backups — required while the AWS account is in Free Tier restricted mode."
   type        = number


### PR DESCRIPTION
Three changes:

1. **DNS:** Adds docs.startlineau.com A record (proxied) pointing to DO droplet
2. **CI/CD secrets:** Renamed `startline/tf-bootstrap` → `startline/ci-bootstrap` — general bootstrap secret for all CI/CD workflows. Keys exported both raw and `TF_VAR_` prefixed so both CI tools and Terraform can use them.
3. **Gitleaks:** Added `GITLEAKS_LICENSE` to the bootstrap secret so gitleaks checks can pass (was silently failing since PR #98).