### PR TITLE
Start staging RDS before deploy if stopped

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,22 @@ jobs:
           environment: ${{ env.ENV }}
           bootstrap-export-keys: ""
 
+      - name: Start staging RDS if stopped
+        if: env.ENV == 'staging'
+        shell: bash
+        run: |
+          STATUS=$(aws rds describe-db-instances \
+            --db-instance-identifier startline-staging-postgres \
+            --query 'DBInstances[0].DBInstanceStatus' --output text)
+          if [ "$STATUS" = "stopped" ]; then
+            echo "Starting staging RDS..."
+            aws rds start-db-instance --db-instance-identifier startline-staging-postgres
+            aws rds wait db-instance-available --db-instance-identifier startline-staging-postgres
+            echo "Staging RDS ready"
+          else
+            echo "Staging RDS status: $STATUS — no start needed"
+          fi
+
       - name: Resolve Amplify app ID
         id: amplify-app
         shell: bash


### PR DESCRIPTION
Staging RDS is auto-stopped nightly at midnight (AEST) via EventBridge Scheduler. Deploys running after that time fail because `prisma migrate deploy` can't connect to the stopped database.

Adds a pre-build step to `deploy.yml` that checks if the staging RDS is stopped and starts it before triggering the Amplify build. Uses `aws rds wait db-instance-available` to block until the DB is ready. Prod is unaffected (never stopped).