### PR TITLE
CI: use staging env for e2e tests; add missing Cognito vars to prod SM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       - uses: ./.github/actions/load-env
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
-          environment: prod
+          environment: staging
           bootstrap-export-keys: ""
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: staging
-          bootstrap-export-keys: ""
+          bootstrap-export-keys: "STRIPE_SECRET_KEY"
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: staging
-          bootstrap-export-keys: "STRIPE_SECRET_KEY"
+          bootstrap-export-keys: "STRIPE_SECRET_KEY,ARGOS_TOKEN"
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -22,7 +22,7 @@ export async function selectStateFilter(page: Page, state: string): Promise<void
   }
 }
 
-export async function organiserLogin(page: Page, email = "test.organiser@startlineau.com"): Promise<void> {
+export async function organiserLogin(page: Page, email = "organiser@startline.test"): Promise<void> {
   // Sign-in is now a modal on the main site — not on /organiser
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
@@ -56,7 +56,7 @@ export async function organiserLogin(page: Page, email = "test.organiser@startli
   await page.waitForURL("**/organiser/dashboard**", { timeout: 30000 });
 }
 
-export async function adminLogin(page: Page, email = "admin@startlineau.com"): Promise<void> {
+export async function adminLogin(page: Page, email = "admin@startline.test"): Promise<void> {
   // Navigate to login page - may need retries for Turbopack cold start
   for (let attempt = 0; attempt < 3; attempt++) {
     try {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: 1,
-  workers: process.env.CI ? 2 : 4,
+  workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI
     ? [
         ["list"],


### PR DESCRIPTION
Now that the Terraform apply has granted the CI role access to `startline/staging/*` secrets, switch the e2e job back to `environment: staging` so it uses the non-prod Cognito pool with seed users.

Also added the missing `NEXT_PUBLIC_COGNITO_USER_POOL_ID` and `NEXT_PUBLIC_COGNITO_CLIENT_ID` to `startline/prod/app` Secrets Manager entry (prod pool: `ap-southeast-2_2yiwzeO39`).