### PR TITLE
Rename deploy branches: production → prod, non-production → nonprod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - non-production
-      - production
+      - nonprod
+      - prod
 
 concurrency:
   group: ${{ github.ref_name }}
@@ -19,14 +19,14 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_name == 'production' && 'prod' || 'nonprod' }}
+    environment: ${{ github.ref_name == 'prod' && 'prod' || 'nonprod' }}
     steps:
       - uses: actions/checkout@v5
 
       - uses: ./.github/actions/load-env
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
-          environment: ${{ github.ref_name == 'production' && 'prod' || 'nonprod' }}
+          environment: ${{ github.ref_name == 'prod' && 'prod' || 'nonprod' }}
 
       - name: Resolve Amplify app ID
         id: amplify-app
@@ -40,7 +40,7 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const env = '${{ github.ref_name == 'production' && 'prod' || 'nonprod' }}'
+            const env = '${{ github.ref_name == 'prod' && 'prod' || 'nonprod' }}'
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -97,7 +97,7 @@ jobs:
         with:
           script: |
             const state = '${{ job.status }}' === 'success' ? 'success' : 'failure'
-            const envUrl = '${{ github.ref_name == 'production' && 'https://startlineau.com' || 'https://nonprod.startlineau.com' }}'
+            const envUrl = '${{ github.ref_name == 'prod' && 'https://startlineau.com' || 'https://nonprod.startlineau.com' }}'
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ All worktrees under `~/.herdr/worktrees/startline/`. Docker infra (PostgreSQL, M
 
 Infra in `terraform/`:
 - `terraform-plan.yml` on PR, `terraform-apply.yml` on push to main
-- App deploys via Amplify on branch push: `non-production` → staging, `production` → live
+- App deploys via Amplify on branch push: `nonprod` → nonprod, `prod` → live
 - No app code CI (no lint/test/build checks)
 
 Terraform reads bootstrap secrets from SM via `data "aws_secretsmanager_secret" "bootstrap"`. No `TF_VAR_*` needed.

--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -36,8 +36,8 @@ data "aws_iam_policy_document" "terraform_ci_assume" {
       variable = "token.actions.githubusercontent.com:sub"
       values = [
         "repo:${var.github_repository}:*:refs/heads/main",
-        "repo:${var.github_repository}:*:refs/heads/non-production",
-        "repo:${var.github_repository}:*:refs/heads/production",
+        "repo:${var.github_repository}:*:refs/heads/nonprod",
+        "repo:${var.github_repository}:*:refs/heads/prod",
       ]
     }
   }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,7 +64,7 @@ locals {
             - corepack enable && pnpm install --frozen-lockfile
             - >
               SECRET="startline/nonprod/app"
-              && [ "$AWS_BRANCH" = "production" ] && SECRET="startline/prod/app"
+              && [ "$AWS_BRANCH" = "prod" ] && SECRET="startline/prod/app"
               && aws secretsmanager get-secret-value
               --secret-id "$SECRET"
               --query SecretString --output text
@@ -86,7 +86,7 @@ locals {
   # captures only the things that diverge between prod and nonprod.
   environments = {
     prod = {
-      branch_name                  = "production"
+      branch_name                  = "prod"
       amplify_stage                = "PRODUCTION"
       auto_build_enabled           = false
       vpc_cidr                     = "10.20.0.0/16"
@@ -98,7 +98,7 @@ locals {
       site_url                     = "https://startlineau.com"
     }
     nonprod = {
-      branch_name                  = "non-production"
+      branch_name                  = "nonprod"
       amplify_stage                = "DEVELOPMENT"
       auto_build_enabled           = false
       vpc_cidr                     = "10.21.0.0/16"

--- a/terraform/modules/environment/variables.tf
+++ b/terraform/modules/environment/variables.tf
@@ -14,7 +14,7 @@ variable "amplify_app_id" {
 }
 
 variable "branch_name" {
-  description = "Git branch deployed to this environment (e.g. production, non-production)."
+  description = "Git branch deployed to this environment (e.g. prod, nonprod)."
   type        = string
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -18,8 +18,8 @@ output "amplify_production_branch" {
   value       = module.env["prod"].branch_name
 }
 
-output "amplify_non_production_branch" {
-  description = "Non-production branch name in Amplify."
+output "amplify_nonprod_branch" {
+  description = "Nonprod branch name in Amplify."
   value       = module.env["nonprod"].branch_name
 }
 


### PR DESCRIPTION
## Summary
Rename git/Amplify branches to match the Terraform environment keys for consistent naming.

## Changes

- `production` branch → `prod`
- `non-production` branch → `nonprod`

### Files changed (6 files, 15 edits)

| File | Change |
|---|---|
| `terraform/main.tf` | Amplify `branch_name` values + build spec $AWS_BRANCH check |
| `terraform/github_oidc.tf` | OIDC trust branch refs |
| `.github/workflows/deploy.yml` | Trigger branches + all `== 'production'` checks |
| `terraform/outputs.tf` | Rename output `amplify_nonprod_branch` |
| `terraform/modules/environment/variables.tf` | Description text |
| `AGENTS.md` | Docs |

### Before merge (manual)

- [x] Branch protection rules set up in GitHub UI for `prod` and `nonprod`
- [x] `prod` and `nonprod` branches pushed to GitHub

### After merge (terraform apply)

- Creates new Amplify branches `prod`/`nonprod`
- Destroys old `production`/`non-production` Amplify branches
- Updates OIDC trust

### Cleanup (after apply)

- [ ] Delete old `production` and `non-production` git branches
- [ ] Delete old branch protection rules