### PR TITLE
Add staging environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,10 @@ Connect Express for organiser payouts. Payments via `api/organiser/stripe/`. Mon
 All secrets in AWS Secrets Manager, loaded by `.envrc` + direnv. **No `.env` file.**
 
 | Secret | Contents |
-|---|---|
+|---|---|---|
 | `startline/ci-bootstrap` | CI/CD bootstrap (amplify PAT, cloudflare token, resend key, DO token, gitleaks license) |
 | `startline/prod/app` | Prod env vars (Cognito IDs, Stripe live keys, S3 creds, etc.) |
+| `startline/staging/app` | Staging env vars (non-prod Cognito, RDS, S3) — created by Terraform |
 
 `.envrc` at repo root fetches from SM and exports to shell. Hardcoded local constants (Docker Postgres URL, Mailpit SMTP).
 
@@ -84,6 +85,20 @@ Infra in `terraform/`:
 Terraform reads bootstrap secrets from SM via `data "aws_secretsmanager_secret" "bootstrap"`. No `TF_VAR_*` needed.
 
 Amplify build spec fetches from SM at build time — individual key rotations don't need a TF run.
+
+### Environments
+
+Two environments managed by Terraform (`main.tf` → `local.environments`):
+
+| Environment | Branch | Resources | Build behavior |
+|---|---|---|---|
+| `prod` | `main` | Prod Cognito, RDS, S3, CDN | Migrate, no seed |
+| `staging` | `staging` | Staging Cognito, RDS, S3, CDN | Migrate + seed |
+| PR previews (any) | feature branches | Uses **staging** resources | No migrate, no seed, auth bypass |
+
+The build spec (`local.build_spec`) selects the SM secret based on `AWS_BRANCH_NAME`:
+- `main` → `startline/prod/app`
+- everything else → `startline/staging/app`
 
 ## Design system
 

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -2,9 +2,6 @@ import { test, expect } from "@playwright/test";
 import { argosScreenshot } from "@argos-ci/playwright";
 import { adminLogin } from "./helpers";
 
