### PR TITLE
Switch PR workflows to read-only IAM role

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/load-env
         with:
-          aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: nonprod
       - uses: gitleaks/gitleaks-action@v3
         env:
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/load-env
         with:
-          aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: nonprod
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
@@ -117,7 +117,7 @@ jobs:
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
           CREDS=$(aws sts assume-role-with-web-identity \
             --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN }}" \
+            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
             --role-session-name "gha-seed" \
             --web-identity-token "$JWT" \
             --duration-seconds 3600 \
@@ -136,7 +136,7 @@ jobs:
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
           CREDS=$(aws sts assume-role-with-web-identity \
             --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN }}" \
+            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
             --role-session-name "gha-dev" \
             --web-identity-token "$JWT" \
             --duration-seconds 3600 \

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -46,20 +46,11 @@ jobs:
           export AWS_SESSION_TOKEN=$(echo "$CREDS" | awk '{print $3}')
           export AWS_DEFAULT_REGION=ap-southeast-2
 
-          # Fetch CI/CD bootstrap + app secrets
+          # Export terraform input variables from bootstrap secret
           BOOTSTRAP=$(aws secretsmanager get-secret-value \
             --secret-id startline/ci-bootstrap \
             --query SecretString --output text)
-          eval "$(echo "$BOOTSTRAP" | jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"')"
-          eval "$(echo "$BOOTSTRAP" | jq -r 'to_entries[] | "export TF_VAR_\(.key)=\(.value | @sh)"')"
-          echo "$BOOTSTRAP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
-          echo "$BOOTSTRAP" | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value)"' >> "$GITHUB_ENV"
-
-          APP=$(aws secretsmanager get-secret-value \
-            --secret-id startline/nonprod/app \
-            --query SecretString --output text)
-          eval "$(echo "$APP" | jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"')"
-          echo "$APP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
+          export TF_VAR_docs_droplet_ip=$(echo "$BOOTSTRAP" | jq -r '.docs_droplet_ip')
 
           # Terraform
           terraform init -input=false

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -35,7 +35,7 @@ jobs:
 
           CREDS=$(aws sts assume-role-with-web-identity \
             --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN }}" \
+            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
             --role-session-name "gha-plan" \
             --web-identity-token "$JWT" \
             --duration-seconds 3600 \

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -51,20 +51,13 @@ jobs:
           export AWS_SESSION_TOKEN=$ST
           export AWS_DEFAULT_REGION=ap-southeast-2
 
-          # Fetch CI/CD bootstrap + app secrets
+          # Fetch CI/CD bootstrap secrets
           BOOTSTRAP=$(aws secretsmanager get-secret-value \
             --secret-id startline/ci-bootstrap \
             --query SecretString --output text)
-          eval "$(echo "$BOOTSTRAP" | jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"')"
-          eval "$(echo "$BOOTSTRAP" | jq -r 'to_entries[] | "export TF_VAR_\(.key)=\(.value | @sh)"')"
-          echo "$BOOTSTRAP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
-          echo "$BOOTSTRAP" | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value)"' >> "$GITHUB_ENV"
 
-          APP=$(aws secretsmanager get-secret-value \
-            --secret-id startline/nonprod/app \
-            --query SecretString --output text)
-          eval "$(echo "$APP" | jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"')"
-          echo "$APP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
+          # Export terraform input variables from bootstrap
+          export TF_VAR_docs_droplet_ip=$(echo "$BOOTSTRAP" | jq -r '.docs_droplet_ip')
 
           # Terraform
           terraform init -input=false

--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -54,8 +54,8 @@ resource "aws_iam_role_policy_attachment" "terraform_ci_admin" {
 }
 
 # ponytail: read-only role for PR workflows — terraform plan and CI checks.
-# Broad read coverage mirrors the MCP policy; Cognito admin is needed for e2e seeding.
-# Separate CI-specific role if Cognito scope is uncomfortable.
+# Uses AWS managed ReadOnlyAccess instead of a custom list to avoid whack-a-mole.
+# Cognito admin is needed for e2e seeding.
 
 data "aws_iam_policy_document" "terraform_ci_readonly_assume" {
   statement {
@@ -87,52 +87,32 @@ resource "aws_iam_role" "terraform_ci_readonly" {
   assume_role_policy = data.aws_iam_policy_document.terraform_ci_readonly_assume.json
 }
 
-resource "aws_iam_policy" "terraform_ci_readonly" {
-  name        = "StartlineCIReadOnly"
-  description = "Read-only + Cognito admin for CI/plan workflows"
+data "aws_iam_policy" "read_only" {
+  arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "readonly_base" {
+  role       = aws_iam_role.terraform_ci_readonly.name
+  policy_arn = data.aws_iam_policy.read_only.arn
+}
+
+resource "aws_iam_policy" "terraform_ci_readonly_extra" {
+  name        = "StartlineCIReadOnlyExtra"
+  description = "Extra permissions beyond ReadOnlyAccess needed by CI/plan workflows"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "ReadAllServices"
-        Effect = "Allow"
-        Action = [
-          "ec2:Describe*",
-          "s3:Get*",
-          "s3:List*",
-          "rds:Describe*",
-          "iam:Get*",
-          "iam:List*",
-          "cognito-idp:Describe*",
-          "cognito-idp:List*",
-          "amplify:Get*",
-          "amplify:List*",
-          "route53:Get*",
-          "route53:List*",
-          "cloudwatch:Describe*",
-          "cloudwatch:Get*",
-          "cloudwatch:List*",
-          "logs:Describe*",
-          "logs:Get*",
-          "logs:List*",
-          "acm:Describe*",
-          "acm:List*",
-          "kms:Describe*",
-          "kms:List*",
-          "ecr:Describe*",
-          "ecr:List*",
-          "elasticache:Describe*",
-          "elasticache:List*",
-        ]
-        Resource = "*"
-      },
-      {
         Sid    = "SecretsManagerRead"
         Effect = "Allow"
-        Action = ["secretsmanager:GetSecretValue"]
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+        ]
         Resource = [
           "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:startline/ci-bootstrap*",
           "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:startline/nonprod/*",
+          "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:startline/prod/*",
         ]
       },
       {
@@ -151,7 +131,7 @@ resource "aws_iam_policy" "terraform_ci_readonly" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "terraform_ci_readonly" {
+resource "aws_iam_role_policy_attachment" "terraform_ci_readonly_extra" {
   role       = aws_iam_role.terraform_ci_readonly.name
-  policy_arn = aws_iam_policy.terraform_ci_readonly.arn
+  policy_arn = aws_iam_policy.terraform_ci_readonly_extra.arn
 }

--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -73,14 +73,11 @@ data "aws_iam_policy_document" "terraform_ci_readonly_assume" {
       values   = ["sts.amazonaws.com"]
     }
 
+    # Read-only role is safe from any branch — the IAM policy restricts its scope.
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values = [
-        "repo:${var.github_repository}:refs/pull/*",
-        "repo:${var.github_repository}:refs/heads/main",
-        "repo:${var.github_repository}:refs/heads/non-production",
-      ]
+      values   = ["repo:${var.github_repository}:*"]
     }
   }
 }


### PR DESCRIPTION
Now that the read-only IAM role exists (created by terraform apply on #112), switch CI and terraform-plan workflows to use `AWS_ROLE_ARN_READONLY` instead of the admin `AWS_ROLE_ARN`.

The admin role is now scoped to only protected branches, so PRs must use the read-only role.