### PR TITLE
fix: OIDC auth, remove redundant re-auth, resolve App ID at runtime

### DIFF
--- a/.github/workflows/argos-baseline.yml
+++ b/.github/workflows/argos-baseline.yml
@@ -42,41 +42,12 @@ jobs:
       - run: npx playwright install chromium
       - run: npx prisma generate
       - run: npx prisma migrate deploy
-      - name: Seed database with AWS credentials
+      - name: Seed database
         shell: bash
-        run: |
-          JWT=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
-          CREDS=$(aws sts assume-role-with-web-identity \
-            --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
-            --role-session-name "gha-seed" \
-            --web-identity-token "$JWT" \
-            --duration-seconds 3600 \
-            --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-            --output text)
-          export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | awk '{print $1}')
-          export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | awk '{print $2}')
-          export AWS_SESSION_TOKEN=$(echo "$CREDS" | awk '{print $3}')
-          export AWS_DEFAULT_REGION=ap-southeast-2
-          npx prisma db seed
+        run: npx prisma db seed
       - name: Start Next.js dev server
         shell: bash
         run: |
-          JWT=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
-          CREDS=$(aws sts assume-role-with-web-identity \
-            --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
-            --role-session-name "gha-dev" \
-            --web-identity-token "$JWT" \
-            --duration-seconds 3600 \
-            --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-            --output text)
-          export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | awk '{print $1}')
-          export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | awk '{print $2}')
-          export AWS_SESSION_TOKEN=$(echo "$CREDS" | awk '{print $3}')
-          export AWS_DEFAULT_REGION=ap-southeast-2
           pnpm dev -p 3000 &
           npx wait-on http://localhost:3000/admin/login --timeout 60000
       - run: pnpm test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,43 +118,12 @@ jobs:
       - run: npx playwright install chromium
       - run: npx prisma generate
       - run: npx prisma migrate deploy
-      - name: Seed database with AWS credentials
+      - name: Seed database
         shell: bash
-        run: |
-          # Get fresh AWS credentials via OIDC
-          JWT=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
-          CREDS=$(aws sts assume-role-with-web-identity \
-            --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
-            --role-session-name "gha-seed" \
-            --web-identity-token "$JWT" \
-            --duration-seconds 3600 \
-            --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-            --output text)
-          export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | awk '{print $1}')
-          export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | awk '{print $2}')
-          export AWS_SESSION_TOKEN=$(echo "$CREDS" | awk '{print $3}')
-          export AWS_DEFAULT_REGION=ap-southeast-2
-          npx prisma db seed
+        run: npx prisma db seed
       - name: Start Next.js dev server
         shell: bash
         run: |
-          # Get fresh AWS credentials via OIDC for the app server
-          JWT=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
-          CREDS=$(aws sts assume-role-with-web-identity \
-            --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN_READONLY }}" \
-            --role-session-name "gha-dev" \
-            --web-identity-token "$JWT" \
-            --duration-seconds 3600 \
-            --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-            --output text)
-          export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | awk '{print $1}')
-          export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | awk '{print $2}')
-          export AWS_SESSION_TOKEN=$(echo "$CREDS" | awk '{print $3}')
-          export AWS_DEFAULT_REGION=ap-southeast-2
           pnpm dev -p 3000 &
           npx wait-on http://localhost:3000/admin/login --timeout 60000
       - run: pnpm test:e2e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,13 @@ jobs:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           environment: ${{ github.ref_name == 'production' && 'prod' || 'nonprod' }}
 
+      - name: Resolve Amplify app ID
+        id: amplify-app
+        shell: bash
+        run: |
+          APP_ID=$(aws amplify list-apps --query "apps[?name=='startline'].appId" --output text)
+          echo "app_id=$APP_ID" >> "$GITHUB_OUTPUT"
+
       - name: Start deployment
         id: deployment
         uses: actions/github-script@v9
