### PR TITLE
Dev auth bypass + drop nonprod Amplify branch + PR previews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - nonprod
       - prod
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ All worktrees under `~/.herdr/worktrees/startline/`. Docker infra (PostgreSQL, M
 
 Infra in `terraform/`:
 - `terraform-plan.yml` on PR, `terraform-apply.yml` on push to main
-- App deploys via Amplify on branch push: `nonprod` → nonprod, `prod` → live
+- App deploys via Amplify on branch push: `prod` → live. PR previews deploy automatically to temp URLs against the nonprod backend.
 - No app code CI (no lint/test/build checks)
 
 Terraform reads bootstrap secrets from SM via `data "aws_secretsmanager_secret" "bootstrap"`. No `TF_VAR_*` needed.

--- a/lib/amplify-server.ts
+++ b/lib/amplify-server.ts
@@ -50,6 +50,16 @@ async function verifyToken(token: string) {
 }
 
 export async function getServerSession(): Promise<ServerSession | null> {
+  const isBypass = process.env.NODE_ENV === "development" ||
+    process.env.NEXT_PUBLIC_AUTH_BYPASS === "true";
+  if (isBypass) {
+    return {
+      sub: "dev-bypass-admin",
+      email: "admin@startline.test",
+      groups: ["admins"],
+    };
+  }
+
   try {
     const cookieStore = await cookies();
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -60,7 +60,12 @@ function isAdmin(payload: JWTPayload): boolean {
   return groups.includes("admins");
 }
 
+const isBypass = process.env.NODE_ENV === "development" ||
+  process.env.NEXT_PUBLIC_AUTH_BYPASS === "true";
+
 export async function middleware(req: NextRequest) {
+  if (isBypass) return NextResponse.next();
+
   const { pathname } = req.nextUrl;
   const host = req.headers.get("host") ?? "";
 

--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -36,7 +36,6 @@ data "aws_iam_policy_document" "terraform_ci_assume" {
       variable = "token.actions.githubusercontent.com:sub"
       values = [
         "repo:${var.github_repository}:*:refs/heads/main",
-        "repo:${var.github_repository}:*:refs/heads/nonprod",
         "repo:${var.github_repository}:*:refs/heads/prod",
       ]
     }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -69,7 +69,8 @@ locals {
               --secret-id "$SECRET"
               --query SecretString --output text
               | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env.production
-            - npx prisma migrate deploy
+            - [ -n "$AWS_PULL_REQUEST_ID" ] && echo "NEXT_PUBLIC_AUTH_BYPASS=true" >> .env.production
+            - [ -z "$AWS_PULL_REQUEST_ID" ] && npx prisma migrate deploy
         build:
           commands:
             - pnpm run build
@@ -86,6 +87,7 @@ locals {
   # captures only the things that diverge between prod and nonprod.
   environments = {
     prod = {
+      create_amplify_branch        = true
       branch_name                  = "prod"
       amplify_stage                = "PRODUCTION"
       auto_build_enabled           = false
@@ -98,6 +100,7 @@ locals {
       site_url                     = "https://startlineau.com"
     }
     nonprod = {
+      create_amplify_branch        = false
       branch_name                  = "nonprod"
       amplify_stage                = "DEVELOPMENT"
       auto_build_enabled           = false
@@ -112,7 +115,7 @@ locals {
   }
 }
 
-# Singleton Amplify app. Branches (prod, nonprod) attach via the env module.
+# Singleton Amplify app. Branch (prod) attaches via the env module.
 resource "aws_amplify_app" "this" {
   name       = var.project_name
   platform   = "WEB_COMPUTE"
@@ -124,10 +127,20 @@ resource "aws_amplify_app" "this" {
   repository   = local.connect_repository ? var.amplify_repository_url : null
   access_token = local.connect_repository ? local.bootstrap.amplify_repository_access_token : null
 
-  # App-level env vars apply to BOTH branches. Secrets are fetched from
-  # Secrets Manager at build time via the build spec. Branch-level env vars
-  # (DATABASE_URL, bucket names) are set by the env module.
+  # App-level env vars apply to both the prod branch and PR previews. Secrets
+  # are fetched from Secrets Manager at build time via the build spec.
+  # Branch-level env vars (DATABASE_URL, bucket names) are set by the env module.
   environment_variables = var.amplify_environment_variables
+
+  enable_auto_branch_creation = true
+
+  auto_branch_creation_patterns = ["main"]
+
+  auto_branch_creation_config {
+    enable_pull_request_preview = true
+    enable_auto_build           = false
+    stage                       = "DEVELOPMENT"
+  }
 
   lifecycle {
     precondition {
@@ -148,9 +161,10 @@ module "env" {
   project_name   = var.project_name
   amplify_app_id = aws_amplify_app.this.id
 
-  branch_name        = each.value.branch_name
-  amplify_stage      = each.value.amplify_stage
-  auto_build_enabled = each.value.auto_build_enabled
+  create_amplify_branch = each.value.create_amplify_branch
+  branch_name           = each.value.branch_name
+  amplify_stage         = each.value.amplify_stage
+  auto_build_enabled    = each.value.auto_build_enabled
 
   vpc_cidr      = each.value.vpc_cidr
   database_name = each.value.database_name

--- a/terraform/modules/environment/main.tf
+++ b/terraform/modules/environment/main.tf
@@ -382,6 +382,11 @@ resource "aws_amplify_branch" "this" {
     },
     var.extra_branch_environment_variables,
   )
+
+  tags = {
+    Environment = var.name == "prod" ? "Prod" : "Stage"
+    Service     = var.project_name
+  }
 }
 
 # ===== S3 upload bucket =====

--- a/terraform/modules/environment/main.tf
+++ b/terraform/modules/environment/main.tf
@@ -367,6 +367,7 @@ resource "aws_cognito_user_group" "this" {
 # ===== Amplify branch =====
 
 resource "aws_amplify_branch" "this" {
+  count       = var.create_amplify_branch ? 1 : 0
   app_id      = var.amplify_app_id
   branch_name = var.branch_name
   stage       = var.amplify_stage

--- a/terraform/modules/environment/outputs.tf
+++ b/terraform/modules/environment/outputs.tf
@@ -1,11 +1,11 @@
 output "branch_name" {
   description = "Amplify branch name attached to this environment."
-  value       = aws_amplify_branch.this.branch_name
+  value       = var.create_amplify_branch ? aws_amplify_branch.this[0].branch_name : ""
 }
 
 output "branch_arn" {
   description = "Amplify branch ARN."
-  value       = aws_amplify_branch.this.arn
+  value       = var.create_amplify_branch ? aws_amplify_branch.this[0].arn : ""
 }
 
 output "database_host" {

--- a/terraform/modules/environment/variables.tf
+++ b/terraform/modules/environment/variables.tf
@@ -13,6 +13,12 @@ variable "amplify_app_id" {
   type        = string
 }
 
+variable "create_amplify_branch" {
+  description = "Whether to create an Amplify branch for this environment."
+  type        = bool
+  default     = true
+}
+
 variable "branch_name" {
   description = "Git branch deployed to this environment (e.g. prod, nonprod)."
   type        = string

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -18,11 +18,6 @@ output "amplify_production_branch" {
   value       = module.env["prod"].branch_name
 }
 
-output "amplify_nonprod_branch" {
-  description = "Nonprod branch name in Amplify."
-  value       = module.env["nonprod"].branch_name
-}
-
 output "aws_account_id" {
   description = "AWS account ID resources were created in."
   value       = data.aws_caller_identity.current.account_id


### PR DESCRIPTION
## Summary
Adds a dev auth bypass so local dev and PR previews don't need Cognito auth, drops the nonprod Amplify branch (keeping backend infra), and enables Amplify PR previews against `main`.

## Changes (10 files)

### Dev auth bypass
- **`middleware.ts`** — Skip auth when `NODE_ENV=development` or `NEXT_PUBLIC_AUTH_BYPASS=true`
- **`lib/amplify-server.ts`** — Return mock admin session when bypass is active

### Build spec
- **`terraform/main.tf`** — Set bypass flag for PR previews, skip `prisma migrate deploy` for previews

### Terraform
- **`terraform/modules/environment/`** — Add `create_amplify_branch` variable, conditionalize Amplify branch and outputs
- **`terraform/main.tf`** — Nonprod env: `create_amplify_branch = false`. Amplify app: enable PR previews via auto-branch-creation for `main`
- **`terraform/outputs.tf`** — Remove `amplify_nonprod_branch` output
- **`terraform/github_oidc.tf`** — Remove `nonprod` from admin role trust

### Workflow
- **`.github/workflows/deploy.yml`** — Remove `nonprod` trigger (prod only)

### Docs
- **`AGENTS.md`** — Update deploy docs

### Git
- Delete `nonprod` branch and its protection

## After merge
- Terraform apply creates Amplify PR preview config + destroys nonprod Amplify branch
- Every PR to `main` gets an auto-built preview at a temp URL with a GitHub PR comment