### PR TITLE
feat: default events map to user's area via geolocation

### DIFF
--- a/components/EventsListing.tsx
+++ b/components/EventsListing.tsx
@@ -97,18 +97,38 @@ function EventsListingInner() {
       .catch(() => {});
   }, []);
 
-  // Fetch user location for map centering
+  // Default map to the user's area: device GPS first, then profile city/state,
+  // then fall back to the Australia-wide view. Runs once on mount.
   useEffect(() => {
-    if (status !== "authenticated") return;
-    fetch("/api/user/profile")
-      .then((r) => r.json())
-      .then((data) => {
-        if (data?.city && data?.state) {
-          const [lat, lng] = getEventCoords(data.city, data.state);
-          setInitialCenter({ lng, lat, zoom: 5 });
-        }
-      })
-      .catch(() => {});
+    let cancelled = false;
+
+    function tryProfileFallback() {
+      if (status !== "authenticated") return;
+      fetch("/api/user/profile")
+        .then((r) => r.json())
+        .then((data) => {
+          if (!cancelled && data?.city && data?.state) {
+            const [lat, lng] = getEventCoords(data.city, data.state);
+            setInitialCenter({ lng, lat, zoom: 8 });
+          }
+        })
+        .catch(() => {});
+    }
+
+    if (!navigator.geolocation) {
+      tryProfileFallback();
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        if (!cancelled) setInitialCenter({ lng: pos.coords.longitude, lat: pos.coords.latitude, zoom: 10 });
+      },
+      () => tryProfileFallback(),
+      { timeout: 5000, maximumAge: 300_000 },
+    );
+
+    return () => { cancelled = true; };
   }, [status]);
 
   const searchParams = useSearchParams();

--- a/e2e/events.spec.ts
+++ b/e2e/events.spec.ts
@@ -42,6 +42,15 @@ test.describe("events page", () => {
     await page.getByTestId("view-mode-map").first().click();
     await expect(page.getByTestId("events-map")).toBeVisible();
   });
+
+  test("map renders when geolocation is granted", async ({ page, context }) => {
+    await context.grantPermissions(["geolocation"], { origin: "http://localhost:3000" });
+    await context.setGeolocation({ latitude: -33.8688, longitude: 151.2093, accuracy: 5 });
+    await page.goto("/events");
+    await page.waitForLoadState("networkidle");
+    await page.getByTestId("view-mode-map").first().click();
+    await expect(page.getByTestId("events-map")).toBeVisible();
+  });
 });
 
 test.describe("event detail page", () => {


### PR DESCRIPTION
## Description

Default the events map to the user's area instead of zooming to the whole of Australia. Resolves part of #199.

Priority chain when the events page loads:
1. **Device GPS** — `navigator.geolocation.getCurrentPosition`, zoom 10 (city + suburbs). Works for anonymous and logged-in users.
2. **Profile city/state** (auth only) — fallback when geolocation is denied/unavailable, zoom 8.
3. **Australia-wide view** — last resort, unchanged.

Previously this only used the profile city/state and only for authenticated users (`zoom: 5`); anonymous users always saw the continent view.

## Related issues

Closes part of #199 — distance-based filtering/sorting is tracked separately in #205.