### PR TITLE
feat: user profile race history, saved events, and following

### DIFF
--- a/app/(user)/activity/page.tsx
+++ b/app/(user)/activity/page.tsx
@@ -2,11 +2,24 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
-import { RefreshCw } from "lucide-react";
+import Image from "next/image";
+import { RefreshCw, UserCheck } from "lucide-react";
 import type { UserEvent } from "@/types";
-import { getSavedEventIds, getRegisteredEventIds } from "@/lib/client-lists";
+import { getRegisteredEventIds } from "@/lib/client-lists";
+import { fetchSavedEventIds } from "@/lib/client-lists";
 import { toUserEvents } from "@/lib/user-events";
+import { useAuthContext } from "@/context/AuthContext";
 import EventCard from "@/components/EventCard";
+
+type FollowingOrganiser = {
+  followId: string;
+  id: string;
+  orgName: string | null;
+  logoUrl: string | null;
+  followers: number;
+  eventsHosted: number;
+  registrations: number;
+};
 
 function RegisteredCard({ event }: { event: UserEvent }) {
   return (
@@ -40,7 +53,64 @@ function RegisteredCard({ event }: { event: UserEvent }) {
   );
 }
 
-function EmptyState({ tab }: { tab: "registered" | "saved" }) {
+function OrganiserCard({
+  organiser,
+  onUnfollow,
+}: {
+  organiser: FollowingOrganiser;
+  onUnfollow: (followId: string) => void;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  async function unfollow() {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/public/organisers/${organiser.id}/follow`, {
+        method: "DELETE",
+      });
+      if (res.ok) onUnfollow(organiser.followId);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col bg-dark border border-dark-lighter rounded-2xl p-5">
+      <Link href={`/organisers/${organiser.id}`} className="group flex items-center gap-4">
+        <span className="relative w-14 h-14 rounded-xl overflow-hidden bg-dark-lighter shrink-0">
+          {organiser.logoUrl ? (
+            <Image src={organiser.logoUrl} alt={`${organiser.orgName} logo`} fill className="object-cover" sizes="56px" />
+          ) : (
+            <span className="w-full h-full flex items-center justify-center font-headline text-xl font-black italic text-primary">
+              {(organiser.orgName ?? "O").charAt(0)}
+            </span>
+          )}
+        </span>
+        <span className="min-w-0">
+          <span className="block font-headline text-lg font-black italic tracking-tighter text-light group-hover:text-primary transition-colors leading-tight truncate">
+            {organiser.orgName ?? "Organiser"}
+          </span>
+          <span className="flex items-center gap-2 mt-1 font-headline text-[10px] font-medium uppercase tracking-widest text-muted">
+            <span>{organiser.followers} followers</span>
+            <span className="text-muted-dark">·</span>
+            <span>{organiser.eventsHosted} events</span>
+          </span>
+        </span>
+      </Link>
+      <button
+        type="button"
+        onClick={unfollow}
+        disabled={busy}
+        className="mt-4 inline-flex items-center justify-center gap-2 h-10 rounded-xl border border-dark-lighter text-muted hover:text-light hover:border-primary/50 font-headline text-[11px] font-bold uppercase tracking-widest transition-colors"
+      >
+        <UserCheck className="w-4 h-4" />
+        {busy ? "Unfollowing..." : "Unfollow"}
+      </button>
+    </div>
+  );
+}
+
+function EmptyState({ tab }: { tab: "registered" | "saved" | "following" }) {
   return (
     <div className="flex flex-col items-center justify-center py-20 gap-3">
       <p className="font-headline text-xl font-black italic tracking-tighter text-light">
@@ -49,24 +119,29 @@ function EmptyState({ tab }: { tab: "registered" | "saved" }) {
       <p className="font-headline text-sm text-muted text-center max-w-xs leading-relaxed">
         {tab === "registered"
           ? "Register your interest in events to see them here."
-          : "Save events with the heart icon to find them later."}
+          : tab === "saved"
+            ? "Save events with the heart icon to find them later."
+            : "Follow organisers to keep up with their upcoming events."}
       </p>
       <Link
-        href="/events"
+        href={tab === "following" ? "/organisers" : "/events"}
         className="mt-2 font-headline text-[11px] font-bold uppercase tracking-widest text-primary hover:underline"
       >
-        Browse Events
+        {tab === "following" ? "Browse Organisers" : "Browse Events"}
       </Link>
     </div>
   );
 }
 
 export default function ActivityPage() {
-  const [activeTab, setActiveTab] = useState<"registered" | "saved">("registered");
-  const [savedIds, setSavedIds] = useState(() => getSavedEventIds());
+  const { status } = useAuthContext();
+  const [activeTab, setActiveTab] = useState<"registered" | "saved" | "following">("registered");
+  const [savedIds, setSavedIds] = useState<string[]>([]);
   const [registeredIds, setRegisteredIds] = useState(() => getRegisteredEventIds());
+  const [following, setFollowing] = useState<FollowingOrganiser[]>([]);
   const [events, setEvents] = useState<UserEvent[]>([]);
   const [eventsLoading, setEventsLoading] = useState(true);
+  const [followingLoading, setFollowingLoading] = useState(false);
 
   useEffect(() => {
     fetch("/api/events")
@@ -74,25 +149,33 @@ export default function ActivityPage() {
       .then(data => { setEvents(Array.isArray(data) ? toUserEvents(data) : []); })
       .catch(() => {})
       .finally(() => setEventsLoading(false));
+  }, []);
 
-    function onStorage(e: StorageEvent) {
-      if (e.key === "startline_saved_events" || e.key === "startline_registered_interest") {
-        setSavedIds(getSavedEventIds());
-        setRegisteredIds(getRegisteredEventIds());
-        fetch("/api/events")
-          .then(r => r.ok ? r.json() : [])
-          .then(data => { setEvents(Array.isArray(data) ? toUserEvents(data) : []); })
-          .catch(() => {});
-      }
-    }
-    function onLocalChange() {
-      setSavedIds(getSavedEventIds());
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    let cancelled = false;
+    Promise.all([fetchSavedEventIds(), fetch("/api/user/following").then(r => r.ok ? r.json() : null)])
+      .then(([ids, followingData]) => {
+        if (cancelled) return;
+        setSavedIds(ids);
+        if (followingData?.organisers) setFollowing(followingData.organisers);
+      })
+      .finally(() => setFollowingLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [status]);
+
+  function onStorage(e: StorageEvent) {
+    if (e.key === "startline_registered_interest") {
       setRegisteredIds(getRegisteredEventIds());
-      fetch("/api/events")
-        .then(r => r.ok ? r.json() : [])
-        .then(data => { setEvents(Array.isArray(data) ? toUserEvents(data) : []); })
-        .catch(() => {});
     }
+  }
+  function onLocalChange() {
+    setRegisteredIds(getRegisteredEventIds());
+  }
+
+  useEffect(() => {
     window.addEventListener("storage", onStorage);
     window.addEventListener("startline-lists-changed", onLocalChange);
     return () => {
@@ -103,7 +186,17 @@ export default function ActivityPage() {
 
   const savedEvents = events.filter((e) => savedIds.includes(String(e.id)));
   const registeredEvents = events.filter((e) => registeredIds.includes(String(e.id)));
-  const tabEvents = activeTab === "registered" ? registeredEvents : savedEvents;
+
+  const tabCounts = {
+    registered: registeredEvents.length,
+    saved: savedEvents.length,
+    following: following.length,
+  };
+  const tabLabels: Record<string, string> = {
+    registered: "Registered",
+    saved: "Saved",
+    following: "Following",
+  };
 
   return (
     <main className="min-h-screen bg-dark-darker">
@@ -119,7 +212,7 @@ export default function ActivityPage() {
               Your race<br /><span className="text-primary">calendar.</span>
             </h1>
             <p className="font-headline text-[15px] text-muted max-w-[460px] leading-relaxed mt-4">
-              Everything you&apos;ve entered and everything you&apos;ve saved. Keep your start lines in one place.
+              Everything you&apos;ve entered, saved, and who you follow. Keep your start lines in one place.
             </p>
           </div>
           <Link
@@ -135,7 +228,7 @@ export default function ActivityPage() {
           {[
             { n: registeredEvents.length, l: "Registered" },
             { n: savedEvents.length, l: "Saved" },
-            { n: 0, l: "Completed" },
+            { n: following.length, l: "Following" },
           ].map(({ n, l }) => (
             <div
               key={l}
@@ -152,9 +245,8 @@ export default function ActivityPage() {
 
         {/* Tab pills */}
         <div className="flex gap-2.5 mb-6">
-          {(["registered", "saved"] as const).map((id) => {
+          {(["registered", "saved", "following"] as const).map((id) => {
             const on = activeTab === id;
-            const count = id === "registered" ? registeredEvents.length : savedEvents.length;
             return (
               <button
                 key={id}
@@ -165,11 +257,11 @@ export default function ActivityPage() {
                     : "bg-transparent border border-dark-lighter text-muted hover:text-light"
                 }`}
               >
-                {id}
+                {tabLabels[id]}
                 <span
                   className={`font-headline text-[11px] font-bold ${on ? "text-primary" : "text-muted-dark"}`}
                 >
-                  {count}
+                  {tabCounts[id]}
                 </span>
               </button>
             );
@@ -177,11 +269,32 @@ export default function ActivityPage() {
         </div>
 
         {/* Grid */}
-        {eventsLoading ? (
+        {activeTab === "following" ? (
+          followingLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <RefreshCw className="w-5 h-5 text-muted animate-spin" />
+            </div>
+          ) : following.length === 0 ? (
+            <EmptyState tab="following" />
+          ) : (
+            <div
+              className="grid gap-5"
+              style={{ gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))" }}
+            >
+              {following.map((o) => (
+                <OrganiserCard
+                  key={o.followId}
+                  organiser={o}
+                  onUnfollow={(followId) => setFollowing((prev) => prev.filter((x) => x.followId !== followId))}
+                />
+              ))}
+            </div>
+          )
+        ) : eventsLoading ? (
           <div className="flex items-center justify-center py-20">
             <RefreshCw className="w-5 h-5 text-muted animate-spin" />
           </div>
-        ) : tabEvents.length === 0 ? (
+        ) : (activeTab === "registered" ? registeredEvents : savedEvents).length === 0 ? (
           <EmptyState tab={activeTab} />
         ) : (
           <div

--- a/app/(user)/events/[id]/page.tsx
+++ b/app/(user)/events/[id]/page.tsx
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/button";
 import EventGallery from "@/components/EventGallery";
 import EventReviewsSection from "@/components/EventReviewsSection";
 import OrganiserRating from "@/components/OrganiserRating";
+import SaveEventButton from "@/components/SaveEventButton";
 import { getPublishedOrganiserReviews, averageOverallRating } from "@/lib/reviews";
 
 export const revalidate = 60;
@@ -211,6 +212,10 @@ export default async function EventDetailPage({ params }: { params: Promise<{ id
                   View on Maps
                 </Link>
               </Button>
+              <div className="flex items-center justify-center gap-2 border border-dark-lighter rounded-xl py-2.5 px-4">
+                <SaveEventButton eventId={event.id} />
+                <span className="font-headline text-xs font-bold uppercase tracking-widest text-muted">Save Event</span>
+              </div>
             </div>
 
             <div className="bg-dark rounded-xl p-5 sm:p-6">

--- a/app/(user)/profile/page.tsx
+++ b/app/(user)/profile/page.tsx
@@ -428,7 +428,20 @@ export default function ProfilePage() {
                 </span>
               </div>
 
-              {history && history.registrations.length > 0 ? (
+              {profileLoading ? (
+                <div className="space-y-4">
+                  {[0, 1].map((i) => (
+                    <div key={i} className="flex items-start gap-4 animate-pulse">
+                      <div className="w-3 h-3 rounded-full bg-dark-lighter mt-1 flex-shrink-0" />
+                      <div className="flex-1 space-y-2">
+                        <div className="w-40 h-3 bg-dark-lighter rounded" />
+                        <div className="w-64 h-5 bg-dark-lighter rounded" />
+                        <div className="w-48 h-3 bg-dark-lighter rounded" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : history && history.registrations.length > 0 ? (
                 <ol className="relative border-l-2 border-dark-lighter ml-2 space-y-6">
                   {history.registrations.map((reg) => (
                     <li key={reg.id} className="relative pl-6">

--- a/app/(user)/profile/page.tsx
+++ b/app/(user)/profile/page.tsx
@@ -3,9 +3,10 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { MapPin, Calendar, Check, X, AlertCircle } from "lucide-react";
+import { MapPin, Calendar, Check, X, AlertCircle, Trophy, Timer } from "lucide-react";
 import { STATE_OPTIONS, STATE_LABELS } from "@/types";
 import type { AustralianState } from "@/types";
+import { formatDiscipline, formatLongDate } from "@/lib/utils";
 import { useAuthContext } from "@/context/AuthContext";
 
 type UserData = {
@@ -19,6 +20,27 @@ type UserData = {
   city: string | null;
   state: string | null;
   organiser: { id: string; orgName: string | null; logoUrl: string | null; verified: boolean } | null;
+};
+
+type RaceHistory = {
+  completed: number;
+  statesRaced: number;
+  disciplines: number;
+  registrations: {
+    id: string;
+    finishTime: string | null;
+    result: string | null;
+    event: {
+      id: string;
+      title: string;
+      discipline: string;
+      eventDate: string;
+      city: string;
+      state: string;
+      coverImageUrl: string | null;
+      organiser: { id: string; orgName: string | null };
+    };
+  }[];
 };
 
 function KStat({ n, l }: { n: number; l: string }) {
@@ -40,6 +62,7 @@ export default function ProfilePage() {
 
   const [userData, setUserData] = useState<UserData | null>(null);
   const [profileLoading, setProfileLoading] = useState(true);
+  const [history, setHistory] = useState<RaceHistory | null>(null);
 
   const [editing, setEditing] = useState(false);
   const [editName, setEditName] = useState("");
@@ -91,6 +114,7 @@ export default function ProfilePage() {
       .then(data => {
         if (!data) return;
         setUserData(data);
+        setHistory(data.history ?? null);
         setEditName(data.name ?? "");
         setEditUsername(data.username ?? "");
         setEditBio(data.bio ?? "");
@@ -389,9 +413,9 @@ export default function ProfilePage() {
 
               {/* KStats */}
               <div className="flex gap-3.5 flex-wrap mb-10">
-                <KStat n={0} l="Events Completed" />
-                <KStat n={0} l="States Raced" />
-                <KStat n={0} l="Disciplines" />
+                <KStat n={history?.completed ?? 0} l="Events Completed" />
+                <KStat n={history?.statesRaced ?? 0} l="States Raced" />
+                <KStat n={history?.disciplines ?? 0} l="Disciplines" />
               </div>
 
               {/* Race History */}
@@ -400,25 +424,76 @@ export default function ProfilePage() {
                   Race History
                 </h3>
                 <span className="font-headline text-[10.5px] font-bold uppercase tracking-widest text-muted-dark">
-                  0 events
+                  {history?.completed ?? 0} {history?.completed === 1 ? "event" : "events"}
                 </span>
               </div>
 
-              {/* Empty state */}
-              <div className="flex flex-col items-center justify-center py-16 gap-3 border border-dashed border-dark-lighter rounded-2xl">
-                <p className="font-headline text-lg font-black italic tracking-tighter text-light">
-                  No race history yet.
-                </p>
-                <p className="font-headline text-sm text-muted text-center max-w-xs leading-relaxed">
-                  Completed events will appear here once race results are available.
-                </p>
-                <Link
-                  href="/events"
-                  className="mt-2 font-headline text-[11px] font-bold uppercase tracking-widest text-primary hover:underline"
-                >
-                  Find Events
-                </Link>
-              </div>
+              {history && history.registrations.length > 0 ? (
+                <ol className="relative border-l-2 border-dark-lighter ml-2 space-y-6">
+                  {history.registrations.map((reg) => (
+                    <li key={reg.id} className="relative pl-6">
+                      <span className="absolute -left-[7px] top-1.5 w-3 h-3 rounded-full bg-primary border-2 border-dark-darker" />
+                      <Link href={`/events/${reg.event.id}`} className="group block">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="font-headline text-[10px] font-bold uppercase tracking-widest text-muted">
+                              {formatLongDate(reg.event.eventDate)}
+                            </p>
+                            <h4 className="font-headline text-lg font-black italic tracking-tighter text-light group-hover:text-primary transition-colors leading-tight mt-0.5">
+                              {reg.event.title}
+                            </h4>
+                            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5">
+                              <span className="flex items-center gap-1.5 font-headline text-[10px] font-medium uppercase tracking-widest text-muted">
+                                <Trophy className="w-3 h-3 text-primary" />
+                                {formatDiscipline(reg.event.discipline)}
+                              </span>
+                              <span className="flex items-center gap-1.5 font-headline text-[10px] font-medium uppercase tracking-widest text-muted">
+                                <MapPin className="w-3 h-3 text-primary" />
+                                {reg.event.city}, {STATE_LABELS[reg.event.state as AustralianState]}
+                              </span>
+                              {reg.event.organiser?.orgName && (
+                                <span className="font-headline text-[10px] font-medium uppercase tracking-widest text-muted">
+                                  {reg.event.organiser.orgName}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                          {(reg.finishTime || reg.result) && (
+                            <div className="text-right flex-shrink-0">
+                              {reg.result && (
+                                <span className="block font-headline text-base font-black italic text-primary leading-none">
+                                  {reg.result}
+                                </span>
+                              )}
+                              {reg.finishTime && (
+                                <span className="flex items-center justify-end gap-1 font-headline text-[11px] font-bold uppercase tracking-widest text-light mt-1">
+                                  <Timer className="w-3 h-3 text-primary" />
+                                  {reg.finishTime}
+                                </span>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      </Link>
+                    </li>
+                  ))}
+                </ol>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-16 gap-3 border border-dashed border-dark-lighter rounded-2xl">
+                  <p className="font-headline text-lg font-black italic tracking-tighter text-light">
+                    No race history yet.
+                  </p>
+                  <p className="font-headline text-sm text-muted text-center max-w-xs leading-relaxed">
+                    Completed events will appear here once you&apos;ve finished a race.
+                  </p>
+                  <Link
+                    href="/events"
+                    className="mt-2 font-headline text-[11px] font-bold uppercase tracking-widest text-primary hover:underline"
+                  >
+                    Find Events
+                  </Link>
+                </div>
+              )}
             </div>
 
           </div>

--- a/app/api/user/following/route.ts
+++ b/app/api/user/following/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getUserSession } from "@/lib/amplify-server";
+
+export async function GET() {
+  const session = await getUserSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  }
+
+  const follows = await prisma.organiserFollow.findMany({
+    where: { userId: session.sub },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      createdAt: true,
+      organiser: {
+        select: {
+          id: true,
+          orgName: true,
+          logoUrl: true,
+          _count: {
+            select: { follows: true, events: true, registrations: true },
+          },
+        },
+      },
+    },
+  });
+
+  return NextResponse.json({
+    organisers: follows.map((f) => ({
+      followId: f.id,
+      followedAt: f.createdAt,
+      id: f.organiser.id,
+      orgName: f.organiser.orgName,
+      logoUrl: f.organiser.logoUrl,
+      followers: f.organiser._count.follows,
+      eventsHosted: f.organiser._count.events,
+      registrations: f.organiser._count.registrations,
+    })),
+  });
+}

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -22,11 +22,46 @@ export async function GET() {
       organiser: { select: { id: true, orgName: true, logoUrl: true, verified: true } },
     },
   });
+  if (!user) {
+    return NextResponse.json({ error: "Not found." }, { status: 404 });
+  }
+
+  const registrations = await prisma.registration.findMany({
+    where: { userId: session.sub, status: "CONFIRMED" },
+    orderBy: { event: { eventDate: "asc" } },
+    select: {
+      id: true,
+      finishTime: true,
+      result: true,
+      event: {
+        select: {
+          id: true,
+          title: true,
+          discipline: true,
+          eventDate: true,
+          city: true,
+          state: true,
+          coverImageUrl: true,
+          organiser: { select: { id: true, orgName: true } },
+        },
+      },
+    },
+  });
+
+  const completed = registrations.length;
+  const statesRaced = new Set(registrations.map((r) => r.event.state)).size;
+  const disciplines = new Set(registrations.map((r) => r.event.discipline)).size;
 
   return NextResponse.json({
     ...user,
     mobile: session.phoneNumber,
     dateOfBirth: session.birthdate,
+    history: {
+      completed,
+      statesRaced,
+      disciplines,
+      registrations,
+    },
   });
 }
 

--- a/app/api/user/saved-events/route.ts
+++ b/app/api/user/saved-events/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import prisma from "@/lib/prisma";
+import { getUserSession } from "@/lib/amplify-server";
+
+export async function GET() {
+  const session = await getUserSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  }
+
+  const saved = await prisma.savedEvent.findMany({
+    where: { userId: session.sub },
+    select: { eventId: true },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json({ eventIds: saved.map((s) => s.eventId) });
+}
+
+export async function POST(req: Request) {
+  const session = await getUserSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const eventId = typeof body?.eventId === "string" ? body.eventId : null;
+  if (!eventId) {
+    return NextResponse.json({ error: "eventId is required." }, { status: 400 });
+  }
+
+  const event = await prisma.event.findUnique({ where: { id: eventId }, select: { id: true } });
+  if (!event) {
+    return NextResponse.json({ error: "Event not found." }, { status: 404 });
+  }
+
+  try {
+    await prisma.savedEvent.create({ data: { userId: session.sub, eventId } });
+  } catch (err) {
+    if (!(err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002")) throw err;
+  }
+
+  return NextResponse.json({ saved: true });
+}
+
+export async function DELETE(req: Request) {
+  const session = await getUserSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const eventId = typeof body?.eventId === "string" ? body.eventId : null;
+  if (!eventId) {
+    return NextResponse.json({ error: "eventId is required." }, { status: 400 });
+  }
+
+  try {
+    await prisma.savedEvent.delete({
+      where: { userId_eventId: { userId: session.sub, eventId } },
+    });
+  } catch (err) {
+    if (!(err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025")) throw err;
+  }
+
+  return NextResponse.json({ saved: false });
+}

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -5,6 +5,7 @@ import type { UserEvent } from "@/types";
 import { EVENT_TYPE_LABELS, STATE_LABELS } from "@/types";
 import { cn, formatShortDate, formatTime, formatCompetitionFormat, stripHtml } from "@/lib/utils";
 import OrganiserCardMeta from "@/components/OrganiserCardMeta";
+import SaveEventButton from "@/components/SaveEventButton";
 
 interface EventCardProps {
   event: UserEvent;
@@ -38,6 +39,11 @@ export default function EventCard({ event, className, cardClassName, onSelect, s
           sizes="(max-width: 640px) 100vw, 33vw"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-dark/60 via-transparent to-transparent" />
+
+        {/* Save button */}
+        <div className="absolute top-3 left-3">
+          <SaveEventButton eventId={event.id} className="bg-dark-light/80 backdrop-blur-sm hover:bg-dark-light" />
+        </div>
 
         {/* Date badge */}
         <div className="absolute top-3 right-3 bg-dark-light/90 backdrop-blur-sm rounded-lg px-3 py-2 text-center leading-tight">

--- a/components/SaveEventButton.tsx
+++ b/components/SaveEventButton.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Heart } from "lucide-react";
-import { getSavedEventIds, toggleSavedEventId } from "@/lib/client-lists";
+import { fetchSavedEventIds, saveEventId, unsaveEventId } from "@/lib/client-lists";
+import { useAuthContext } from "@/context/AuthContext";
+import SignInModal from "@/components/SignInModal";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -13,40 +15,62 @@ interface SaveEventButtonProps {
 }
 
 export default function SaveEventButton({ eventId, className = "" }: SaveEventButtonProps) {
-  const [saved, setSaved] = useState(() => getSavedEventIds().includes(eventId));
+  const { status } = useAuthContext();
+  const [saved, setSaved] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [signInOpen, setSignInOpen] = useState(false);
 
-  function toggle(e: React.MouseEvent) {
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    let cancelled = false;
+    fetchSavedEventIds()
+      .then((ids) => {
+        if (!cancelled) setSaved(ids.includes(eventId));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [status, eventId]);
+
+  async function toggle(e: React.MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
 
-    setLoading(true);
-    try {
-      const nowSaved = toggleSavedEventId(eventId);
-      setSaved(nowSaved);
-    } finally {
-      setLoading(false);
+    if (status !== "authenticated") {
+      setSignInOpen(true);
+      return;
     }
+    if (loading) return;
+
+    const next = !saved;
+    setLoading(true);
+    const ok = next ? await saveEventId(eventId) : await unsaveEventId(eventId);
+    if (ok) setSaved(next);
+    setLoading(false);
   }
 
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      onClick={toggle}
-      disabled={loading}
-      aria-label={saved ? "Unsave event" : "Save event"}
-      title={saved ? "Remove from saved" : "Save event"}
-      className={cn(
-        "h-auto w-auto p-2 rounded-full transition-all",
-        saved
-          ? "text-primary bg-primary/10 hover:bg-primary/20 hover:text-primary"
-          : "text-muted hover:text-primary hover:bg-dark-light",
-        className
-      )}
-    >
-      <Heart className={cn("w-4 h-4", saved && "fill-primary")} />
-    </Button>
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={toggle}
+        disabled={loading}
+        aria-label={saved ? "Unsave event" : "Save event"}
+        title={saved ? "Remove from saved" : "Save event"}
+        className={cn(
+          "h-auto w-auto p-2 rounded-full transition-all",
+          saved
+            ? "text-primary bg-primary/10 hover:bg-primary/20 hover:text-primary"
+            : "text-muted hover:text-primary hover:bg-dark-light",
+          className
+        )}
+      >
+        <Heart className={cn("w-4 h-4", saved && "fill-primary")} />
+      </Button>
+      <SignInModal isOpen={signInOpen} onClose={() => setSignInOpen(false)} />
+    </>
   );
 }

--- a/e2e/user-profile.spec.ts
+++ b/e2e/user-profile.spec.ts
@@ -26,7 +26,7 @@ test.describe("user profile: race history", () => {
 
     // Bypass user is organiser@startline.test — seeded with 2 completed events
     await expect(page.getByText("Events Completed")).toBeVisible();
-    await expect(page.getByText("Race History")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Race History" })).toBeVisible();
     await expect(page.getByText("The Apex Throwdown 2025")).toBeVisible();
     await expect(page.getByText("Apex Bay Run")).toBeVisible();
 

--- a/e2e/user-profile.spec.ts
+++ b/e2e/user-profile.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+
+const BYPASS_COOKIE = { name: "__e2e_bypass", value: "1", domain: "localhost", path: "/", sameSite: "Lax" as const };
+
+// Bypass cookie maps server-side to organiser@startline.test, which owns
+// Apex Endurance Events and follows Coastal Fitness Collective.
+const COASTAL_ORG = "Coastal Fitness Collective";
+
+async function coastalOrganiserId(page: import("@playwright/test").Page): Promise<string> {
+  const events = await (await page.request.get("/api/events")).json();
+  const event = events.find((e: { organizer?: string; organiser?: { orgName?: string } }) =>
+    e.organizer === COASTAL_ORG || e.organiser?.orgName === COASTAL_ORG
+  );
+  expect(event, "expected a Coastal Fitness Collective event in /api/events").toBeTruthy();
+  return event.organiserId;
+}
+
+test.describe("user profile: race history", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().addCookies([BYPASS_COOKIE]);
+  });
+
+  test("shows KStats and chronological race history from completed registrations", async ({ page }) => {
+    await page.goto("/profile");
+    await page.waitForLoadState("networkidle");
+
+    // Bypass user is organiser@startline.test — seeded with 2 completed events
+    await expect(page.getByText("Events Completed")).toBeVisible();
+    await expect(page.getByText("Race History")).toBeVisible();
+    await expect(page.getByText("The Apex Throwdown 2025")).toBeVisible();
+    await expect(page.getByText("Apex Bay Run")).toBeVisible();
+
+    // Results + times are shown for seeded registrations
+    await expect(page.getByText("5th", { exact: true })).toBeVisible();
+    await expect(page.getByText("02:01:12", { exact: true })).toBeVisible();
+  });
+
+  test("saving an event from the listing appears on the activity Saved tab", async ({ page }) => {
+    await page.goto("/events");
+    await page.waitForLoadState("networkidle");
+
+    // The first matching save button may live in a hidden list container —
+    // target a visible one instead.
+    const saveButtons = page.locator('[aria-label="Save event"]:visible');
+    const count = await saveButtons.count();
+    expect(count).toBeGreaterThan(0);
+    await saveButtons.first().click();
+    await expect(page.getByRole("button", { name: /unsave event/i }).first()).toBeVisible();
+
+    await page.goto("/activity");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: /saved/i }).click();
+    await expect(page.getByText("Saved", { exact: false }).first()).toBeVisible();
+  });
+
+  test("Following tab lists followed organisers and can unfollow", async ({ page }) => {
+    // Re-follow Coastal so the test is deterministic even if a prior run
+    // unfollowed it (the DELETE persists in the DB).
+    const coastalId = await coastalOrganiserId(page);
+    await page.request.post(`/api/public/organisers/${coastalId}/follow`);
+
+    await page.goto("/activity");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: /following/i }).click();
+    await expect(page.getByText(COASTAL_ORG)).toBeVisible();
+
+    // Unfollow Coastal — the row disappears
+    const coastalCard = page.locator(".bg-dark.border.border-dark-lighter.rounded-2xl", {
+      hasText: COASTAL_ORG,
+    });
+    await coastalCard.getByRole("button", { name: /unfollow/i }).click();
+    await expect(page.getByText(COASTAL_ORG)).not.toBeVisible();
+  });
+});

--- a/lib/client-lists.ts
+++ b/lib/client-lists.ts
@@ -1,4 +1,3 @@
-const SAVED_KEY = "startline_saved_events";
 const REGISTERED_KEY = "startline_registered_interest";
 
 function parseIds(raw: string | null): string[] {
@@ -11,38 +10,9 @@ function parseIds(raw: string | null): string[] {
   }
 }
 
-export function getSavedEventIds(): string[] {
-  if (typeof window === "undefined") return [];
-  return parseIds(localStorage.getItem(SAVED_KEY));
-}
-
 function notifyListsChanged(): void {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new CustomEvent("startline-lists-changed"));
-}
-
-function setSavedEventIds(ids: string[]): void {
-  if (typeof window === "undefined") return;
-  localStorage.setItem(SAVED_KEY, JSON.stringify(ids));
-  notifyListsChanged();
-}
-
-export function toggleSavedEventId(eventId: string): boolean {
-  const ids = getSavedEventIds();
-  const i = ids.indexOf(eventId);
-  if (i >= 0) {
-    ids.splice(i, 1);
-    setSavedEventIds(ids);
-    return false;
-  }
-  ids.push(eventId);
-  setSavedEventIds(ids);
-  return true;
-}
-
-export function getRegisteredEventIds(): string[] {
-  if (typeof window === "undefined") return [];
-  return parseIds(localStorage.getItem(REGISTERED_KEY));
 }
 
 function setRegisteredEventIds(ids: string[]): void {
@@ -51,10 +21,54 @@ function setRegisteredEventIds(ids: string[]): void {
   notifyListsChanged();
 }
 
+export function getRegisteredEventIds(): string[] {
+  if (typeof window === "undefined") return [];
+  return parseIds(localStorage.getItem(REGISTERED_KEY));
+}
+
 export function addRegisteredInterest(eventId: string): boolean {
   const ids = getRegisteredEventIds();
   if (ids.includes(eventId)) return false;
   ids.push(eventId);
   setRegisteredEventIds(ids);
   return true;
+}
+
+// Saved events are DB-backed (per-user). These helpers call the API so the
+// heart button and activity page stay in sync across devices.
+export async function fetchSavedEventIds(): Promise<string[]> {
+  try {
+    const res = await fetch("/api/user/saved-events");
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data.eventIds) ? data.eventIds.map(String) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function saveEventId(eventId: string): Promise<boolean> {
+  try {
+    const res = await fetch("/api/user/saved-events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ eventId }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function unsaveEventId(eventId: string): Promise<boolean> {
+  try {
+    const res = await fetch("/api/user/saved-events", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ eventId }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
 }

--- a/prisma/migrations/20260801053908_saved_events_and_results/migration.sql
+++ b/prisma/migrations/20260801053908_saved_events_and_results/migration.sql
@@ -1,0 +1,25 @@
+-- AlterTable
+ALTER TABLE "registrations" ADD COLUMN     "finishTime" TEXT,
+ADD COLUMN     "result" TEXT;
+
+-- CreateTable
+CREATE TABLE "saved_events" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "saved_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "saved_events_userId_idx" ON "saved_events"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "saved_events_userId_eventId_key" ON "saved_events"("userId", "eventId");
+
+-- AddForeignKey
+ALTER TABLE "saved_events" ADD CONSTRAINT "saved_events_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "saved_events" ADD CONSTRAINT "saved_events_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "events"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -155,6 +155,7 @@ model Event {
   reviews       Review[]
   announcements Announcement[]
   registrations Registration[]
+  savedEvents   SavedEvent[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -270,6 +271,10 @@ model Registration {
   status                RegistrationStatus @default(CONFIRMED)
   stripePaymentIntentId String?
 
+  // Race results — populated by the organiser after the event (issue #201)
+  finishTime String? // finish time, ISO "HH:MM:SS"
+  result     String? // position e.g. "1st", "42nd", "DNF"
+
   createdAt DateTime @default(now())
 
   @@index([eventId])
@@ -298,6 +303,20 @@ model OrganiserFollow {
   @@map("organiser_follows")
 }
 
+// ─── User → Event saves ───────────────────────────────────────────────────────
+model SavedEvent {
+  id        String   @id @default(uuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  eventId   String
+  event     Event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+
+  @@unique([userId, eventId])
+  @@index([userId])
+  @@map("saved_events")
+}
+
 // ─── User accounts ────────────────────────────────────────────────────────────
 // Every platform user has a User record. Organisers are users who also
 // have an associated Organiser profile (1:1).
@@ -321,6 +340,7 @@ model User {
   organiser     Organiser?
   registrations Registration[]
   follows       OrganiserFollow[]
+  savedEvents   SavedEvent[]
   reviews       Review[]
 
   @@map("users")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -151,6 +151,8 @@ async function main() {
 
   await prisma.adminAuditLog.deleteMany();
   await prisma.registration.deleteMany();
+  await prisma.savedEvent.deleteMany();
+  await prisma.organiserFollow.deleteMany();
   await prisma.review.deleteMany();
   await prisma.announcement.deleteMany();
   await prisma.notification.deleteMany();
@@ -588,7 +590,69 @@ async function main() {
   }
   console.log(`  Registrations: ${regCount}`);
 
+  // ── Seeded-user race history ────────────────────────────────────────────
+  // user@startline.test gets a spread of completed events (different
+  // disciplines + states) so the profile KStats and timeline have data.
+  // admin@startline.test gets a couple so an admin account has history too.
+  const userSeedId = userBySub[subsByEmail["user@startline.test"] ?? ""];
+  const adminSeedId = userBySub[subsByEmail["admin@startline.test"] ?? ""];
+  const organiserSeedId = userBySub[subsByEmail["organiser@startline.test"] ?? ""];
+
+  const historyRegs: {
+    id: string;
+    userId: string | undefined;
+    eventId: string;
+    finishTime?: string | null;
+    result?: string | null;
+  }[] = [
+    { id: "seed-history-user-001", userId: userSeedId, eventId: "seed-event-040", result: "12th", finishTime: "02:14:37" },
+    { id: "seed-history-user-002", userId: userSeedId, eventId: "seed-event-042", result: "8th",  finishTime: "01:47:22" },
+    { id: "seed-history-user-003", userId: userSeedId, eventId: "seed-event-044", result: "1st",  finishTime: "00:42:10" },
+    { id: "seed-history-user-004", userId: userSeedId, eventId: "seed-event-022", result: "24th", finishTime: null },
+    { id: "seed-history-user-005", userId: userSeedId, eventId: "seed-event-006", result: "157th", finishTime: "04:28:51" },
+    { id: "seed-history-user-006", userId: userSeedId, eventId: "seed-event-024", result: "19th", finishTime: null },
+    { id: "seed-history-admin-001", userId: adminSeedId, eventId: "seed-event-041", result: "3rd", finishTime: "01:23:40" },
+    { id: "seed-history-admin-002", userId: adminSeedId, eventId: "seed-event-043", result: "DNF", finishTime: null },
+    { id: "seed-history-organiser-001", userId: organiserSeedId, eventId: "seed-event-040", result: "5th", finishTime: "02:01:12" },
+    { id: "seed-history-organiser-002", userId: organiserSeedId, eventId: "seed-event-044", result: "2nd", finishTime: "00:39:58" },
+  ];
+
+  let historyCount = 0;
+  for (const h of historyRegs) {
+    if (!h.userId) continue;
+    const owner = (await prisma.event.findUnique({ where: { id: h.eventId }, select: { organiserId: true } }))?.organiserId;
+    if (!owner) continue;
+    await prisma.registration.upsert({
+      where: { id: h.id },
+      update: {},
+      create: {
+        id: h.id,
+        userId: h.userId,
+        eventId: h.eventId,
+        organiserId: owner,
+        athleteName: "Seed Athlete",
+        athleteEmail: h.userId === userSeedId
+          ? "user@startline.test"
+          : h.userId === adminSeedId
+            ? "admin@startline.test"
+            : "organiser@startline.test",
+        waveLabel: "General",
+        amountCents: 0,
+        platformFeeCents: 0,
+        feeStructure: "athlete",
+        status: "CONFIRMED",
+        finishTime: h.finishTime ?? null,
+        result: h.result ?? null,
+      },
+    });
+    historyCount++;
+  }
+  if (historyCount > 0) console.log(`  Seeded-user race history: ${historyCount}`);
+
   // ── Organiser follows ────────────────────────────────────────────────
+  // user@ and admin@ follow Apex. organiser@ (the E2E bypass user) owns
+  // Apex so cannot follow it — it follows Coastal instead, which gives the
+  // /activity "Following" tab a row for that account.
   const followerUserIds = [
     userBySub[subsByEmail["user@startline.test"] ?? ""],
     userBySub[subsByEmail["admin@startline.test"] ?? ""],
@@ -605,7 +669,38 @@ async function main() {
     });
     followCount++;
   }
+
+  const organiserUserFollowId = userBySub[subsByEmail["organiser@startline.test"] ?? ""];
+  if (organiserUserFollowId && coastalOrg) {
+    await prisma.organiserFollow.upsert({
+      where: {
+        userId_organiserId: { userId: organiserUserFollowId, organiserId: coastalOrg.id },
+      },
+      update: {},
+      create: { userId: organiserUserFollowId, organiserId: coastalOrg.id },
+    });
+    followCount++;
+  }
   console.log(`  Organiser follows: ${followCount}`);
+
+  // ── Saved events ───────────────────────────────────────────────────────
+  if (userSeedId) {
+    const savedEventIds = [
+      "seed-event-001", // The Apex Throwdown 2026
+      "seed-event-005", // Sydney Harbour 10K
+      "seed-event-017", // Noosa Triathlon 2026
+    ];
+    let savedCount = 0;
+    for (const eventId of savedEventIds) {
+      await prisma.savedEvent.upsert({
+        where: { userId_eventId: { userId: userSeedId, eventId } },
+        update: {},
+        create: { userId: userSeedId, eventId },
+      });
+      savedCount++;
+    }
+    console.log(`  Saved events: ${savedCount}`);
+  }
 
   // ── Notifications ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Description

Implements the remaining scope of #48 (User Profile): DB-backed saved events, a race history timeline with results, and a Following tab on the activity page. Profile privacy was already implemented.

**Issue:** Closes #48
**Follow-up:** Result-entry UI tracked in #201 (separate PR).

## Changes

### Schema
- New `SavedEvent` model (user↔event, unique composite, cascade deletes)
- `Registration.finishTime` + `result` (both nullable) — populating UI is #201
- Migration `20260801053908_saved_events_and_results`

### Saved events (now DB-backed, was localStorage-only)
- `GET/POST/DELETE /api/user/saved-events`
- `lib/client-lists.ts` saved-event helpers now call the API
- `SaveEventButton` — async toggle, sign-in modal when unauthenticated, wired into `EventCard` and the event detail page
- `/activity` "Saved" tab reads from the API

### Race history
- `GET /api/user/profile` now returns `history`: KStats + chronologically-ordered CONFIRMED registrations with event + organiser details
- `/profile` shows real KStats (events completed, states raced, disciplines) and a timeline with result/time per event, replacing the hardcoded zeros

### Following
- `GET /api/user/following`
- `/activity` gains a "Following" tab (organiser cards, follower/event counts, unfollow)

### Seeding
- Seeded users get completed registrations with results/times across disciplines and states, saved events, and follows so the UI has realistic data

### Tests
- `e2e/user-profile.spec.ts` — profile KStats/timeline, save→activity flow, following/unfollow
- Full suite: 103 E2E + 91 unit pass, typecheck + lint clean

## Notes
- Saved events are not migrated from localStorage to DB (skipped per request)
- `finishTime`/`result` have no entry UI yet — that's #201