### PR TITLE
Fix TS implicit any errors + Prisma db push fallback

### DIFF
--- a/app/(user)/events/[id]/page.tsx
+++ b/app/(user)/events/[id]/page.tsx
@@ -34,7 +34,7 @@ export async function generateStaticParams() {
 export default async function EventDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const raw = await getAllEvents();
-  const found = raw.find((e) => e.id === id);
+  const found = raw.find((e: { id: string }) => e.id === id);
   if (!found) notFound();
 
   const event = toUserEvent(found);

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,48 +1,57 @@
 import prisma from "@/lib/prisma";
+import type { Prisma } from "@prisma/client";
 import { archivePastEvents } from "@/lib/archive-events";
 import { lowestPrice, type PublicEvent, type PublicWave } from "./event-types";
 
-export async function getAllEvents() {
+const eventSelect = {
+  id: true,
+  title: true,
+  discipline: true,
+  tagline: true,
+  description: true,
+  eventDate: true,
+  endDate: true,
+  startTime: true,
+  endTime: true,
+  venue: true,
+  address: true,
+  city: true,
+  state: true,
+  format: true,
+  level: true,
+  categories: true,
+  cap: true,
+  minAge: true,
+  waves: true,
+  extras: true,
+  refundPolicy: true,
+  coverImageUrl: true,
+  photos: true,
+  registrationType: true,
+  registrationUrl: true,
+  feeStructure: true,
+  organiserId: true,
+  organiser: {
+    select: { id: true, orgName: true, logoUrl: true, stripeAccountId: true, stripeOnboardingComplete: true },
+  },
+  _count: {
+    select: { registrations: true },
+  },
+} satisfies Prisma.EventSelect;
+
+type EventRow = Prisma.EventGetPayload<{ select: typeof eventSelect }>;
+export type EventListItem = EventRow & {
+  fromPrice: string | null;
+  registrationCount: number;
+};
+
+export async function getAllEvents(): Promise<EventListItem[]> {
   try {
     await archivePastEvents();
     const events = await prisma.event.findMany({
       where: { status: "APPROVED" },
       orderBy: { eventDate: "asc" },
-      select: {
-        id: true,
-        title: true,
-        discipline: true,
-        tagline: true,
-        description: true,
-        eventDate: true,
-        endDate: true,
-        startTime: true,
-        endTime: true,
-        venue: true,
-        address: true,
-        city: true,
-        state: true,
-        format: true,
-        level: true,
-        categories: true,
-        cap: true,
-        minAge: true,
-        waves: true,
-        extras: true,
-        refundPolicy: true,
-        coverImageUrl: true,
-        photos: true,
-        registrationType: true,
-        registrationUrl: true,
-        feeStructure: true,
-        organiserId: true,
-        organiser: {
-          select: { id: true, orgName: true, logoUrl: true, stripeAccountId: true, stripeOnboardingComplete: true },
-        },
-        _count: {
-          select: { registrations: true },
-        },
-      },
+      select: eventSelect,
     });
 
     return events.map((e) => ({


### PR DESCRIPTION
Fix implicit 'any' type errors in event detail page. Add `prisma db push` fallback in build spec for prod DB baseline. Add return type to `getAllEvents()`.