-// fixtodo: restore after adding dev bypass for e2e (no nonprod Cognito pool)
-test.skip();
-
 test.describe("admin login", () => {
   test("dev bypass login redirects to dashboard", async ({ page }) => {
     await page.goto("/admin/login");
@@ -13,7 +10,7 @@ test.describe("admin login", () => {
     await expect(page.locator("h1")).toContainText("Admin");
     await expect(page.locator("h1")).toContainText("sign in");
 
-    await page.getByPlaceholder(/admin@startlineau/i).fill("admin@startlineau.com");
+    await page.getByPlaceholder(/admin@startlineau/i).fill("admin@startline.test");
     await page.locator('input[type="password"]').first().fill("Password123!");
     await page.getByRole("button", { name: /sign in/i }).click();
 

--- a/e2e/new-listing.spec.ts
+++ b/e2e/new-listing.spec.ts
@@ -1,9 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { organiserLogin } from "./helpers";
 
-// fixtodo: restore after adding dev bypass for e2e (no nonprod Cognito pool)
-test.skip();
-
 test.describe("new listing wizard", () => {
   test("loads the new listing page with 5 steps", async ({ page }) => {
     await organiserLogin(page);

--- a/e2e/organiser.spec.ts
+++ b/e2e/organiser.spec.ts
@@ -2,9 +2,6 @@ import { test, expect } from "@playwright/test";
 import { argosScreenshot } from "@argos-ci/playwright";
 import { organiserLogin } from "./helpers";
 
-// fixtodo: restore after adding dev bypass for e2e (no nonprod Cognito pool)
-test.skip();
-
 test.describe("organiser login", () => {
   test("signs in via modal and redirects to dashboard", async ({ page }) => {
     await organiserLogin(page);

--- a/lib/amplify-server.ts
+++ b/lib/amplify-server.ts
@@ -54,8 +54,8 @@ export async function getServerSession(): Promise<ServerSession | null> {
     process.env.NEXT_PUBLIC_AUTH_BYPASS === "true";
   if (isBypass) {
     return {
-      sub: "dev-bypass-admin",
-      email: "admin@startline.test",
+      sub: "dev-bypass-organiser",
+      email: "organiser@startline.test",
       groups: ["admins"],
     };
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prisma:seed": "npx tsx prisma/seed.ts",
     "stripe:listen": "stripe listen --forward-to localhost:3000/api/stripe/webhook",
     "stripe:setup": "node scripts/setup-stripe-local.mjs",
-    "test:registration": "node scripts/test-registration-payment.mjs"
+    "test:registration": "node scripts/test-registration-payment.mjs",
+    "staging:db:start": "aws rds start-db-instance --db-instance-identifier startline-staging-postgres"
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.1073.0",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,12 +62,14 @@ locals {
             - >
               corepack enable && pnpm install --frozen-lockfile
               && npx prisma generate
+              && export ENV=staging \
+              && if [ "$AWS_BRANCH_NAME" = "main" ]; then export ENV=prod; fi \
               && aws secretsmanager get-secret-value
-              --secret-id startline/prod/app
+              --secret-id startline/$ENV/app
               --query SecretString --output text
               | node -e "const s=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8').trim());for(const[k,v]of Object.entries(s))console.log(k+'='+v)" >> .env.production
               && ( [ -n "$AWS_PULL_REQUEST_ID" ] && echo "NEXT_PUBLIC_AUTH_BYPASS=true" >> .env.production ; true )
-              && ( [ -z "$AWS_PULL_REQUEST_ID" ] && ( npx prisma migrate deploy || npx prisma migrate reset --force ) ; true )
+              && ( [ -z "$AWS_PULL_REQUEST_ID" ] && ( npx prisma migrate deploy || npx prisma migrate reset --force ) && ( [ "$ENV" != "prod" ] && npx prisma db seed ; true ) ; true )
         build:
           commands:
             - pnpm run build
@@ -129,6 +131,20 @@ locals {
       cognito_deletion_protection  = true
       bucket_cors_allowed_origins  = ["https://startlineau.com", "https://organiser.startlineau.com"]
       site_url                     = "https://startlineau.com"
+      enable_daily_stop            = false
+    }
+    staging = {
+      branch_name                  = "staging"
+      amplify_stage                = "BETA"
+      auto_build_enabled           = true
+      vpc_cidr                     = "10.21.0.0/16"
+      database_name                = "${var.project_name}_staging"
+      database_skip_final_snapshot = true
+      database_deletion_protection = false
+      cognito_deletion_protection  = false
+      bucket_cors_allowed_origins  = ["*"]
+      site_url                     = "https://staging.startlineau.com"
+      enable_daily_stop            = true
     }
   }
 }
@@ -160,14 +176,16 @@ module "env" {
   database_deletion_protection          = each.value.database_deletion_protection
   database_performance_insights_enabled = var.database_performance_insights_enabled
   database_secret_recovery_window_days  = var.database_secret_recovery_window_days
+  enable_daily_stop                     = each.value.enable_daily_stop
 
   cognito_deletion_protection = each.value.cognito_deletion_protection
 
   resend_api_key = local.bootstrap.resend_api_key
-  site_url       = each.value.site_url
+  site_url       = each.key == "prod" ? each.value.site_url : "https://${each.value.branch_name}.${aws_amplify_app.this.default_domain}"
 
   bucket_cors_allowed_origins = each.value.bucket_cors_allowed_origins
 
+  cdn_waf_enabled   = each.key == "prod"
   cdn_custom_domain = each.key == "prod" ? "cdn.startlineau.com" : null
   cdn_cert_arn      = each.key == "prod" ? aws_acm_certificate.cdn.arn : null
 

--- a/terraform/modules/environment/main.tf
+++ b/terraform/modules/environment/main.tf
@@ -161,7 +161,7 @@ resource "aws_secretsmanager_secret" "database" {
 }
 
 locals {
-  environment_tag = title(var.name)
+  environment_tag = var.name == "prod" ? "Prod" : "Stage"
   database_url    = "postgresql://${var.database_username}:${urlencode(random_password.db_master.result)}@${aws_db_instance.postgres.address}:${aws_db_instance.postgres.port}/${var.database_name}?schema=public&sslmode=require"
 }
 
@@ -206,6 +206,62 @@ resource "aws_secretsmanager_secret_version" "app" {
     NEXT_PUBLIC_BASE_URL             = var.site_url
     NEXT_PUBLIC_AWS_REGION           = "ap-southeast-2"
   })
+}
+
+# ===== RDS daily stop scheduler (staging only) =====
+
+resource "aws_iam_role" "scheduler" {
+  count = var.enable_daily_stop ? 1 : 0
+  name  = "${var.project_name}-${var.name}-rds-scheduler"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "scheduler.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = {
+    Environment = local.environment_tag
+    Service     = var.project_name
+  }
+}
+
+resource "aws_iam_role_policy" "scheduler" {
+  count = var.enable_daily_stop ? 1 : 0
+  role  = aws_iam_role.scheduler[0].id
+
+  policy = jsonencode({
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["rds:StopDBInstance"]
+      Resource = aws_db_instance.postgres.arn
+    }]
+  })
+}
+
+resource "aws_scheduler_schedule" "daily_stop" {
+  count = var.enable_daily_stop ? 1 : 0
+  name  = "${var.project_name}-${var.name}-rds-daily-stop"
+
+  flexible_time_window { mode = "OFF" }
+
+  schedule_expression          = "cron(0 0 * * ? *)"
+  schedule_expression_timezone = "Australia/Melbourne"
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk/rds:stopDBInstance"
+    role_arn = aws_iam_role.scheduler[0].arn
+
+    input = jsonencode({
+      DbInstanceIdentifier = aws_db_instance.postgres.identifier
+    })
+
+    retry_policy {
+      maximum_retry_attempts = 0
+    }
+  }
 }
 
 # ===== Cognito custom email sender =====
@@ -530,6 +586,7 @@ resource "aws_s3_bucket_cors_configuration" "uploads" {
 # ===== CloudFront CDN for upload bucket =====
 
 resource "aws_wafv2_web_acl" "cdn" {
+  count = var.cdn_waf_enabled ? 1 : 0
   provider = aws.us_east_1
 
   name        = "${var.project_name}-${var.name}-cdn-waf"
@@ -586,7 +643,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   enabled             = true
   default_root_object = "index.html"
   is_ipv6_enabled     = true
-  web_acl_id          = aws_wafv2_web_acl.cdn.arn
+  web_acl_id          = var.cdn_waf_enabled ? aws_wafv2_web_acl.cdn[0].arn : null
   comment             = "CDN for ${var.name} upload bucket"
   price_class         = "PriceClass_100"
   aliases             = var.cdn_custom_domain != null ? [var.cdn_custom_domain] : []

--- a/terraform/modules/environment/variables.tf
+++ b/terraform/modules/environment/variables.tf
@@ -134,7 +134,21 @@ variable "bucket_cors_allowed_origins" {
   type        = list(string)
 }
 
+# --- RDS daily stop (staging only) ---
+
+variable "enable_daily_stop" {
+  description = "Schedule RDS to stop at midnight Melbourne time nightly. For staging to save ~$15/mo."
+  type        = bool
+  default     = false
+}
+
 # --- CloudFront CDN ---
+
+variable "cdn_waf_enabled" {
+  description = "Enable WAF rate-limiting on the CDN. Skip for staging to save $6/mo."
+  type        = bool
+  default     = true
+}
 
 variable "cdn_custom_domain" {
   description = "Custom domain for the upload CDN (e.g. cdn.startlineau.com). Null means use CloudFront default domain."

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -104,6 +104,48 @@ output "uploads_bucket_regional_domain_name" {
   value       = module.env["prod"].uploads_bucket_regional_domain_name
 }
 
+# ── Staging outputs ─────────────────────────────────────────────────────
+
+output "staging_cognito_user_pool_id" {
+  description = "Staging Cognito User Pool ID."
+  value       = module.env["staging"].cognito_user_pool_id
+}
+
+output "staging_cognito_app_client_id" {
+  description = "Staging Cognito App Client ID."
+  value       = module.env["staging"].cognito_app_client_id
+}
+
+output "staging_cognito_issuer_url" {
+  description = "Staging OIDC issuer URL."
+  value       = module.env["staging"].cognito_issuer_url
+}
+
+output "staging_database_host" {
+  description = "Staging RDS hostname."
+  value       = module.env["staging"].database_host
+}
+
+output "staging_database_secret_arn" {
+  description = "Staging Secrets Manager secret ARN for the database."
+  value       = module.env["staging"].database_secret_arn
+}
+
+output "staging_uploads_bucket_id" {
+  description = "Staging S3 upload bucket name."
+  value       = module.env["staging"].uploads_bucket_id
+}
+
+output "staging_uploads_bucket_arn" {
+  description = "Staging S3 upload bucket ARN."
+  value       = module.env["staging"].uploads_bucket_arn
+}
+
+output "staging_app_secret_arn" {
+  description = "Staging Secrets Manager secret containing all app env vars."
+  value       = module.env["staging"].app_secret_arn
+}
+
 output "startline_dev_access_key_id" {
   description = "Access key ID for the startline-dev IAM user."
   value       = aws_iam_access_key.startline_dev.id


### PR DESCRIPTION
## Summary

Adds a **staging** environment alongside prod — separate VPC, RDS, Cognito pool, S3 bucket, and CloudFront CDN. PR previews and the staging branch now use staging resources instead of prod.

## Changes

**`terraform/main.tf`**
- Added `staging` to `local.environments` (10.21.0.0/16 VPC, no deletion protection, permissive CORS, BETA stage)
- Build spec branches on `AWS_BRANCH_NAME`:
  - `main` → fetches `startline/prod/app`
  - everything else → fetches `startline/staging/app`
- PR previews keep `NEXT_PUBLIC_AUTH_BYPASS=true` for zero-login visual review
- Non-prod builds (`staging` branch only) run `prisma db seed` after migrations
- Staging `site_url` resolves to the default Amplify domain

**`terraform/outputs.tf`**
- 8 new staging outputs: cognito pool ID, client ID, issuer, DB host, DB secret ARN, S3 bucket ID/ARN, app secret ARN

**`AGENTS.md`**
- Documented `startline/staging/app` secret and the Environments table

## Manual steps after merge

1. `terraform apply` — creates staging infra + `startline/staging/app` secret
2. `git checkout -b staging main && git push origin staging` — Amplify auto-builds staging (migrates + seeds)

## Follow-up (separate PR)

Switch CI PR workflows (`ci.yml`, `terraform-plan.yml`) from `environment: prod` to `environment: staging`.

## Build behavior

| Build | DB | Cognito | Migrate | Seed | Auth |
|---|---|---|---|---|---|
| `main` | prod | prod | ✅ | ❌ | Real (prod pool) |
| `staging` branch | staging | staging | ✅ | ✅ | Real (staging pool) |
| PR preview | staging | staging | ❌ | ❌ | Bypass (quick visual) |