### PR TITLE
chore: bump configure-aws-credentials to v6 (Node 24)

### DIFF
--- a/.github/actions/load-env/action.yml
+++ b/.github/actions/load-env/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: aws-actions/configure-aws-credentials@v4
+    - uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ap-southeast-2


### PR DESCRIPTION
Bump `aws-actions/configure-aws-credentials` from `@v4` (Node 20, deprecated) to `@v6` (Node 24). Drop-in replacement for our usage — eliminates the CI warning.