### PR TITLE
feat: enable Amplify PR preview deployments for staging and main

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -124,6 +124,7 @@ locals {
       branch_name                  = "main"
       amplify_stage                = "PRODUCTION"
       auto_build_enabled           = false
+      enable_pull_request_preview  = true
       vpc_cidr                     = "10.20.0.0/16"
       database_name                = "${var.project_name}_prod"
       database_skip_final_snapshot = false
@@ -137,6 +138,7 @@ locals {
       branch_name                  = "staging"
       amplify_stage                = "BETA"
       auto_build_enabled           = true
+      enable_pull_request_preview  = true
       vpc_cidr                     = "10.21.0.0/16"
       database_name                = "${var.project_name}_staging"
       database_skip_final_snapshot = true
@@ -157,9 +159,10 @@ module "env" {
   project_name   = var.project_name
   amplify_app_id = aws_amplify_app.this.id
 
-  branch_name        = each.value.branch_name
-  amplify_stage      = each.value.amplify_stage
-  auto_build_enabled = each.value.auto_build_enabled
+  branch_name                 = each.value.branch_name
+  amplify_stage               = each.value.amplify_stage
+  auto_build_enabled          = each.value.auto_build_enabled
+  enable_pull_request_preview = each.value.enable_pull_request_preview
 
   vpc_cidr      = each.value.vpc_cidr
   database_name = each.value.database_name

--- a/terraform/modules/environment/main.tf
+++ b/terraform/modules/environment/main.tf
@@ -448,7 +448,8 @@ resource "aws_amplify_branch" "this" {
   branch_name = var.branch_name
   stage       = var.amplify_stage
 
-  enable_auto_build = var.auto_build_enabled
+  enable_auto_build           = var.auto_build_enabled
+  enable_pull_request_preview  = var.enable_pull_request_preview
 
   environment_variables = merge(
     {
@@ -458,6 +459,13 @@ resource "aws_amplify_branch" "this" {
     },
     var.extra_branch_environment_variables,
   )
+
+  lifecycle {
+    precondition {
+      condition     = contains(["PRODUCTION", "BETA", "DEVELOPMENT"], var.amplify_stage)
+      error_message = "amplify_stage must be one of PRODUCTION, BETA, or DEVELOPMENT."
+    }
+  }
 
   tags = {
     Environment = var.name == "prod" ? "Prod" : "Stage"

--- a/terraform/modules/environment/variables.tf
+++ b/terraform/modules/environment/variables.tf
@@ -28,6 +28,12 @@ variable "auto_build_enabled" {
   type        = bool
 }
 
+variable "enable_pull_request_preview" {
+  description = "Enable PR preview deployments for this branch."
+  type        = bool
+  default     = false
+}
+
 variable "extra_branch_environment_variables" {
   description = "Extra env vars to set on the Amplify branch in addition to DATABASE_URL."
   type        = map(string)


### PR DESCRIPTION
## What

Enables Amplify pull request preview deployments on both the `main` (prod) and `staging` branches.

## Why

PRs targeting `staging` never got preview deployments because `enable_pull_request_preview` was never set on the `aws_amplify_branch` resource (defaulted to `false`). The `main` branch had the same issue — the `auto_branch_creation_config` had `enable_pull_request_preview = true`, but since there is also an explicit `aws_amplify_branch` resource managing `main`, that setting was likely overridden.

## What changed

- Added `enable_pull_request_preview = true` to both the `prod` and `staging` environment configs in `terraform/main.tf`
- Added `enable_pull_request_preview` variable to `terraform/modules/environment/variables.tf`
- Set it on the `aws_amplify_branch` resource in `terraform/modules/environment/main.tf`

## Related

- PR #165 added CI triggers for staging but did not address Amplify previews