### PR TITLE
fix: stop blanket-exporting bootstrap keys to GITHUB_ENV

### DIFF
--- a/.github/actions/load-env/action.yml
+++ b/.github/actions/load-env/action.yml
@@ -7,6 +7,9 @@ inputs:
   environment:
     description: "environment name (prod, etc.)"
     default: "prod"
+  bootstrap-export-keys:
+    description: "Comma-separated list of bootstrap keys to export as env vars (empty = none)"
+    default: ""
 
 runs:
   using: "composite"
@@ -32,9 +35,17 @@ runs:
           echo "::add-mask::$value"
         done < <(echo "$BOOTSTRAP" | jq -r 'values[]')
 
-        # Export to env (raw + TF_VAR_ prefixed)
-        echo "$BOOTSTRAP" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
-        echo "$BOOTSTRAP" | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value)"' >> "$GITHUB_ENV"
+        # Export only whitelisted bootstrap keys (raw + TF_VAR_ prefixed)
+        if [ -n "${{ inputs.bootstrap-export-keys }}" ]; then
+          IFS=',' read -ra KEYS <<< "${{ inputs.bootstrap-export-keys }}"
+          for key in "${KEYS[@]}"; do
+            val=$(echo "$BOOTSTRAP" | jq -r --arg k "$key" '.[$k] // empty')
+            if [ -n "$val" ]; then
+              echo "$key=$val" >> "$GITHUB_ENV"
+              echo "TF_VAR_$key=$val" >> "$GITHUB_ENV"
+            fi
+          done
+        fi
 
         APP=$(aws secretsmanager get-secret-value \
           --secret-id startline/${{ inputs.environment }}/app \

--- a/.github/workflows/argos-baseline.yml
+++ b/.github/workflows/argos-baseline.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: prod
+          bootstrap-export-keys: ARGOS_TOKEN
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: prod
+          bootstrap-export-keys: GITLEAKS_LICENSE
       - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -125,6 +126,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: prod
+          bootstrap-export-keys: ""
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           environment: prod
+          bootstrap-export-keys: ""
 
       - name: Resolve Amplify app ID
         id: amplify-app

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           environment: prod
+          bootstrap-export-keys: ""
 
       - name: Install Terraform
         shell: bash

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: prod
+          bootstrap-export-keys: INFRACOST_API_KEY
 
       - name: Install Terraform
         shell: bash


### PR DESCRIPTION
## Changes

**Security:** Rotated 6 API keys exposed in CI logs (Closes #121):
- Infracost, Argos, Cloudflare, Resend, Gitleaks, GitHub PAT
- Skips DigitalOcean token
- All updated in `startline/ci-bootstrap` SM secret

**`load-env` action fix:** Added `bootstrap-export-keys` input. Instead of dumping all bootstrap secret keys to `$GITHUB_ENV`, only exports the specific keys each workflow needs:

| Workflow | Keys exported |
|---|---|
| `ci.yml` (gitleaks) | `GITLEAKS_LICENSE` |
| `ci.yml` (e2e) | *(none)* |
| `terraform-plan.yml` | `INFRACOST_API_KEY` |
| `terraform-apply.yml` | *(none)* |
| `deploy.yml` | *(none)* |
| `argos-baseline.yml` | `ARGOS_TOKEN` |