### PR TITLE
CI: make all jobs blocking by removing continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
-    continue-on-error: true
+    continue-on-error: false
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/startline?schema=public
@@ -44,7 +44,7 @@ jobs:
       - run: pnpm lint
 
   typecheck:
-    continue-on-error: true
+    continue-on-error: false
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/startline?schema=public
@@ -61,7 +61,7 @@ jobs:
       - run: pnpm typecheck
 
   build:
-    continue-on-error: true
+    continue-on-error: false
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/startline?schema=public
@@ -78,7 +78,7 @@ jobs:
       - run: pnpm build
 
   test:
-    continue-on-error: true
+    continue-on-error: false
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/startline?schema=public
@@ -95,7 +95,7 @@ jobs:
       - run: pnpm test
 
   e2e:
-    continue-on-error: true
+    continue-on-error: false
     runs-on: ubuntu-latest
     services:
       postgres:


### PR DESCRIPTION
All CI jobs had `continue-on-error: true`, which allowed PRs with build, lint, typecheck, test, or E2E failures to merge to main. This caused deployment failures when broken code reached Amplify.

**Changes:** Set `continue-on-error: false` on all jobs (lint, typecheck, build, test, e2e). Gitleaks was already `false`.

Closes #196