### PR TITLE
fix: rotate exposed CI keys + selective bootstrap export

### DIFF
--- a/.github/actions/load-env/action.yml
+++ b/.github/actions/load-env/action.yml
@@ -7,6 +7,9 @@ inputs:
   environment:
     description: "environment name (prod, etc.)"
     default: "prod"
+  bootstrap-export-keys:
+    description: "Comma-separated list of bootstrap keys to export as env vars (empty = none)"
+    default: ""
 
 runs:
   using: "composite"
@@ -32,9 +35,17 @@ runs:
           echo "::add-mask::$value"
         done < <(echo "$BOOTSTRAP" | jq -r 'values[]')
 
-        # Export to env (raw + TF_VAR_ prefixed)
-        echo "$BOOTSTRAP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
-        echo "$BOOTSTRAP" | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value)"' >> "$GITHUB_ENV"
+        # Export only whitelisted bootstrap keys (raw + TF_VAR_ prefixed)
+        if [ -n "${{ inputs.bootstrap-export-keys }}" ]; then
+          IFS=',' read -ra KEYS <<< "${{ inputs.bootstrap-export-keys }}"
+          for key in "${KEYS[@]}"; do
+            val=$(echo "$BOOTSTRAP" | jq -r --arg k "$key" '.[$k] // empty')
+            if [ -n "$val" ]; then
+              echo "$key=$val" >> "$GITHUB_ENV"
+              echo "TF_VAR_$key=$val" >> "$GITHUB_ENV"
+            fi
+          done
+        fi
 
         APP=$(aws secretsmanager get-secret-value \
           --secret-id startline/${{ inputs.environment }}/app \

--- a/.github/workflows/argos-baseline.yml
+++ b/.github/workflows/argos-baseline.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: prod
+          bootstrap-export-keys: ARGOS_TOKEN
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    branches: [main, staging]
 
 permissions:
   id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: prod
+          bootstrap-export-keys: GITLEAKS_LICENSE
       - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -125,6 +126,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: prod
+          bootstrap-export-keys: ""
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           environment: prod
+          bootstrap-export-keys: ""
 
       - name: Resolve Amplify app ID
         id: amplify-app

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           environment: prod
+          bootstrap-export-keys: ""
 
       - name: Install Terraform
         shell: bash

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: prod
+          bootstrap-export-keys: INFRACOST_API_KEY
 
       - name: Install Terraform
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Next.js 15 (App Router) fitness event discovery platform. Three portals:
 
 ## Development
 
-- **Package manager:** pnpm 11.10.0
+- **Package manager:** pnpm 11.11.0
 - **Dev:** `pnpm dev` (Turbopack). **Build:** `pnpm build` (standalone `next.config.ts`). `@/*` → root.
 - **Docker:** PostgreSQL 15 on :5432 + Mailpit (SMTP :1025, UI :8026). Start: `docker compose up -d`.
 - **Worktree?** Check via `git worktree list`. If yes, Docker infra runs on main checkout — just `pnpm dev`, no `docker compose up`.
@@ -19,8 +19,6 @@ Next.js 15 (App Router) fitness event discovery platform. Three portals:
 ## Auth (Cognito)
 
 JWT verification in `middleware.ts` via `jose`. Tokens in Cognito-managed cookies. Only Cognito group: `admins`. Authorisation at DB level (Prisma).
-
-Uses AWS Cognito with JWT verification in middleware via `jose`. Tokens in Cognito-managed cookies. Only `admins` group used — non-admin users have no special group assignment. Authorisation at the DB level (Prisma).
 
 Production Cognito pool (managed via Terraform). Users created by `prisma/seed.ts` via `AdminCreateUser` + `AdminSetUserPassword` per seed user, plus `AdminAddUserToGroup` for admin only.
 
@@ -69,7 +67,7 @@ prefix = ["/Users/Lachlan/"]
 
 **Key rotation:** Update the SM secret, trigger an Amplify rebuild. No code changes, no TF runs.
 
-**CI:** Composite action at `.github/actions/load-env/` — assumes OIDC role, fetches bootstrap + app secrets, exports as env vars. Used by all 3 workflows.
+**CI:** Composite action at `.github/actions/load-env/` — assumes OIDC role, fetches bootstrap + app secrets, exports as env vars. Used by all workflows.
 
 ## Git worktrees
 
@@ -80,7 +78,7 @@ All worktrees under `~/.herdr/worktrees/startline/`. Docker infra (PostgreSQL, M
 Infra in `terraform/`:
 - `terraform-plan.yml` on PR, `terraform-apply.yml` on push to main
 - App deploys via Amplify on push to `main`. PR previews deploy automatically to temp URLs.
-- No app code CI (no lint/test/build checks)
+- `ci.yml` runs lint, typecheck, build, test, e2e on PRs (non-blocking, informational).
 
 Terraform reads bootstrap secrets from SM via `data "aws_secretsmanager_secret" "bootstrap"`. No `TF_VAR_*` needed.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,18 @@ Use labels, native issue type (Bug/Feature/Task), Priority/Effort via GraphQL (f
 
 Configured in `opencode.json`: stripe, resend, aws, cloudflare. Skills listed below.
 
+## README accuracy
+
+`README.md` has several known inaccuracies. Do not treat it as authoritative — cross-reference with this file and the actual codebase:
+
+- **License:** README says MIT, actual `LICENSE` file is All Rights Reserved.
+- **Secret name:** README says `startline/nonprod/app`, actual name is `startline/staging/app`.
+- **`.envrc`:** README says it exists at root fetching SM secrets — it does not exist in the repo (gitignored). Devs load env vars another way (direnv + local config).
+- **Scripts table:** Missing `typecheck`, `prisma:generate`, `test:watch`, `stripe:*`, `start`, `test:registration`, `staging:db:start`.
+- **`prisma:migrate`:** README says "Apply Prisma migrations" — the script actually runs `prisma migrate dev` (dev-only, creates migrations), not `prisma migrate deploy`.
+- **Site state:** README describes a live event browsing platform; the site is currently in waitlist mode.
+- **Admin domain:** Implies three separate domains; admin actually shares `organiser.startlineau.com` as a path prefix.
+
 ## Idempotency
 
 - Prisma client singleton in `lib/prisma.ts`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-StartLine helps performance-driven fitness individuals discover competitive events across Australia. Find fitness racing, CrossFit competitions, running races, and hybrid fitness events in one place.
+Startline helps performance-driven fitness individuals discover competitive events across Australia. Find fitness racing, CrossFit competitions, running races, and hybrid fitness events in one place.
 
 ## Tech Stack
 

--- a/app/(user)/about/page.tsx
+++ b/app/(user)/about/page.tsx
@@ -5,25 +5,25 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "About Us",
   description:
-    "Meet the team behind StartLine — Australia's fitness event calendar. Founded by Lachlan Martin, Nathan Sweet, Hugo Shrowder, and Noah Helu.",
+    "Meet the team behind Startline — Australia's fitness event calendar. Founded by Lachlan Martin, Nathan Sweet, Hugo Shrowder, and Noah Helu.",
   openGraph: {
-    title: "About Us | StartLine",
+    title: "About Us | Startline",
     description:
-      "Meet the team behind StartLine — Australia's fitness event calendar.",
+      "Meet the team behind Startline — Australia's fitness event calendar.",
     url: "/about",
     images: [
       {
         url: "/images/about/about-hero.jpg",
         width: 1200,
         height: 630,
-        alt: "About StartLine",
+        alt: "About Startline",
       },
     ],
   },
   twitter: {
-    title: "About Us | StartLine",
+    title: "About Us | Startline",
     description:
-      "Meet the team behind StartLine — Australia's fitness event calendar.",
+      "Meet the team behind Startline — Australia's fitness event calendar.",
     images: ["/images/about/about-hero.jpg"],
   },
   alternates: {
@@ -35,7 +35,7 @@ const founders = [
   {
     name: "Lachlan Martin",
     initials: "LM",
-    bio: "Lachlan brings a lifelong passion for fitness and competition to StartLine. With experience building products that connect communities, he drives the vision and strategy behind the platform.",
+    bio: "Lachlan brings a lifelong passion for fitness and competition to Startline. With experience building products that connect communities, he drives the vision and strategy behind the platform.",
   },
   {
     name: "Nathan Sweet",
@@ -45,12 +45,12 @@ const founders = [
   {
     name: "Hugo Shrowder",
     initials: "HS",
-    bio: "Hugo shapes the athlete experience with a sharp eye for design and detail. He ensures every interaction on StartLine feels fast, precise, and purposeful.",
+    bio: "Hugo shapes the athlete experience with a sharp eye for design and detail. He ensures every interaction on Startline feels fast, precise, and purposeful.",
   },
   {
     name: "Noah Helu",
     initials: "NH",
-    bio: "Noah brings a competitive drive and deep understanding of the athlete journey to StartLine. He focuses on building the tools that make event registration and management effortless.",
+    bio: "Noah brings a competitive drive and deep understanding of the athlete journey to Startline. He focuses on building the tools that make event registration and management effortless.",
   },
 ];
 
@@ -76,7 +76,7 @@ export default function AboutPage() {
             Built for the <span className="text-primary">start line.</span>
           </h1>
           <p className="font-headline text-sm sm:text-base font-medium text-muted max-w-xl leading-relaxed mt-3">
-            StartLine is Australia&apos;s fitness event calendar. We connect
+            Startline is Australia&apos;s fitness event calendar. We connect
             athletes with the races, competitions, and communities that push them
             further.
           </p>
@@ -90,7 +90,7 @@ export default function AboutPage() {
             Founders
           </p>
           <h2 className="font-headline text-[32px] sm:text-4xl font-black italic leading-none tracking-tighter text-light mb-4">
-            Meet the team behind <em className="text-primary not-italic">StartLine.</em>
+            Meet the team behind <em className="text-primary not-italic">Startline.</em>
           </h2>
           <p className="text-[15px] text-muted leading-relaxed">
             Three people who share a belief that finding your next challenge
@@ -142,7 +142,7 @@ export default function AboutPage() {
             </h2>
             <p className="text-[15px] text-muted leading-relaxed">
               We believe the hardest part of any event is showing up at the
-              start line — not finding one to enter. StartLine brings every
+              start line — not finding one to enter. Startline brings every
               fitness event in Australia into one place so you can discover,
               compare, and register in minutes, not hours.
             </p>

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
 
   try {
     await resend.emails.send({
-      from: "StartLine Contact <events@startlineau.com>",
+      from: "Startline Contact <events@startlineau.com>",
       to: ADMIN_EMAIL,
       replyTo: email,
       subject: `[Contact] ${subject}`,

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: Request) {
     <table width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;margin:0 auto;background:#1D1D1D;border:1px solid #2A2A2A;border-radius:12px;">
       <tr>
         <td style="padding:28px 32px 8px;">
-          <p style="margin:0 0 4px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.2em;color:#B3E153;">StartLine Feedback</p>
+          <p style="margin:0 0 4px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.2em;color:#B3E153;">Startline Feedback</p>
           <h1 style="margin:0 0 4px;font-size:24px;font-weight:700;color:#F5F7FA;">${escapeHtml(title)}</h1>
           <p style="margin:0 0 28px;font-size:12px;color:#6E737B;">Ref ${ref}</p>
         </td>
@@ -82,7 +82,7 @@ export async function POST(request: Request) {
   const resend = new Resend(resendApiKey);
 
   const { data, error } = await resend.emails.send({
-    from:    "StartLine <noreply@startlineau.com>",
+    from:    "Startline <noreply@startlineau.com>",
     to:      ADMIN_EMAIL,
     replyTo,
     subject: `[${escapeHtml(type)}] ${escapeHtml(title)} — ${ref}`,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,8 +19,8 @@ export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
 
   title: {
-    default:  "StartLine - Find Your Next Race",
-    template: "%s | StartLine",
+    default:  "Startline - Find Your Next Race",
+    template: "%s | Startline",
   },
   description:
     "Discover fitness racing, CrossFit, running and hybrid fitness events across Australia. Find, compare and register for competitions near you.",
@@ -40,8 +40,8 @@ export const metadata: Metadata = {
 
   openGraph: {
     type:        "website",
-    siteName:    "StartLine",
-    title:       "StartLine - Find Your Next Race",
+    siteName:    "Startline",
+    title:       "Startline - Find Your Next Race",
     description:
       "Discover fitness racing, CrossFit, running and hybrid fitness events across Australia.",
     url:         SITE_URL,
@@ -50,14 +50,14 @@ export const metadata: Metadata = {
         url:    "/site-preview.png",
         width:  1200,
         height: 630,
-        alt:    "StartLine - Australia's fitness event calendar",
+        alt:    "Startline - Australia's fitness event calendar",
       },
     ],
   },
 
   twitter: {
     card:        "summary_large_image",
-    title:       "StartLine - Find Your Next Race",
+    title:       "Startline - Find Your Next Race",
     description: "Discover fitness racing, CrossFit, running and hybrid fitness events across Australia.",
     images:      ["/site-preview.png"],
   },

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
             <Link href="/" className="inline-flex items-center mb-3">
               <Image
                 src="/images/logo-title.svg"
-                alt="StartLine"
+                alt="Startline"
                 width={130}
                 height={34}
                 className="h-7 w-auto"
@@ -119,7 +119,7 @@ export default function Footer() {
 
         <div className="border-t border-dark-lighter pt-5">
           <p className="font-headline text-[10px] font-medium uppercase tracking-widest text-muted">
-            &copy; {new Date().getFullYear()} StartLine. All Rights Reserved.
+            &copy; {new Date().getFullYear()} Startline. All Rights Reserved.
           </p>
         </div>
       </div>

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -13,7 +13,7 @@ test.describe("about page", () => {
 test.describe("homepage", () => {
   test("renders with expected title", async ({ page }) => {
     await goToHomepage(page);
-    await expect(page).toHaveTitle(/StartLine/i);
+    await expect(page).toHaveTitle(/Startline/i);
   });
 
   test("homepage visual snapshot", async ({ page }) => {

--- a/terraform/state.tf
+++ b/terraform/state.tf
@@ -1,4 +1,4 @@
-# S3 bucket holding Terraform state for StartLine infra.
+# S3 bucket holding Terraform state for Startline infra.
 #
 # Bootstrap order (one-time):
 #   1. Apply with current local backend to create this bucket.


### PR DESCRIPTION
## Changes

**Security:** Rotated 6 API keys exposed in CI logs (Closes #121):
- Infracost, Argos, Cloudflare, Resend, Gitleaks, GitHub PAT
- Skips DigitalOcean token
- All updated in `startline/ci-bootstrap` SM secret

**`load-env` action fix:** Added `bootstrap-export-keys` input. Instead of dumping all bootstrap secret keys to `$GITHUB_ENV`, only exports the specific keys each workflow needs:

| Workflow | Keys exported |
|---|---|
| `ci.yml` (gitleaks) | `GITLEAKS_LICENSE` |
| `ci.yml` (e2e) | *(none)* |
| `terraform-plan.yml` | `INFRACOST_API_KEY` |
| `terraform-apply.yml` | *(none)* |
| `deploy.yml` | *(none)* |
| `argos-baseline.yml` | `ARGOS_TOKEN` |

**Spelling consistency:** Normalised `StartLine` → `Startline` across 8 source files.