### PR TITLE
Fix TS type error + prisma db push fallback

### DIFF
--- a/app/(user)/events/[id]/page.tsx
+++ b/app/(user)/events/[id]/page.tsx
@@ -25,7 +25,7 @@ export const revalidate = 60;
 export async function generateStaticParams() {
   try {
     const events = await getAllEvents();
-    return events.map((e) => ({ id: e.id }));
+    return events.map((e: { id: string }) => ({ id: e.id }));
   } catch {
     return [];
   }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -70,7 +70,7 @@ locals {
               --query SecretString --output text
               | node -e "const s=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8').trim());for(const[k,v]of Object.entries(s))console.log(k+'='+v)" >> .env.production
               && ( [ -n "$AWS_PULL_REQUEST_ID" ] && echo "NEXT_PUBLIC_AUTH_BYPASS=true" >> .env.production ; true )
-              && ( [ -z "$AWS_PULL_REQUEST_ID" ] && npx prisma migrate deploy ; true )
+              && ( [ -z "$AWS_PULL_REQUEST_ID" ] && ( npx prisma migrate deploy || npx prisma db push ) ; true )
         build:
           commands:
             - pnpm run build


### PR DESCRIPTION
Fix implicit 'any' type in sitemap gen and add `prisma db push` fallback when `migrate deploy` fails (handles prod DB baseline).