### PR TITLE
fix: enable PR previews for Amplify app

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -118,6 +118,16 @@ resource "aws_amplify_app" "this" {
   }
 }
 
+resource "null_resource" "enable_pr_previews" {
+  triggers = {
+    app_id = aws_amplify_app.this.id
+  }
+
+  provisioner "local-exec" {
+    command = "aws amplify update-app --app-id ${aws_amplify_app.this.id} --enable-pull-request-preview"
+  }
+}
+
 locals {
   environments = {
     prod = {


### PR DESCRIPTION
## Summary

PR previews are not working. The Terraform config at `terraform/main.tf` set `enable_pull_request_preview` only inside `auto_branch_creation_config` (which applies to branches matching `["main"]` only), never at the app level. Result: no `pr-*` environments exist, even though recent PRs like #164 and #165 targeted staging.

## Changes

- **`terraform/main.tf`** — Added `null_resource "enable_pr_previews"` that calls `aws amplify update-app --enable-pull-request-preview` via `local-exec` provisioner. This is needed because the Terraform AWS provider v5.x doesn't expose the Amplify API's app-level `enablePullRequestPreview` parameter as a top-level attribute on `aws_amplify_app`.

  The `null_resource` triggers on the app ID, so it runs on first apply (enabling PR previews) and is a no-op on subsequent applies.