### PR TITLE
Move admin portal to admin.startlineau.com

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Next.js 15 (App Router) fitness event discovery platform. Three portals:
 |---|---|---|
 | `(user)/` | startlineau.com | Public event browsing |
 | `organiser/` | organiser.startlineau.com | Event management |
-| `admin/` | organiser.startlineau.com | Approvals, org management |
+| `admin/` | admin.startlineau.com | Approvals, org management |
 
 ## Development
 
@@ -185,7 +185,7 @@ Configured in `opencode.json`: stripe, resend, aws, cloudflare. Skills listed be
 - **Scripts table:** Missing `typecheck`, `prisma:generate`, `test:watch`, `stripe:*`, `start`, `test:registration`, `staging:db:start`.
 - **`prisma:migrate`:** README says "Apply Prisma migrations" — the script actually runs `prisma migrate dev` (dev-only, creates migrations), not `prisma migrate deploy`.
 - **Site state:** README describes a live event browsing platform; the site is currently in waitlist mode.
-- **Admin domain:** Implies three separate domains; admin actually shares `organiser.startlineau.com` as a path prefix.
+- **Admin domain:** Implies three separate domains; admin previously shared `organiser.startlineau.com` as a path prefix but now has its own `admin.startlineau.com`.
 
 ## Idempotency
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Startline helps performance-driven fitness individuals discover competitive even
 Three portals, domain-routed in production:
 - **startlineau.com** — public event browsing
 - **organiser.startlineau.com** — event management
-- **Admin** — approval workflow, organiser management
+- **admin.startlineau.com** — approval workflow, organiser management
 
 ## Getting Started
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -31,6 +31,7 @@ const ADMIN_PROTECTED = [
 
 const USER_DOMAIN = "startlineau.com";
 const ORGANISER_DOMAIN = "organiser.startlineau.com";
+const ADMIN_DOMAIN = "admin.startlineau.com";
 
 async function getVerifiedPayload(req: NextRequest): Promise<JWTPayload | null> {
   const lastAuthUser = req.cookies.get(
@@ -81,23 +82,26 @@ export async function middleware(req: NextRequest) {
       return NextResponse.next();
     }
 
-    if (ADMIN_PROTECTED.some((p) => pathname.startsWith(p))) {
-      const payload = await getVerifiedPayload(req);
-      if (!payload || !isAdmin(payload)) {
-        return NextResponse.redirect(new URL("/admin/login", req.url));
-      }
-      return NextResponse.next();
-    }
-
     if (
       !pathname.startsWith("/organiser") &&
-      !pathname.startsWith("/admin") &&
       !pathname.startsWith("/_next") &&
       !pathname.startsWith("/api") &&
       !pathname.startsWith("/images") &&
       !pathname.startsWith("/favicon")
     ) {
       return NextResponse.redirect(new URL("https://startlineau.com"));
+    }
+
+    return NextResponse.next();
+  }
+
+  if (host === ADMIN_DOMAIN) {
+    if (ADMIN_PROTECTED.some((p) => pathname.startsWith(p))) {
+      const payload = await getVerifiedPayload(req);
+      if (!payload || !isAdmin(payload)) {
+        return NextResponse.redirect(new URL("/admin/login", req.url));
+      }
+      return NextResponse.next();
     }
 
     return NextResponse.next();

--- a/terraform/cloudflare-dns.tf
+++ b/terraform/cloudflare-dns.tf
@@ -194,6 +194,16 @@ resource "cloudflare_record" "organiser" {
 
 # ===== Upload CDN (CloudFront) =====
 
+resource "cloudflare_record" "admin" {
+  count   = local.deploy_amplify_dns ? 1 : 0
+  zone_id = cloudflare_zone.primary.id
+  name    = "admin"
+  type    = "CNAME"
+  ttl     = 1
+  content = local.amplify_admin_target
+  proxied = true
+}
+
 resource "cloudflare_record" "cdn" {
   count   = local.deploy_amplify_dns ? 1 : 0
   zone_id = cloudflare_zone.primary.id

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -140,6 +140,7 @@ locals {
   amplify_apex_target      = try(local.amplify_sub_domains_by_prefix[""], "")
   amplify_www_target       = try(local.amplify_sub_domains_by_prefix["www"], "")
   amplify_organiser_target = try(local.amplify_sub_domains_by_prefix["organiser"], "")
+  amplify_admin_target     = try(local.amplify_sub_domains_by_prefix["admin"], "")
 
   # certificate_verification_dns_record looks like
   # "_xxx.startlineau.com. CNAME _yyy.acm-validations.aws."
@@ -191,6 +192,16 @@ resource "aws_route53_record" "organiser_cname" {
   type            = "CNAME"
   ttl             = 300
   records         = [local.amplify_organiser_target]
+  allow_overwrite = true
+}
+
+resource "aws_route53_record" "admin_cname" {
+  count           = local.deploy_amplify_dns ? 1 : 0
+  zone_id         = aws_route53_zone.primary.zone_id
+  name            = "admin.startlineau.com"
+  type            = "CNAME"
+  ttl             = 300
+  records         = [local.amplify_admin_target]
   allow_overwrite = true
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -129,7 +129,7 @@ locals {
       database_skip_final_snapshot = false
       database_deletion_protection = true
       cognito_deletion_protection  = true
-      bucket_cors_allowed_origins  = ["https://startlineau.com", "https://organiser.startlineau.com"]
+      bucket_cors_allowed_origins  = ["https://startlineau.com", "https://organiser.startlineau.com", "https://admin.startlineau.com"]
       site_url                     = "https://startlineau.com"
       enable_daily_stop            = false
     }
@@ -222,5 +222,10 @@ resource "aws_amplify_domain_association" "this" {
   sub_domain {
     branch_name = module.env["prod"].branch_name
     prefix      = "organiser"
+  }
+
+  sub_domain {
+    branch_name = module.env["prod"].branch_name
+    prefix      = "admin"
   }
 }


### PR DESCRIPTION
Moves the admin portal from `organiser.startlineau.com/admin/*` to its own `admin.startlineau.com/admin/*` domain.

### Changes

- **middleware.ts** — Added `ADMIN_DOMAIN` constant + new host check block for `admin.startlineau.com` with JWT + admin group auth. Removed admin path handling from the organiser domain block (organiser domain will no longer serve admin routes).
- **terraform/dns.tf** — Added `amplify_admin_target` local + `admin_cname` Route53 CNAME record pointing to Amplify CloudFront.
- **terraform/cloudflare-dns.tf** — Added `admin` CNAME record (proxied).
- **terraform/main.tf** — Added `prefix = "admin"` subdomain in `aws_amplify_domain_association`; added `https://admin.startlineau.com` to prod S3 CORS origins.
- **AGENTS.md, README.md** — Updated domain tables to reflect three separate domains.

### Not changed

- `next.config.ts` — admin portal only displays Stripe status data, doesn't load Stripe.js, so existing CSP is sufficient.
- No app route changes — `app/admin/*` works under any domain the middleware routes to it.

Closes #(add issue number if applicable)