### PR TITLE
Fix Amplify build spec: remove stray backslashes

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,8 +62,8 @@ locals {
             - >
               corepack enable && pnpm install --frozen-lockfile
               && npx prisma generate
-              && export ENV=staging \
-              && if [ "$AWS_BRANCH_NAME" = "main" ]; then export ENV=prod; fi \
+              && export ENV=staging
+              && if [ "$AWS_BRANCH_NAME" = "main" ]; then export ENV=prod; fi
               && aws secretsmanager get-secret-value
               --secret-id startline/$ENV/app
               --query SecretString --output text


### PR DESCRIPTION
The `\` at end of YAML lines in the `- >` folded block were being passed literally to the shell script, causing `syntax error near unexpected token`. YAML folding already joins lines with spaces — no backslash continuations needed.