### PR TITLE
Remove DigitalOcean docs droplet and Outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Open [http://localhost:3000](http://localhost:3000) to view the site.
 
 Secrets are stored in AWS Secrets Manager and loaded automatically via `.envrc` + direnv:
 
-- `startline/ci-bootstrap` — CI/CD bootstrap secrets (API keys for Cloudflare, Resend, Amplify, DigitalOcean)
+- `startline/ci-bootstrap` — CI/CD bootstrap secrets (API keys for Cloudflare, Resend, Amplify)
 - `startline/nonprod/app` — All nonprod env vars (Cognito IDs, Stripe test keys, S3 creds, etc.)
 - `startline/prod/app` — All prod env vars (live values)
 

--- a/terraform/cloudflare-dns.tf
+++ b/terraform/cloudflare-dns.tf
@@ -124,17 +124,6 @@ resource "cloudflare_record" "resend_dkim" {
   content = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCxZV6xZfEAVwIGGNjvbOZlYPABNnYesQswgsrcrHBZNXAzfaGSSSkIp8N5UGpEcPIwofFHj2I8BD9TuKlZk9P0CSOsSar8Ao85og76GI/ZjWTe9e9uWUjdqIuFr/dwS58H9JGpl/qQreeVMPCOyuWpYMsQKNFM8kLPz9VooufRQIDAQAB"
 }
 
-# ===== Outline docs (Docker droplet) =====
-
-resource "cloudflare_record" "docs" {
-  zone_id = cloudflare_zone.primary.id
-  name    = "docs"
-  type    = "A"
-  ttl     = 1
-  content = var.docs_droplet_ip
-  proxied = true
-}
-
 # ===== Apex TXT (verifications + SPF) =====
 
 resource "cloudflare_record" "apex_txt" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -4,8 +4,6 @@
 #   - amplify_repository_access_token
 #   - cloudflare_api_token
 #   - resend_api_key
-#   - digitalocean_api_token
-#   - docs_droplet_ip
 # Set them via: aws secretsmanager put-secret-value --secret-id startline/ci-bootstrap ...
 #
 # aws_region   = "ap-southeast-2"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -88,11 +88,6 @@ variable "database_allowed_cidr_blocks" {
   default     = ["0.0.0.0/0"]
 }
 
-variable "docs_droplet_ip" {
-  description = "IPv4 address of the DigitalOcean droplet running Outline docs."
-  type        = string
-}
-
 variable "database_backup_retention_period" {
   description = "Days of automated backups. 0 disables backups — required while the AWS account is in Free Tier restricted mode."
   type        = number


### PR DESCRIPTION
Removes the DigitalOcean docs droplet and Outline docs infrastructure.

- Remove `docs_droplet_ip` variable from Terraform (was blocking `terraform apply`)
- Remove Cloudflare DNS A record for `docs.startlineau.com`
- Clean up `terraform.tfvars.example` and `README.md` references

Docs will be managed as a basic markdown folder with git going forward.