### PR TITLE
Tighten secret leak prevention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: ['*']
 
 permissions:
   id-token: write
@@ -12,7 +14,7 @@ permissions:
 
 jobs:
   gitleaks:
-    continue-on-error: true
+    continue-on-error: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Closes secret leak found in #... (reported via conversation)

**Changes:**
- Gitleaks CI job now triggers on push to **all branches** (not just PRs to main)
-  removed from gitleaks — it now **blocks** on failure
- Pre-commit hook installed locally: runs 
- GitHub push protection enabled on the repo