### PR TITLE
chore: add workflow_dispatch + load-env trigger to terraform-apply and deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - non-production

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,11 +1,13 @@
 name: Terraform apply
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform-*.yml'
+      - '.github/actions/load-env/**'
 
 permissions:
   id-token: write


### PR DESCRIPTION
Minimal change — adds manual trigger capability and ensures load-env changes correctly trigger the terraform-apply workflow.

- `workflow_dispatch` on both `terraform-apply.yml` and `deploy.yml` for manual ops runs
- `.github/actions/load-env/**` path added to terraform-apply trigger (changes to the auth action were silently breaking the workflow)