### PR TITLE
Add Argos baseline workflow for post-merge E2E screenshots

### DIFF
--- a/.github/workflows/argos-baseline.yml
+++ b/.github/workflows/argos-baseline.yml
@@ -1,0 +1,82 @@
+name: Argos Baseline
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  baseline:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: startline
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/load-env
+        with:
+          aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
+          environment: nonprod
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile || pnpm approve-builds --all
+      - run: pnpm install --frozen-lockfile
+      - run: npx playwright install chromium
+      - run: npx prisma generate
+      - run: npx prisma migrate deploy
+      - name: Seed database with AWS credentials
+        shell: bash
+        run: |
+          JWT=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
+          CREDS=$(aws sts assume-role-with-web-identity \
+            --region ap-southeast-2 \
+            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
+            --role-session-name "gha-seed" \
+            --web-identity-token "$JWT" \
+            --duration-seconds 3600 \
+            --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+            --output text)
+          export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | awk '{print $1}')
+          export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | awk '{print $2}')
+          export AWS_SESSION_TOKEN=$(echo "$CREDS" | awk '{print $3}')
+          export AWS_DEFAULT_REGION=ap-southeast-2
+          npx prisma db seed
+      - name: Start Next.js dev server
+        shell: bash
+        run: |
+          JWT=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
+          CREDS=$(aws sts assume-role-with-web-identity \
+            --region ap-southeast-2 \
+            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
+            --role-session-name "gha-dev" \
+            --web-identity-token "$JWT" \
+            --duration-seconds 3600 \
+            --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+            --output text)
+          export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | awk '{print $1}')
+          export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | awk '{print $2}')
+          export AWS_SESSION_TOKEN=$(echo "$CREDS" | awk '{print $3}')
+          export AWS_DEFAULT_REGION=ap-southeast-2
+          pnpm dev -p 3000 &
+          npx wait-on http://localhost:3000/admin/login --timeout 60000
+      - run: pnpm test:e2e


### PR DESCRIPTION
Establishes Argos visual regression baselines on `main` by running E2E tests after each PR merge. Without this, Argos has no baseline to compare PR screenshots against.

- Triggers on `push` to `main`
- Runs the same E2E suite as the PR CI
- Argos Playwright reporter uploads screenshots → becomes the baseline
- Fails silently (`continue-on-error: true`)
- `ARGOS_TOKEN` loaded from `startline/ci-bootstrap` via existing `load-env` action