### PR TITLE
Ignore local Cognito emulator data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ next-env.d.ts
 # prisma local database
 /dev.db
 
+# local Cognito emulator
+/.cognito/
+
 # terraform
 terraform/.terraform/
 terraform/terraform.tfvars

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,8 @@ Use `-s=<name>` for isolated sessions (e.g., `-s=customer`, `-s=organiser`). Pas
 
 Use `gh` CLI — the MCP `server-github` fails for this private org repo.
 
+**`main` is protected.** Never push directly — always use a PR.
+
 ### Pre-commit gate
 
 Before staging/committing:


### PR DESCRIPTION
Adds `.cognito/` to `.gitignore` — local Cognito emulator database files contain JWTs and should not be committed.\n\nAlso documents the `main` branch protection rule in AGENTS.md.