### PR TITLE
Add legal and FAQ pages with footer links

### DIFF
--- a/app/(user)/cookies/page.tsx
+++ b/app/(user)/cookies/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Cookie Policy",
+  description:
+    "Startline Cookie Policy — how we use cookies and similar technologies on our platform.",
+  openGraph: {
+    title: "Cookie Policy | Startline",
+    description:
+      "How we use cookies and similar technologies on Startline.",
+    url: "/cookies",
+  },
+  alternates: {
+    canonical: "/cookies",
+  },
+};
+
+export default function CookiesPage() {
+  return (
+    <main className="min-h-screen bg-dark-darker">
+      <section className="max-w-[1440px] mx-auto px-4 sm:px-6 py-20 sm:py-28">
+        <div className="max-w-3xl">
+          <p className="font-headline text-[10px] font-bold uppercase tracking-[0.25em] text-primary mb-3.5">
+            Legal
+          </p>
+          <h1 className="font-headline text-[32px] sm:text-4xl font-black italic leading-none tracking-tighter text-light mb-4">
+            Cookie <span className="text-primary">Policy</span>
+          </h1>
+          <p className="text-[13px] text-muted-dark font-headline uppercase tracking-widest mb-10">
+            Last updated: 1 July 2026
+          </p>
+
+          <div className="space-y-8 text-[15px] text-muted leading-relaxed">
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                1. What Are Cookies
+              </h2>
+              <p>
+                Cookies are small text files stored on your device when you visit a
+                website. They help us make the platform work, remember your
+                preferences, and understand how you use Startline.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                2. How We Use Cookies
+              </h2>
+              <p>
+                We use essential cookies required for platform operation and security.
+                We also use functional cookies to remember your preferences, analytics
+                cookies to understand usage patterns, and authentication cookies to
+                keep you signed in.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                3. Third-Party Cookies
+              </h2>
+              <p>
+                We may use third-party services such as analytics providers and payment
+                processors that set their own cookies. These are governed by the
+                respective third-party privacy policies.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                4. Managing Cookies
+              </h2>
+              <p>
+                You can control cookies through your browser settings. Disabling
+                essential cookies may prevent the platform from functioning correctly.
+                Most browsers allow you to block or delete cookies through their
+                preferences menu.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                5. Changes
+              </h2>
+              <p>
+                We may update this Cookie Policy from time to time. Changes will be
+                posted on this page with an updated revision date.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                6. Contact
+              </h2>
+              <p>
+                For questions about our use of cookies, contact us at{" "}
+                <a href="mailto:privacy@startline.com.au" className="text-primary hover:underline">
+                  privacy@startline.com.au
+                </a>.
+              </p>
+            </section>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/(user)/faq/page.tsx
+++ b/app/(user)/faq/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "FAQ",
+  description:
+    "Frequently asked questions about Startline — how to register, manage your account, and more.",
+  openGraph: {
+    title: "FAQ | Startline",
+    description:
+      "Frequently asked questions about using Startline.",
+    url: "/faq",
+  },
+  alternates: {
+    canonical: "/faq",
+  },
+};
+
+const faqs = [
+  {
+    q: "What is Startline?",
+    a: "Startline is Australia's fitness event calendar. We help athletes discover, compare, and register for races, competitions, and fitness events across the country.",
+  },
+  {
+    q: "How do I register for an event?",
+    a: "Browse events on the platform, select one you're interested in, and click Register. You'll complete payment and receive a confirmation email with your event details.",
+  },
+  {
+    q: "Can I get a refund if I can't attend?",
+    a: "Refund policies are set by each event organiser. Check the event listing for their specific policy before registering. Contact the organiser directly for refund requests.",
+  },
+  {
+    q: "How do I create an account?",
+    a: "Click Sign In at the top of any page and select Create Account. You'll need an email address and a password. You can also sign in with passkeys on supported devices.",
+  },
+  {
+    q: "How do I become an organiser?",
+    a: "Visit the Become an Organiser page and follow the setup process. You'll need to provide your organisation details and agree to our Terms of Service.",
+  },
+  {
+    q: "Is my payment information secure?",
+    a: "Yes. All payments are processed securely through Stripe, a PCI-compliant payment processor. We never store your full payment details on our servers.",
+  },
+  {
+    q: "Can I edit or cancel my registration?",
+    a: "Contact the event organiser directly for changes to your registration. Their contact details are available on the event listing page.",
+  },
+  {
+    q: "How do I contact support?",
+    a: "Send us a message through the Feedback page or email support@startline.com.au. We aim to respond within 24 hours.",
+  },
+];
+
+export default function FAQPage() {
+  return (
+    <main className="min-h-screen bg-dark-darker">
+      <section className="max-w-[1440px] mx-auto px-4 sm:px-6 py-20 sm:py-28">
+        <div className="max-w-3xl">
+          <p className="font-headline text-[10px] font-bold uppercase tracking-[0.25em] text-primary mb-3.5">
+            Help
+          </p>
+          <h1 className="font-headline text-[32px] sm:text-4xl font-black italic leading-none tracking-tighter text-light mb-10">
+            Frequently Asked <span className="text-primary">Questions</span>
+          </h1>
+
+          <div className="space-y-6">
+            {faqs.map((faq, i) => (
+              <div key={i} className="border border-dark-lighter rounded-xl p-6 bg-dark">
+                <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                  {faq.q}
+                </h2>
+                <p className="text-[15px] text-muted leading-relaxed">
+                  {faq.a}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/(user)/privacy/page.tsx
+++ b/app/(user)/privacy/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "Startline Privacy Policy — how we collect, use, and protect your personal information.",
+  openGraph: {
+    title: "Privacy Policy | Startline",
+    description:
+      "How we collect, use, and protect your personal information.",
+    url: "/privacy",
+  },
+  alternates: {
+    canonical: "/privacy",
+  },
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-dark-darker">
+      <section className="max-w-[1440px] mx-auto px-4 sm:px-6 py-20 sm:py-28">
+        <div className="max-w-3xl">
+          <p className="font-headline text-[10px] font-bold uppercase tracking-[0.25em] text-primary mb-3.5">
+            Legal
+          </p>
+          <h1 className="font-headline text-[32px] sm:text-4xl font-black italic leading-none tracking-tighter text-light mb-4">
+            Privacy <span className="text-primary">Policy</span>
+          </h1>
+          <p className="text-[13px] text-muted-dark font-headline uppercase tracking-widest mb-10">
+            Last updated: 1 July 2026
+          </p>
+
+          <div className="space-y-8 text-[15px] text-muted leading-relaxed">
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                1. Information We Collect
+              </h2>
+              <p>
+                We collect information you provide directly to us, including your name,
+                email address, phone number, and billing information when you register
+                for an account or purchase event entries. We also collect information
+                about your use of the platform, including events viewed, registrations,
+                and preferences.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                2. How We Use Your Information
+              </h2>
+              <p>
+                We use your information to provide and improve our services, process
+                registrations and payments, send event confirmations and reminders,
+                communicate with you about your account, and personalise your
+                experience on Startline. We may also use aggregated data for analytics
+                and platform improvement.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                3. Information Sharing
+              </h2>
+              <p>
+                We share your information with event organisers when you register for
+                their events, with payment processors to complete transactions, and
+                with service providers who help us operate the platform. We do not sell
+                your personal information to third parties.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                4. Data Security
+              </h2>
+              <p>
+                We implement industry-standard security measures including encryption
+                in transit and at rest, access controls, and regular security audits.
+                However, no method of transmission over the internet is completely
+                secure, and we cannot guarantee absolute security.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                5. Your Rights
+              </h2>
+              <p>
+                You may access, update, or delete your account information at any time
+                through your profile settings. You may also contact us to request a
+                copy of the data we hold about you or to request its deletion, subject
+                to legal obligations.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                6. Contact
+              </h2>
+              <p>
+                For privacy-related inquiries, contact us at{" "}
+                <a href="mailto:privacy@startline.com.au" className="text-primary hover:underline">
+                  privacy@startline.com.au
+                </a>.
+              </p>
+            </section>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/(user)/terms/page.tsx
+++ b/app/(user)/terms/page.tsx
@@ -1,0 +1,122 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description:
+    "Startline Terms of Service — the terms governing your use of the Startline platform.",
+  openGraph: {
+    title: "Terms of Service | Startline",
+    description:
+      "The terms governing your use of the Startline platform.",
+    url: "/terms",
+  },
+  alternates: {
+    canonical: "/terms",
+  },
+};
+
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-dark-darker">
+      <section className="max-w-[1440px] mx-auto px-4 sm:px-6 py-20 sm:py-28">
+        <div className="max-w-3xl">
+          <p className="font-headline text-[10px] font-bold uppercase tracking-[0.25em] text-primary mb-3.5">
+            Legal
+          </p>
+          <h1 className="font-headline text-[32px] sm:text-4xl font-black italic leading-none tracking-tighter text-light mb-4">
+            Terms of <span className="text-primary">Service</span>
+          </h1>
+          <p className="text-[13px] text-muted-dark font-headline uppercase tracking-widest mb-10">
+            Last updated: 1 July 2026
+          </p>
+
+          <div className="space-y-8 text-[15px] text-muted leading-relaxed">
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                1. Acceptance of Terms
+              </h2>
+              <p>
+                By accessing or using Startline, you agree to be bound by these Terms
+                of Service. If you do not agree, you may not use the platform. We may
+                update these terms from time to time, and continued use constitutes
+                acceptance of the updated terms.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                2. Accounts
+              </h2>
+              <p>
+                You are responsible for maintaining the confidentiality of your account
+                credentials and for all activity under your account. You must provide
+                accurate information and keep it up to date. Accounts may be suspended
+                or terminated for violations of these terms.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                3. Event Listings and Registrations
+              </h2>
+              <p>
+                Event organisers are responsible for the accuracy of their listings.
+                Startline acts as a platform and is not a party to the transaction
+                between organisers and participants. Registration fees are set by
+                organisers and subject to their cancellation and refund policies.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                4. Payments
+              </h2>
+              <p>
+                Payments are processed securely through our third-party payment
+                processor. By making a purchase, you agree to the payment terms
+                presented at checkout. Refunds are handled according to each event
+                organiser&apos;s policy.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                5. Prohibited Conduct
+              </h2>
+              <p>
+                You may not use Startline for any unlawful purpose, to harass or harm
+                others, to distribute malware, to scrape or mine data, or to interfere
+                with the platform&apos;s operation. Violations may result in account
+                termination.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                6. Limitation of Liability
+              </h2>
+              <p>
+                Startline is provided &quot;as is&quot; without warranties of any
+                kind. To the maximum extent permitted by law, Startline shall not be
+                liable for any indirect, incidental, or consequential damages arising
+                from your use of the platform.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-headline text-sm font-bold uppercase tracking-[0.15em] text-light mb-3">
+                7. Contact
+              </h2>
+              <p>
+                For questions about these terms, contact us at{" "}
+                <a href="mailto:legal@startline.com.au" className="text-primary hover:underline">
+                  legal@startline.com.au
+                </a>.
+              </p>
+            </section>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -109,7 +109,6 @@ export default function Footer() {
                   </Link>
                 ))}
               </div>
-              </div>
             </div>
 
             <div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -80,6 +80,14 @@ export default function Footer() {
                 >
                   About
                 </Link>
+                <a
+                  href="https://www.instagram.com/startlineau/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block font-headline text-xs font-medium uppercase tracking-widest text-muted hover:text-primary transition-colors py-0.5"
+                >
+                  Instagram
+                </a>
               </div>
             </div>
 
@@ -103,35 +111,7 @@ export default function Footer() {
               </div>
             </div>
 
-            <div>
-              <h4 className="font-headline text-[10px] font-medium uppercase tracking-widest text-muted mb-3">
-                Follow
-              </h4>
-              <a
-                href="https://www.instagram.com/startlineau/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block font-headline text-xs font-medium uppercase tracking-widest text-muted hover:text-primary transition-colors py-0.5"
-              >
-                Instagram
-              </a>
-              <a
-                href="https://www.facebook.com/startlineau"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block font-headline text-xs font-medium uppercase tracking-widest text-muted hover:text-primary transition-colors py-0.5"
-              >
-                Facebook
-              </a>
-              <a
-                href="https://www.strava.com/clubs/startlineau"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block font-headline text-xs font-medium uppercase tracking-widest text-muted hover:text-primary transition-colors py-0.5"
-              >
-                Strava
-              </a>
-            </div>
+
 
             <div>
               <h4 className="font-headline text-[10px] font-medium uppercase tracking-widest text-muted mb-3">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -109,9 +109,8 @@ export default function Footer() {
                   </Link>
                 ))}
               </div>
+              </div>
             </div>
-
-
 
             <div>
               <h4 className="font-headline text-[10px] font-medium uppercase tracking-widest text-muted mb-3">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -56,6 +56,7 @@ export default function Footer() {
                 {[
                   { href: "/contact", label: "Contact" },
                   { href: "/organiser-setup", label: "Become an Organiser" },
+                  { href: "/organiser", label: "Organiser Login" },
                 ].map((link) => (
                   <Link
                     key={link.href}
@@ -88,6 +89,7 @@ export default function Footer() {
               </h4>
               <div className="space-y-2">
                 {[
+                  { href: "/faq", label: "FAQ" },
                   { href: "/feedback", label: "Feedback" },
                 ].map((link) => (
                   <Link
@@ -109,10 +111,47 @@ export default function Footer() {
                 href="https://www.instagram.com/startlineau/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-headline text-xs font-medium uppercase tracking-widest text-muted hover:text-primary transition-colors"
+                className="block font-headline text-xs font-medium uppercase tracking-widest text-muted hover:text-primary transition-colors py-0.5"
               >
                 Instagram
               </a>
+              <a
+                href="https://www.facebook.com/startlineau"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block font-headline text-xs font-medium uppercase tracking-widest text-muted hover:text-primary transition-colors py-0.5"
+              >
+                Facebook
+              </a>
+              <a
+                href="https://www.strava.com/clubs/startlineau"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block font-headline text-xs font-medium uppercase tracking-widest text-muted hover:text-primary transition-colors py-0.5"
+              >
+                Strava
+              </a>
+            </div>
+
+            <div>
+              <h4 className="font-headline text-[10px] font-medium uppercase tracking-widest text-muted mb-3">
+                Legal
+              </h4>
+              <div className="space-y-2">
+                {[
+                  { href: "/privacy", label: "Privacy Policy" },
+                  { href: "/terms", label: "Terms of Service" },
+                  { href: "/cookies", label: "Cookie Policy" },
+                ].map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="block font-headline text-xs font-medium uppercase tracking-widest text-muted hover:text-primary transition-colors py-0.5"
+                  >
+                    {link.label}
+                  </Link>
+                ))}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description

Adds 4 new pages (Privacy Policy, Terms of Service, Cookie Policy, FAQ) and updates the footer with new links and sections.

### Changes
- **4 new pages** under `app/(user)/`: privacy, terms, cookies, faq — static server components matching the existing page design pattern
- **Footer updates:**
  - New **Legal** section: Privacy Policy, Terms of Service, Cookie Policy
  - **Organiser Login** link added to Platform section (→ `/organiser`)
  - **FAQ** link added to Help section
  - **Facebook** and **Strava** social links added to Follow section (matching email footer)

Closes #118