### PR TITLE
Repurpose main → staging, create prod branch

### DIFF
--- a/.github/workflows/argos-baseline.yml
+++ b/.github/workflows/argos-baseline.yml
@@ -2,7 +2,7 @@ name: Argos Baseline
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main]
 
 permissions:
   id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, staging]
+    branches: [main, prod]
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - prod
 
 concurrency:
   group: ${{ github.ref_name }}
@@ -18,13 +19,16 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      AMPLIFY_BRANCH: ${{ github.ref_name }}
+      ENV: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
     steps:
       - uses: actions/checkout@v5
 
       - uses: ./.github/actions/load-env
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
-          environment: prod
+          environment: ${{ env.ENV }}
           bootstrap-export-keys: ""
 
       - name: Resolve Amplify app ID
@@ -43,7 +47,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.sha,
-              environment: 'prod',
+              environment: process.env.ENV,
               description: context.payload.head_commit?.message || '',
               auto_merge: false,
               required_contexts: [],
@@ -62,17 +66,17 @@ jobs:
         run: |
           JOB_ID=$(aws amplify start-job \
             --app-id ${{ steps.amplify-app.outputs.app_id }} \
-            --branch-name main \
+            --branch-name $AMPLIFY_BRANCH \
             --job-type RELEASE \
             --commit-id ${{ github.sha }} \
             --query 'jobSummary.jobId' --output text)
           echo "amplify_job_id=$JOB_ID" >> $GITHUB_OUTPUT
 
-          echo "Polling Amplify build $JOB_ID on main..."
+          echo "Polling Amplify build $JOB_ID on $AMPLIFY_BRANCH..."
           for i in $(seq 1 60); do
             STATUS=$(aws amplify get-job \
               --app-id ${{ steps.amplify-app.outputs.app_id }} \
-              --branch-name main \
+              --branch-name $AMPLIFY_BRANCH \
               --job-id "$JOB_ID" \
               --query 'job.summary.status' --output text)
             echo "[$i/60] $STATUS"
@@ -92,11 +96,13 @@ jobs:
         with:
           script: |
             const state = '${{ job.status }}' === 'success' ? 'success' : 'failure'
+            const env = process.env.ENV
+            const url = env === 'prod' ? 'https://startlineau.com' : `https://${env}.startlineau.com`
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               deployment_id: parseInt('${{ steps.deployment.outputs.deployment_id }}'),
               state: state,
-              environment_url: 'https://startlineau.com',
+              environment_url: url,
               log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             })

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -3,7 +3,7 @@ name: Terraform apply
 on:
   workflow_dispatch:
   push:
-    branches: [main, staging]
+    branches: [main, prod]
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform-*.yml'
@@ -25,7 +25,7 @@ jobs:
       - uses: ./.github/actions/load-env
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
-          environment: ${{ github.ref_name == 'main' && 'prod' || 'staging' }}
+          environment: ${{ github.ref_name == 'main' && 'staging' || 'prod' }}
           bootstrap-export-keys: ""
 
       - name: Install Terraform
@@ -38,5 +38,5 @@ jobs:
         shell: bash
         run: |
           terraform init -input=false
-          terraform apply -auto-approve -input=false -var="target_environment=${{ github.ref_name == 'main' && 'all' || 'staging' }}"
+          terraform apply -auto-approve -input=false -var="target_environment=${{ github.ref_name == 'main' && 'all' || 'prod' }}"
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -2,7 +2,7 @@ name: Terraform plan
 
 on:
   pull_request:
-    branches: [main, staging]
+    branches: [main, prod]
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform-*.yml'
@@ -65,7 +65,7 @@ jobs:
         run: |
           terraform init -input=false
           terraform validate -no-tests
