### PR TITLE
Show user + organiser nav simultaneously for organiser accounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ shadcn/ui components via `npx shadcn@latest add <component>`. Use `cn()` from `l
 ## Testing
 
 ```
-pnpm lint              # ESLint — 0 errors (warnings OK for <img> on QR codes)
+pnpm lint              # ESLint — 0 errors, 0 warnings
 pnpm test              # Vitest unit tests (77 tests, 8 files)
 pnpm test:watch        # Vitest watch mode
 pnpm test:e2e          # Playwright (needs Docker PostgreSQL + dev server)

--- a/app/(user)/settings/security/page.tsx
+++ b/app/(user)/settings/security/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { Shield, ShieldAlert, Trash2, KeyRound, Plus, ArrowRight, Check, Copy, Eye, EyeOff } from "lucide-react";
 import { useAuthContext } from "@/context/AuthContext";
 
@@ -193,9 +194,12 @@ export default function SecuritySettingsPage() {
             {setupStep === "qr" && (
               <>
                 <div className="flex justify-center">
-                  <img
+                  <Image
                     src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(qrUri)}`}
                     alt="TOTP QR Code"
+                    width={192}
+                    height={192}
+                    unoptimized
                     className="w-48 h-48 rounded-lg"
                   />
                 </div>

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { Mail, Lock, Eye, EyeOff, ArrowRight, ShieldAlert } from "lucide-react";
 import { signIn, signOut, confirmSignIn, fetchAuthSession } from "aws-amplify/auth";
 
@@ -199,9 +200,12 @@ export default function AdminLoginPage() {
         ) : mfaStep === "setup" && totpSetupUri ? (
           <div className="space-y-5">
             <div className="flex justify-center">
-              <img
+              <Image
                 src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(totpSetupUri)}`}
                 alt="TOTP QR Code"
+                width={192}
+                height={192}
+                unoptimized
                 className="w-48 h-48 rounded-lg"
               />
             </div>

--- a/app/api/user/role/route.ts
+++ b/app/api/user/role/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
   }
 
   if (session.groups.includes("admins")) {
-    return NextResponse.json({ role: "admin" });
+    return NextResponse.json({ role: "admin", hasOrganiser: false });
   }
 
   const user = await prisma.user.findUnique({
@@ -17,9 +17,6 @@ export async function GET() {
     include: { organiser: { select: { id: true } } },
   });
 
-  if (user?.organiser) {
-    return NextResponse.json({ role: "organiser" });
-  }
-
-  return NextResponse.json({ role: "user" });
+  const hasOrganiser = Boolean(user?.organiser);
+  return NextResponse.json({ role: hasOrganiser ? "organiser" : "user", hasOrganiser });
 }

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -7,7 +7,7 @@ import { usePathname, useRouter } from "next/navigation";
 import {
   User, LogOut, Building2, ShieldCheck, Shield, Plus, Settings, Bell,
   CheckCircle2, XCircle, Menu, X, LayoutDashboard, CalendarDays,
-  CreditCard, BookOpen, ArrowLeft, ChevronDown, Users, Star,
+  BookOpen, ChevronDown, Users, Star,
   UserCircle, ClipboardList, BarChart2, ScrollText,
 } from "lucide-react";
 import SignInModal from "@/components/SignInModal";
@@ -74,12 +74,10 @@ const NOTIF_ICON: Record<Notification["type"], React.ReactNode> = {
   NEW_REGISTRATION: <User         className="w-4 h-4 text-blue-400" />,
 };
 
