### PR TITLE
feat: show organiser's events map on profile

### DIFF
--- a/components/EventMap.tsx
+++ b/components/EventMap.tsx
@@ -28,7 +28,8 @@ function useIsClient() {
 interface EventMapProps {
   events: UserEvent[];
   selectedId: string | null;
-  onMarkerClick: (id: string) => void;
+  /** Optional — defaults to a noop for read-only embeds (e.g. organiser profile). */
+  onMarkerClick?: (id: string) => void;
   initialCenter?: { lng: number; lat: number; zoom: number };
 }
 
@@ -98,7 +99,7 @@ const EventMap = forwardRef<EventMapHandle, EventMapProps>(function EventMap(
   ref,
 ) {
   const mapRef = useRef<MapRef | null>(null);
-  const onMarkerClickRef = useRef(onMarkerClick);
+  const onMarkerClickRef = useRef(onMarkerClick ?? (() => {}));
   const hasFramedInitial = useRef(false);
   const lastFlownIdRef = useRef<string | null>(null);
   const filterKeyRef = useRef("");
@@ -111,7 +112,7 @@ const EventMap = forwardRef<EventMapHandle, EventMapProps>(function EventMap(
   const [activeMapStyle, setActiveMapStyle] = useState(mapStyle);
 
   useEffect(() => {
-    onMarkerClickRef.current = onMarkerClick;
+    onMarkerClickRef.current = onMarkerClick ?? (() => {});
   }, [onMarkerClick]);
 
   useEffect(() => {
@@ -316,7 +317,7 @@ const EventMap = forwardRef<EventMapHandle, EventMapProps>(function EventMap(
 
                   <button
                     type="button"
-                    onClick={() => onMarkerClick(event.id)}
+                    onClick={() => onMarkerClick?.(event.id)}
                     className={`shrink-0 rounded-full border-2 border-white/90 shadow-[0_0_0_2px_rgba(0,0,0,0.35)] transition-all ${
                       isSelected
                         ? "w-5 h-5 bg-primary scale-125 shadow-[0_0_0_4px_rgba(179,225,83,0.35)]"

--- a/components/OrganiserProfileView.tsx
+++ b/components/OrganiserProfileView.tsx
@@ -190,7 +190,7 @@ export default function OrganiserProfileView({
             </div>
 
             <div className="lg:sticky lg:top-20 h-[320px] lg:h-[min(70vh,640px)] rounded-2xl border border-dark-lighter bg-dark overflow-hidden">
-              <EventMap events={upcoming} selectedId={null} onMarkerClick={() => {}} />
+              <EventMap events={upcoming} selectedId={null} />
             </div>
           </div>
         </div>

--- a/components/OrganiserProfileView.tsx
+++ b/components/OrganiserProfileView.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
 import { format } from "date-fns";
-import { MapPin } from "lucide-react";
 import type { UserEvent } from "@/types";
 import type { PublicReview } from "@/lib/reviews";
 import type { OrganiserPublicStats } from "@/lib/organiser-follows";
@@ -11,6 +10,7 @@ import OrganiserReviewsClient from "@/components/OrganiserReviewsClient";
 import OrganiserRating from "@/components/OrganiserRating";
 import OrganiserFollowSection from "@/components/OrganiserFollowSection";
 import OrganiserEditProfileButton from "@/components/OrganiserEditProfileButton";
+import EventMap from "@/components/EventMap";
 import { ScrollCarousel } from "@/components/ui/ScrollCarousel";
 
 export type OrganiserProfileData = {
@@ -190,12 +190,7 @@ export default function OrganiserProfileView({
             </div>
 
             <div className="lg:sticky lg:top-20 h-[320px] lg:h-[min(70vh,640px)] rounded-2xl border border-dark-lighter bg-dark overflow-hidden">
-              <div className="h-full flex flex-col items-center justify-center gap-2 px-6 text-center">
-                <MapPin className="w-6 h-6 text-primary/60" />
-                <p className="font-headline text-xs font-bold uppercase tracking-widest text-muted">
-                  Map coming soon
-                </p>
-              </div>
+              <EventMap events={upcoming} selectedId={null} onMarkerClick={() => {}} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description

Replaces the "Map coming soon" placeholder on organiser profile pages with the existing `EventMap` component, rendering the organiser's upcoming events with coordinates.

Events already carry `latitude`/`longitude` (with a city/state fallback in `eventLngLat`), so no schema, API, or onboarding changes were needed. `EventMap` handles no-token, loading, and no-events states.

## Changes

- `components/OrganiserProfileView.tsx`: drop the `MapPin` placeholder, render `<EventMap events={upcoming} />`