-          terraform plan -out=/tmp/pr.tfplan -no-color -lock=false -input=false -var="target_environment=${{ github.base_ref == 'main' && 'all' || 'staging' }}" 2>&1 | tee /tmp/plan-output.txt || true
+          terraform plan -out=/tmp/pr.tfplan -no-color -lock=false -input=false -var="target_environment=${{ github.base_ref == 'main' && 'all' || 'prod' }}" 2>&1 | tee /tmp/plan-output.txt || true
 
       - name: Generate Infracost diff
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,15 +77,16 @@ All worktrees under `~/.herdr/worktrees/startline/`. Docker infra (PostgreSQL, M
 
 Infra in `terraform/`:
 
+
 Terraform uses a unified state with a `target_environment` variable (`all`/`prod`/`staging`) to scope applies:
-- **Push to `staging`** → `terraform apply -var=target_environment=staging` (staging resources only)
 - **Push to `main`** → `terraform apply -var=target_environment=all` (both environments)
+- **Push to `prod`** → `terraform apply -var=target_environment=prod` (prod resources only) — although prod is protected, so this is via PR merge
 - **PRs** → `terraform plan` runs with the scope matching the base branch
 
 | Workflow | Trigger | Scope |
 |---|---|---|
-| `terraform-plan.yml` | PR to `main` or `staging` | Plan matching base branch |
-| `terraform-apply.yml` | Push to `main` or `staging` | `all` on main, `staging` on staging |
+| `terraform-plan.yml` | PR to `main` or `prod` | Plan matching base branch |
+| `terraform-apply.yml` | Push to `main` or `prod` | `all` on main, `prod` on prod |
 
 `ci.yml` runs lint, typecheck, build, test, e2e on PRs (non-blocking, informational).
 
@@ -97,15 +98,16 @@ Amplify build spec fetches from SM at build time — individual key rotations do
 
 Two environments managed by Terraform (`main.tf` → `local.environments`). PR previews enabled on both branches:
 
-| Environment | Branch | Amplify stage | Auto-build | PR previews | DB behavior |
-|---|---|---|---|---|---|
-| `prod` | `main` | PRODUCTION | No (GH Actions triggers) | Yes | Migrate, no seed |
-| `staging` | `staging` | BETA | Yes | Yes | Migrate + seed |
-| PR previews | feature branches | — | — | Yes | Uses staging DB, no migrate/seed, auth bypass |
+| Environment | Branch | Build behavior |
+|---|---|---|
+| `prod` | `prod` | Migrate, no seed |
+| `staging` | `main` | Migrate + seed |
+| PR to `main` | preview | Staging resources, auth bypass |
+| PR to `prod` | preview | Prod resources, auth bypass |
 
-The build spec (`local.build_spec`) selects the SM secret based on `AWS_BRANCH_NAME`:
-- `main` → `startline/prod/app`
-- everything else → `startline/staging/app`
+The `ENV` env var is set per Amplify branch (`prod` → `prod`, `main` → `staging`). PR previews inherit the target branch's `ENV` value. The build spec uses `$ENV` to select the Secrets Manager secret (`startline/$ENV/app`).
+
+The `ENV` env var is set per Amplify branch (`prod` → `prod`, `main` → `staging`). PR previews inherit the target branch's `ENV` value. The build spec uses `$ENV` to select the Secrets Manager secret (`startline/$ENV/app`).
 
 ## Design system
 
@@ -160,7 +162,7 @@ Use `-s=<name>` for isolated sessions (e.g., `-s=customer`, `-s=organiser`). Pas
 
 Use `gh` CLI — the MCP `server-github` fails for this private org repo.
 
-**`main` is protected.** Never push directly — always use a PR.
+**`main` and `prod` are protected.** Never push directly — always use a PR.
 
 ### Pre-commit gate
 

--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -36,6 +36,7 @@ data "aws_iam_policy_document" "terraform_ci_assume" {
       variable = "token.actions.githubusercontent.com:sub"
       values = [
         "repo:${var.github_repository}:*:refs/heads/main",
+        "repo:${var.github_repository}:*:refs/heads/prod",
       ]
     }
   }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,8 +62,7 @@ locals {
             - >
               corepack enable && pnpm install --frozen-lockfile
               && npx prisma generate
-              && export ENV=staging
-              && if [ "$AWS_BRANCH_NAME" = "main" ]; then export ENV=prod; fi
+              && [ -n "$ENV" ] || export ENV=staging
               && aws secretsmanager get-secret-value
               --secret-id startline/$ENV/app
               --query SecretString --output text
@@ -99,7 +98,7 @@ resource "aws_amplify_app" "this" {
 
   enable_auto_branch_creation = true
 
-  auto_branch_creation_patterns = ["main"]
+  auto_branch_creation_patterns = ["main", "prod"]
 
   auto_branch_creation_config {
     enable_pull_request_preview = true
@@ -131,7 +130,7 @@ resource "null_resource" "enable_pr_previews" {
 locals {
   environments = {
     prod = {
-      branch_name                  = "main"
+      branch_name                  = "prod"
       amplify_stage                = "PRODUCTION"
       auto_build_enabled           = false
       enable_pull_request_preview  = true
@@ -145,7 +144,7 @@ locals {
       enable_daily_stop            = false
     }
     staging = {
-      branch_name                  = "staging"
+      branch_name                  = "main"
       amplify_stage                = "BETA"
       auto_build_enabled           = true
       enable_pull_request_preview  = true
@@ -198,7 +197,11 @@ module "env" {
   cognito_deletion_protection = each.value.cognito_deletion_protection
 
   resend_api_key = local.bootstrap.resend_api_key
-  site_url       = each.key == "prod" ? each.value.site_url : "https://${each.value.branch_name}.${aws_amplify_app.this.default_domain}"
+  site_url       = each.value.site_url
+
+  extra_branch_environment_variables = {
+    ENV = each.key == "prod" ? "prod" : "staging"
+  }
 
   bucket_cors_allowed_origins = each.value.bucket_cors_allowed_origins
 

--- a/terraform/modules/environment/main.tf
+++ b/terraform/modules/environment/main.tf
@@ -449,7 +449,7 @@ resource "aws_amplify_branch" "this" {
   stage       = var.amplify_stage
 
   enable_auto_build           = var.auto_build_enabled
-  enable_pull_request_preview  = var.enable_pull_request_preview
+  enable_pull_request_preview = var.enable_pull_request_preview
 
   environment_variables = merge(
     {


### PR DESCRIPTION
Closes #178

## Changes

- **Branch swap:** main → staging (BETA), prod → PRODUCTION
- **Build spec:** uses branch-level `ENV` env var instead of hardcoded branch check. PR previews inherit target branch's `ENV`.
- **PR previews on prod:** enabled via `enable_pull_request_preview` on the Amplify branch resource
- **Deploy workflow:** triggers on push to both main and prod. Uses `github.ref_name` and dynamic `ENV` for branch/environment.
- **GitHub OIDC:** prod branch added to admin role trust condition
- **CI/Terraform plan:** now run on PRs to prod too
- **AGENTS.md:** updated branch mapping and docs

## Manual steps already done

- [x] Created `prod` branch from `origin/main` and pushed
- [x] Protected `prod` branch (matching main's settings)
- [x] Deleted old remote `staging` branch

## After merge

Terraform apply will:
1. Reconfigure `main` Amplify branch → BETA (staging)
2. Create `prod` Amplify branch → PRODUCTION
3. First `prod` deploy needs manual trigger via `git push origin prod`