-const CUSTOMER_URL = process.env.NODE_ENV === "development" ? "/" : "https://startlineau.com";
-
 export default function NavBar() {
   const router   = useRouter();
   const pathname = usePathname();
-  const { user, role, status, logout } = useAuthContext();
+  const { user, role, hasOrganiser, status, logout } = useAuthContext();
   const { open: openSettingsModal } = useSettings();
 
   const [isMenuOpen,   setIsMenuOpen]   = useState(false);
@@ -188,8 +186,8 @@ export default function NavBar() {
 
   return (
     <>
-      <nav className="fixed top-0 left-0 right-0 z-50 h-14 bg-dark-darker/80 backdrop-blur-xl border-b border-white/[0.05]">
-        <div className="flex items-center justify-between h-full max-w-[1200px] mx-auto px-4 sm:px-6 gap-4">
+      <nav className="fixed top-0 left-0 right-0 z-50 bg-dark-darker/80 backdrop-blur-xl border-b border-white/[0.05]">
+        <div className="flex items-center justify-between h-14 max-w-[1200px] mx-auto px-4 sm:px-6 gap-4">
 
           {/* ── Logo + Role badge ── */}
           <Link href="/" className="shrink-0 py-1 flex items-center gap-2">
@@ -238,7 +236,7 @@ export default function NavBar() {
                 )}
               </div>
             ) : (
-              (role === "organiser" ? ORGANISER_NAV : USER_NAV).map(({ href, label }) => {
+              USER_NAV.map(({ href, label }) => {
                 const isActive = href === "/" ? pathname === "/" : pathname?.startsWith(href) ?? false;
                 return (
                   <Link key={label} href={href}
@@ -365,16 +363,6 @@ export default function NavBar() {
                       </>
                     )}
 
-                    {role === "organiser" && (
-                      <>
-                        <div className="border-t border-white/10" />
-                        <Link href={CUSTOMER_URL} onClick={() => setIsUserOpen(false)}
-                          className="flex items-center gap-3 px-4 py-3 font-headline text-[13px] font-bold uppercase tracking-widest text-primary/80 hover:text-primary hover:bg-white/5 transition-colors">
-                          <ArrowLeft className="w-4 h-4" /> Switch to User
-                        </Link>
-                      </>
-                    )}
-
                     <div className="border-t border-white/10" />
                     <button onClick={handleSignOut}
                       className="w-full flex items-center gap-3 px-4 py-3 font-headline text-[13px] font-bold uppercase tracking-widest text-red-400/80 hover:text-red-400 hover:bg-white/5 transition-colors">
@@ -394,9 +382,32 @@ export default function NavBar() {
           </div>
         </div>
 
+        {/* ── Organiser secondary bar ── */}
+        {hasOrganiser && (
+          <div className="h-9 flex items-center border-t border-white/[0.05]">
+            <div className="flex items-center gap-0.5 max-w-[1200px] mx-auto px-4 sm:px-6 w-full overflow-x-auto">
+              <span className="shrink-0 flex items-center gap-1.5 font-headline text-[10px] font-bold uppercase tracking-widest text-primary/70">
+                <Building2 className="w-3 h-3" /> Organiser
+              </span>
+              {ORGANISER_NAV.map(({ href, label }) => {
+                const isActive = href === "/organiser/listings"
+                  ? pathname === href || (pathname?.startsWith(href + "/") ?? false)
+                  : pathname?.startsWith(href) ?? false;
+                return (
+                  <Link key={href} href={href}
+                    className={`shrink-0 px-3 py-1.5 rounded-md font-headline text-[11px] font-bold uppercase tracking-widest whitespace-nowrap transition-colors duration-150
+                      ${isActive ? "bg-white/15 text-white" : "text-white/50 hover:text-white hover:bg-white/10"}`}>
+                    {label}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
         {/* ── Mobile dropdown ── */}
         {isMenuOpen && (
-          <div className="md:hidden bg-dark-darker/95 backdrop-blur-xl border-t border-white/[0.05] max-h-[calc(100dvh-3.5rem)] overflow-y-auto">
+          <div className={`md:hidden bg-dark-darker/95 backdrop-blur-xl border-t border-white/[0.05] overflow-y-auto ${hasOrganiser ? "max-h-[calc(100dvh-5.75rem)]" : "max-h-[calc(100dvh-3.5rem)]"}`}>
             <div className="max-w-[1200px] mx-auto px-4 sm:px-6 py-1.5">
               {role && (() => {
                 const BadgeIcon = ROLE_BADGE[role].icon;
@@ -408,7 +419,7 @@ export default function NavBar() {
                 );
               })()}
 
-              {(role === "organiser" ? ORGANISER_NAV : role === "admin" ? ADMIN_NAV : USER_NAV).map(({ href, label, icon: Icon }) => {
+              {(role === "admin" ? ADMIN_NAV : USER_NAV).map(({ href, label, icon: Icon }) => {
                 const isActive = href === "/" ? pathname === "/" : pathname?.startsWith(href) ?? false;
                 return (
                   <Link key={label} href={href} onClick={() => setIsMenuOpen(false)}
@@ -440,12 +451,6 @@ export default function NavBar() {
               <div className="border-t border-white/10 mt-1.5 pt-3 pb-2">
                 {status === "authenticated" ? (
                   <>
-                    {role === "organiser" && (
-                      <Link href={CUSTOMER_URL} onClick={() => setIsMenuOpen(false)}
-                        className="w-full flex items-center justify-center gap-2 h-10 rounded-lg font-headline text-[12px] font-bold uppercase tracking-widest text-primary/80 border border-white/10 hover:text-primary hover:border-primary/30 transition-colors mb-2">
-                        <ArrowLeft className="w-3.5 h-3.5" /> Switch to User
-                      </Link>
-                    )}
                     <button onClick={() => { setIsMenuOpen(false); handleSignOut(); }}
                       className="w-full flex items-center justify-center gap-2 h-10 rounded-lg font-headline text-[12px] font-bold uppercase tracking-widest text-red-400/80 border border-white/10 hover:text-red-400 hover:border-red-400/30 transition-colors">
                       <LogOut className="w-3.5 h-3.5" /> Sign Out
@@ -463,43 +468,8 @@ export default function NavBar() {
         )}
       </nav>
 
-      {/* ── Mobile bottom nav (organiser only) ── */}
-      {role === "organiser" && (
-        <nav className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-dark border-t border-dark-lighter" style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
-          <div className="flex items-stretch h-16">
-            {[
-              { href: "/organiser/dashboard", label: "Home", icon: LayoutDashboard },
-              { href: "/organiser/listings", label: "Listings", icon: CalendarDays },
-              null,
-              { href: "/organiser/payments", label: "Payments", icon: CreditCard },
-              { href: "/organiser/profile", label: "Profile", icon: User },
-            ].map((item, i) => {
-              if (item === null) {
-                return (
-                  <div key="fab" className="flex-1 flex items-center justify-center">
-                    <Link href="/organiser/new-listing" aria-label="Create new listing"
-                      className={`w-12 h-12 rounded-full flex items-center justify-center shadow-lg transition-transform active:scale-95
-                        ${pathname?.startsWith("/organiser/new-listing") ? "bg-primary/80 ring-2 ring-primary/40" : "bg-primary"}`}>
-                      <Plus className="w-6 h-6 text-dark" strokeWidth={2.5} />
-                    </Link>
-                  </div>
-                );
-              }
-              const isActive = item.href === "/organiser/listings"
-                ? pathname === item.href || (pathname?.startsWith(item.href + "/") ?? false)
-                : pathname === item.href;
-              return (
-                <Link key={item.href} href={item.href}
-                  className={`flex-1 flex flex-col items-center justify-center gap-1 min-h-[44px] transition-colors
-                    ${isActive ? "text-primary" : "text-muted"}`}>
-                  <item.icon className="w-[22px] h-[22px]" strokeWidth={isActive ? 2.5 : 2} />
-                  <span className="font-headline text-[10px] uppercase tracking-widest font-bold">{item.label}</span>
-                </Link>
-              );
-            })}
-          </div>
-        </nav>
-      )}
+      {/* Reserves the organiser bar's height in flow so fixed nav never overlaps content */}
+      {hasOrganiser && <div className="h-9" />}
 
       <SignInModal isOpen={isSignInOpen} onClose={() => setIsSignInOpen(false)} />
     </>

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { X, Mail, Lock, Eye, EyeOff, ArrowRight, ArrowLeft, User, ChevronDown, Check, AtSign, ShieldAlert } from "lucide-react";
 import { signIn, signUp, signOut, resetPassword, confirmResetPassword, confirmSignIn } from "aws-amplify/auth";
 import { useAuthContext } from "@/context/AuthContext";
@@ -736,9 +737,12 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
             {mfaStep === "setup" && totpSetupUri && (
               <div className="space-y-4">
                 <div className="flex justify-center">
-                  <img
+                  <Image
                     src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(totpSetupUri)}`}
                     alt="TOTP QR Code"
+                    width={192}
+                    height={192}
+                    unoptimized
                     className="w-48 h-48 rounded-lg"
                   />
                 </div>

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -13,27 +13,30 @@ export type AuthUser = {
 type AuthStatus = "loading" | "authenticated" | "unauthenticated";
 
 type AuthContextValue = {
-  user:    AuthUser | null;
-  role:    Role | null;
-  status:  AuthStatus;
-  loading: boolean;
-  refresh: () => Promise<void>;
-  logout:  () => Promise<void>;
+  user:         AuthUser | null;
+  role:         Role | null;
+  hasOrganiser: boolean;
+  status:       AuthStatus;
+  loading:      boolean;
+  refresh:      () => Promise<void>;
+  logout:       () => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextValue>({
-  user:    null,
-  role:    null,
-  status:  "loading",
-  loading: true,
-  refresh: async () => {},
-  logout:  async () => {},
+  user:         null,
+  role:         null,
+  hasOrganiser: false,
+  status:       "loading",
+  loading:      true,
+  refresh:      async () => {},
+  logout:       async () => {},
 });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user,   setUser]   = useState<AuthUser | null>(null);
-  const [role,   setRole]   = useState<Role | null>(null);
-  const [status, setStatus] = useState<AuthStatus>("loading");
+  const [user,         setUser]         = useState<AuthUser | null>(null);
+  const [role,         setRole]         = useState<Role | null>(null);
+  const [hasOrganiser, setHasOrganiser] = useState(false);
+  const [status,       setStatus]       = useState<AuthStatus>("loading");
 
   const hydrate = useCallback(async () => {
     if (process.env.NODE_ENV === "development" && typeof document !== "undefined" && document.cookie.includes("__e2e_bypass=1")) {
@@ -82,7 +85,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     fetch("/api/user/role")
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
-        if (!cancelled && data?.role) setRole(data.role);
+        if (!cancelled && data?.role) {
+          setRole(data.role);
+          setHasOrganiser(Boolean(data.hasOrganiser));
+        }
       })
       .catch(() => {});
     return () => {
@@ -101,6 +107,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         value={{
           user,
           role,
+          hasOrganiser,
           status,
           loading: status === "loading",
           refresh: hydrate,


### PR DESCRIPTION
## What

Organiser accounts previously defaulted to organiser view with no way back to the user view — the "Switch to User" link just navigated domains and the role API re-resolved to organiser on reload.

Now the main navbar always shows the **user** nav (HOME / EVENTS / ACTIVITY), and when the account has an organiser profile a thin **secondary bar** appears below it with the organiser links (Dashboard, Listings, Profile, Payments, Guide). Both views stay visible; no switching needed.

## Changes

- **`components/NavBar.tsx`** — main bar always renders user nav; new `h-9` secondary organiser bar when `hasOrganiser` (horizontally scrollable on mobile); flow spacer reserves the bar's height so the fixed nav never overlaps page content; removed Switch to User/Organiser buttons and the organiser-only mobile bottom nav.
- **`app/api/user/role/route.ts`** — returns `hasOrganiser` alongside `role` (no role change for existing users).
- **`context/AuthContext.tsx`** — exposes `hasOrganiser` from the role endpoint.
- **`app/(user)/settings/security/page.tsx`, `app/admin/login/page.tsx`, `components/SignInModal.tsx`** — TOTP QR `<img>` → `next/image` (`unoptimized`), clearing the last 3 lint warnings.
- **`AGENTS.md`** — lint line now reads 0 errors, 0 warnings.

## Verification

- `pnpm lint` — 0 errors, 0 warnings
- Typecheck clean on changed files (full `pnpm typecheck` blocked in this worktree by missing `.env.local` → stale `@prisma/client`, pre-existing)
- No e2e tests reference removed UI (`Switch to User` / bottom nav)