### PR TITLE
Fix Amplify build spec YAML indentation

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,13 +62,7 @@ locals {
         preBuild:
           commands:
             - corepack enable && pnpm install --frozen-lockfile
-            - >
-              SECRET="startline/nonprod/app"
-              && [ "$AWS_BRANCH" = "prod" ] && SECRET="startline/prod/app"
-              && aws secretsmanager get-secret-value
-              --secret-id "$SECRET"
-              --query SecretString --output text
-              | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env.production
+            - SECRET="startline/nonprod/app" && [ "$AWS_BRANCH" = "prod" ] && SECRET="startline/prod/app" && aws secretsmanager get-secret-value --secret-id "$SECRET" --query SecretString --output text | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env.production
             - [ -n "$AWS_PULL_REQUEST_ID" ] && echo "NEXT_PUBLIC_AUTH_BYPASS=true" >> .env.production
             - [ -z "$AWS_PULL_REQUEST_ID" ] && npx prisma migrate deploy
         build:


### PR DESCRIPTION
The `>` fold block scalar was eating adjacent list items, causing a YAML parse error. Collapsed the multi-line secret-fetch command into a single line to fix.