### PR TITLE
Add CODEOWNERS file for PR approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @LachlanMartin


### PR DESCRIPTION
Requires code owner (LachlanMartin) approval on all PRs into `main` and `prod`.

Works with the branch protection rules already in place — .