### PR TITLE
Add jq to Amplify build spec

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -63,6 +63,7 @@ locals {
           commands:
             - >
               corepack enable && pnpm install --frozen-lockfile
+              && yum install -y jq
               && SECRET="startline/nonprod/app"
               && [ "$AWS_BRANCH" = "prod" ] && SECRET="startline/prod/app"
               && aws secretsmanager get-secret-value


### PR DESCRIPTION
The build image is missing jq. Install it via yum before secret fetching.