### PR TITLE
fix: run Argos baseline on staging branch

### DIFF
--- a/.github/workflows/argos-baseline.yml
+++ b/.github/workflows/argos-baseline.yml
@@ -2,7 +2,7 @@ name: Argos Baseline
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
 
 permissions:
   id-token: write


### PR DESCRIPTION
Argos baseline workflow only ran on main. Without a staging baseline, visual regression comparisons fail for PRs targeting staging.

Merged in PR #172 but the argos commit came after merge — reopening with just the remaining change.