### PR TITLE
chore: remove TF deploy tracking, rename envs to prod/nonprod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_name == 'production' && 'production' || 'non-production' }}
+    environment: ${{ github.ref_name == 'production' && 'prod' || 'nonprod' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -40,7 +40,7 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const env = '${{ github.ref_name == 'production' && 'production' || 'non-production' }}'
+            const env = '${{ github.ref_name == 'production' && 'prod' || 'nonprod' }}'
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -49,7 +49,7 @@ jobs:
               description: context.payload.head_commit?.message || '',
               auto_merge: false,
               required_contexts: [],
-              transient_environment: env !== 'production',
+              transient_environment: env !== 'prod',
             })
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -12,7 +12,6 @@ on:
 permissions:
   id-token: write
   contents: read
-  deployments: write
 
 jobs:
   apply:
@@ -40,39 +39,3 @@ jobs:
           terraform init -input=false
           terraform apply -auto-approve -input=false
 
-      - name: Start deployment
-        id: tf-deployment
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const deployment = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.sha,
-              environment: 'non-production',
-              description: 'Terraform apply (${{ github.sha }})',
-              auto_merge: false,
-              required_contexts: [],
-            })
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: deployment.data.id,
-              state: 'in_progress',
-            })
-            core.setOutput('deployment_id', deployment.data.id)
-            core.setOutput('env', deployment.data.environment)
-
-      - name: Finish deployment
-        if: always() && steps.tf-deployment.outputs.deployment_id != ''
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const state = '${{ job.status }}' === 'success' ? 'success' : 'failure'
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: parseInt('${{ steps.tf-deployment.outputs.deployment_id }}'),
-              state: state,
-              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-            })


### PR DESCRIPTION
Two changes:

1. **terraform-apply.yml**: Remove deployment tracking. TF apply manages infrastructure for all environments — mapping it to a single environment (non-production) was misleading. Infra changes have CI status checks for visibility.

2. **deploy.yml**: Rename GitHub Environments from `production`/ `non-production` to `prod`/ `nonprod`. GitHub UI auto-cases `production` to "Production" but the hyphen in `non-production` prevents auto-casing, causing inconsistent display. `prod`/ `nonprod` displays consistently as "Prod"/"Nonprod".

GitHub Environments already updated in the repo:
- `prod` (branch policy: `production` branch)
- `nonprod` (branch policy: `non-production` branch)
- Old `production`/ `non-production` environments deleted