### PR TITLE
feat: restrict PRs to main to only come from staging

### DIFF
--- a/.github/workflows/source-branch-check.yml
+++ b/.github/workflows/source-branch-check.yml
@@ -1,0 +1,20 @@
+name: Source Branch Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify source branch
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "❌ Only pull requests from the 'staging' branch into 'main' are permitted."
+            exit 1
+          fi
+          echo "✅ Source branch is staging — allowed."


### PR DESCRIPTION
Creates the source-branch-check workflow that provides the `Source Branch Check / check-source` required check on `main`. Fails if the PR source branch is not `staging`.

Also enables admin enforcement on `staging` via the GitHub API so admins cannot push directly.