@@ -56,7 +63,7 @@ jobs:
         shell: bash
         run: |
           JOB_ID=$(aws amplify start-job \
-            --app-id ${{ vars.AMPLIFY_APP_ID }} \
+            --app-id ${{ steps.amplify-app.outputs.app_id }} \
             --branch-name ${{ github.ref_name }} \
             --job-type RELEASE \
             --commit-id ${{ github.sha }} \
@@ -67,7 +74,7 @@ jobs:
           echo "Polling Amplify build $JOB_ID on ${{ github.ref_name }}..."
           for i in $(seq 1 60); do
             STATUS=$(aws amplify get-job \
-              --app-id ${{ vars.AMPLIFY_APP_ID }} \
+              --app-id ${{ steps.amplify-app.outputs.app_id }} \
               --branch-name ${{ github.ref_name }} \
               --job-id "$JOB_ID" \
               --query 'job.summary.status' --output text)

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -21,39 +21,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: ./.github/actions/load-env
+        with:
+          aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
+          environment: nonprod
+
+      - name: Install Terraform
+        shell: bash
+        run: |
+          curl -sLo /tmp/terraform.zip https://releases.hashicorp.com/terraform/1.10.0/terraform_1.10.0_linux_amd64.zip
+          unzip -qo /tmp/terraform.zip -d /usr/local/bin
+
       - name: Terraform apply
         shell: bash
         run: |
-          # Install terraform
-          curl -sLo terraform.zip https://releases.hashicorp.com/terraform/1.10.0/terraform_1.10.0_linux_amd64.zip
-          unzip -q terraform.zip -d /tmp/terraform-bin
-          export PATH="/tmp/terraform-bin:$PATH"
-
-          # Auth via OIDC
-          JWT=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
-
-          CREDS=$(aws sts assume-role-with-web-identity \
-            --region ap-southeast-2 \
-            --role-arn "${{ vars.AWS_ROLE_ARN }}" \
-            --role-session-name "gha-apply" \
-            --web-identity-token "$JWT" \
-            --duration-seconds 3600 \
-            --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-            --output text)
-
-          export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | awk '{print $1}')
-          export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | awk '{print $2}')
-          export AWS_SESSION_TOKEN=$(echo "$CREDS" | awk '{print $3}')
-          export AWS_DEFAULT_REGION=ap-southeast-2
-
-          # Export terraform input variables from bootstrap secret
-          BOOTSTRAP=$(aws secretsmanager get-secret-value \
-            --secret-id startline/ci-bootstrap \
-            --query SecretString --output text)
-          export TF_VAR_docs_droplet_ip=$(echo "$BOOTSTRAP" | jq -r '.docs_droplet_ip')
-
-          # Terraform
           terraform init -input=false
           terraform apply -auto-approve -input=false
 


### PR DESCRIPTION
Three changes consolidated from follow-up to #125/#126:

**Terraform apply — swap to load-env (fixes OIDC AccessDenied)**
Inline `AssumeRoleWithWebIdentity` was failing on `main`. Switched to the `load-env` composite action — same proven auth flow used by CI, plan, and deploy workflows.

**Deploy workflow — resolve Amplify app ID at runtime**
Removed `AMPLIFY_APP_ID` GitHub repo variable. The deploy workflow now queries `aws amplify list-apps` directly — no drift from Terraform, no manual setup step.

**CI + Argos — remove redundant inline OIDC re-auth**
Both `ci.yml` and `argos-baseline.yml` were re-assuming the read-only role in the seed and dev-server steps even though `load-env` already exports credentials to `GITHUB_ENV`. 64 lines deleted, zero behavior change.

Files:
- `.github/workflows/terraform-apply.yml` — use load-env, 30 lines removed
- `.github/workflows/deploy.yml` — resolve app ID from API
- `.github/workflows/argos-baseline.yml` — remove inline re-auth
- `.github/workflows/ci.yml` — remove inline re-auth
