### PR TITLE
feat: distance-based event search (#205)

### DIFF
--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -59,6 +59,9 @@ export default function EventCard({ event, className, cardClassName, onSelect, s
           <div className="flex items-center gap-2 font-headline text-[10px] font-medium uppercase tracking-widest text-muted">
             <MapPin className="w-3 h-3 text-primary flex-shrink-0" />
             <span className="truncate">{event.city}, {STATE_LABELS[event.state]}</span>
+            {event.distance && (
+              <span data-testid="event-distance" className="ml-auto flex-shrink-0 text-primary font-bold">{event.distance} away</span>
+            )}
           </div>
           <div className="flex items-center gap-2 font-headline text-[10px] font-medium uppercase tracking-widest text-muted">
             <Clock className="w-3 h-3 text-primary flex-shrink-0" />

--- a/components/EventsListing.tsx
+++ b/components/EventsListing.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useEffect, useRef, useCallback, useLayoutEffect, Sus
 import { createPortal } from "react-dom";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Search, MapPin, X, LayoutGrid, ChevronDown, Check, ArrowUpDown } from "lucide-react";
+import { Search, MapPin, X, LayoutGrid, ChevronDown, Check, ArrowUpDown, Locate, Loader2 } from "lucide-react";
 import type { UserEvent, FilterState, EventType, AustralianState, CompetitionFormat, ExperienceLevel, SortOption } from "@/types";
 import {
   EVENT_TYPE_LABELS, STATE_LABELS, STATE_OPTIONS, EVENT_TYPE_OPTIONS,
@@ -13,6 +13,7 @@ import {
 } from "@/types";
 import { filterEvents, sortEvents } from "@/lib/utils";
 import { toUserEvents } from "@/lib/user-events";
+import { eventDistance, formatDistance, DEFAULT_RADIUS_KM } from "@/lib/distance";
 import { getEventCoords } from "@/lib/australia-coords";
 import { useAuthContext } from "@/context/AuthContext";
 import EventMap from "@/components/EventMap";
@@ -114,6 +115,8 @@ function EventsListingInner() {
   const searchParams = useSearchParams();
   const [whatQuery,     setWhatQuery]     = useState(searchParams.get("what")  ?? "");
   const [whereQuery,    setWhereQuery]    = useState(searchParams.get("where") ?? "");
+  const [searchOrigin,  setSearchOrigin]  = useState<{ lat: number; lng: number } | null>(null);
+  const [isGeocoding,   setIsGeocoding]   = useState(false);
   const [typeFilters,   setTypeFilters]   = useState<EventType[]>(searchParams.get("type") ? [searchParams.get("type") as EventType] : []);
   const [stateFilters,  setStateFilters]  = useState<AustralianState[]>([]);
   const [formatFilters, setFormatFilters] = useState<CompetitionFormat[]>([]);
@@ -127,6 +130,64 @@ function EventsListingInner() {
   // Latches true the first time the Map tab is viewed, so EventMap mounts
   // once and then just toggles visibility (avoids re-init/re-fetch on every tab switch).
   const [mapEverViewed, setMapEverViewed] = useState(view === "map");
+
+  const locateMe = useCallback(() => {
+    if (!("geolocation" in navigator)) return;
+    setIsGeocoding(true);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setSearchOrigin({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+        setWhereQuery("Current location");
+        setIsGeocoding(false);
+      },
+      () => {
+        setSearchOrigin(null);
+        setWhereQuery("");
+        setIsGeocoding(false);
+      },
+      { timeout: 10000 }
+    );
+  }, []);
+
+  const handleWhereSearch = useCallback(async (raw?: string) => {
+    const q = (raw ?? whereQuery).trim();
+    if (!q) { setSearchOrigin(null); return; }
+    if (q.toLowerCase() === "current location") { locateMe(); return; }
+    setIsGeocoding(true);
+    try {
+      const res = await fetch(`/api/places/geocode?q=${encodeURIComponent(q)}`);
+      const data = await res.json();
+      const result = data?.result;
+      if (result && typeof result.latitude === "number" && typeof result.longitude === "number") {
+        setSearchOrigin({ lat: result.latitude, lng: result.longitude });
+      } else {
+        // Geocode failed — fall back to substring matching.
+        setSearchOrigin(null);
+      }
+    } catch {
+      setSearchOrigin(null);
+    } finally {
+      setIsGeocoding(false);
+    }
+  }, [whereQuery, locateMe]);
+
+  const clearWhere = useCallback(() => {
+    setWhereQuery("");
+    setSearchOrigin(null);
+  }, []);
+
+  // Auto-search an initial ?where= param (e.g. from HeroSearch) once.
+  const didInitialWhere = useRef(false);
+  useEffect(() => {
+    if (didInitialWhere.current) return;
+    didInitialWhere.current = true;
+    const initial = searchParams.get("where");
+    if (!initial) return;
+    // Defer so the geocode fetch (and its setState) runs after this effect settles.
+    const t = setTimeout(() => handleWhereSearch(initial), 0);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Close an open filter dropdown on outside click / Escape.
   useEffect(() => {
@@ -156,20 +217,37 @@ function EventsListingInner() {
     priceRange,
     dateRange:   dateFilter,
     searchQuery: whatQuery,
-  }), [typeFilters, stateFilters, formatFilters, levelFilters, priceRange, dateFilter, whatQuery]);
+    originLat:   searchOrigin?.lat,
+    originLng:   searchOrigin?.lng,
+    maxDistance: searchOrigin ? DEFAULT_RADIUS_KM : undefined,
+  }), [typeFilters, stateFilters, formatFilters, levelFilters, priceRange, dateFilter, whatQuery, searchOrigin]);
 
   const displayEvents = useMemo(() => {
     let results = filterEvents(allEvents, filterState);
-    results = sortEvents(results, sortBy);
-    if (whereQuery.trim()) {
-      const q = whereQuery.toLowerCase();
-      results = results.filter((e) => e.city.toLowerCase().includes(q) || e.state.toLowerCase().includes(q) || e.location.toLowerCase().includes(q));
+    if (searchOrigin) {
+      // Geocoded search — sort closest-first and stamp distance onto each event.
+      results = results
+        .map((e) => {
+          const dist = eventDistance(searchOrigin, e);
+          return { ...e, distance: dist === null ? undefined : formatDistance(dist) };
+        })
+        .sort((a, b) => {
+          const da = eventDistance(searchOrigin, a) ?? Infinity;
+          const db = eventDistance(searchOrigin, b) ?? Infinity;
+          return da - db;
+        });
+    } else {
+      results = sortEvents(results, sortBy);
+      if (whereQuery.trim()) {
+        const q = whereQuery.toLowerCase();
+        results = results.filter((e) => e.city.toLowerCase().includes(q) || e.state.toLowerCase().includes(q) || e.location.toLowerCase().includes(q));
+      }
     }
     return results;
-  }, [allEvents, filterState, whereQuery, sortBy]);
+  }, [allEvents, filterState, whereQuery, sortBy, searchOrigin]);
 
   function clearFilters() {
-    setWhatQuery(""); setWhereQuery("");
+    setWhatQuery(""); clearWhere();
     setTypeFilters([]); setStateFilters([]); setFormatFilters([]); setLevelFilters([]);
     setPriceRange(null); setDateFilter("all");
   }
@@ -252,8 +330,12 @@ function EventsListingInner() {
             <div className="flex items-center gap-1.5">
               <input type="text" placeholder="State, city, or suburb" value={whereQuery}
                 onChange={(e) => setWhereQuery(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleWhereSearch()}
                 className="w-full bg-transparent text-light font-headline text-sm placeholder:text-muted/40 border-0 focus:ring-0 focus:outline-none" />
-              {whereQuery && <button onClick={() => setWhereQuery("")} className="text-muted hover:text-light flex-shrink-0"><X className="w-3.5 h-3.5" /></button>}
+              {isGeocoding
+                ? <Loader2 data-testid="geocoding-spinner" className="w-3.5 h-3.5 text-muted animate-spin flex-shrink-0" />
+                : <button onClick={locateMe} aria-label="Use my location" title="Use my location" className="text-muted hover:text-primary flex-shrink-0"><Locate className="w-3.5 h-3.5" /></button>}
+              {whereQuery && <button onClick={clearWhere} aria-label="Clear where" className="text-muted hover:text-light flex-shrink-0"><X className="w-3.5 h-3.5" /></button>}
             </div>
           </div>
         </div>
@@ -277,8 +359,12 @@ function EventsListingInner() {
             <MapPin className="w-4 h-4 text-muted flex-shrink-0" />
             <input type="text" placeholder="City or state" value={whereQuery}
               onChange={(e) => setWhereQuery(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleWhereSearch()}
               className="flex-1 bg-transparent text-light font-headline text-sm placeholder:text-muted/40 border-0 focus:outline-none" />
-            {whereQuery && <button onClick={() => setWhereQuery("")} className="text-muted"><X className="w-4 h-4" /></button>}
+            {isGeocoding
+              ? <Loader2 data-testid="geocoding-spinner" className="w-4 h-4 text-muted animate-spin flex-shrink-0" />
+              : <button onClick={locateMe} aria-label="Use my location" title="Use my location" className="text-muted hover:text-primary flex-shrink-0"><Locate className="w-4 h-4" /></button>}
+            {whereQuery && <button onClick={clearWhere} aria-label="Clear where" className="text-muted"><X className="w-4 h-4" /></button>}
           </div>
           <button onClick={() => setMobileSearch(false)} className="text-center font-headline text-xs uppercase tracking-widest text-muted py-1">Done</button>
         </div>

--- a/components/HeroSearch.tsx
+++ b/components/HeroSearch.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Search, X, MapPin } from "lucide-react";
+import { Search, X, MapPin, Locate } from "lucide-react";
 
 export default function HeroSearch() {
   const router = useRouter();
@@ -14,6 +14,15 @@ export default function HeroSearch() {
     if (what.trim())  params.set("what", what.trim());
     if (where.trim()) params.set("where", where.trim());
     router.push(params.toString() ? `/events?${params.toString()}` : "/events");
+  }
+
+  // Geocoding + GPS live in EventsListing; here we just land on the events
+  // page with the "Current location" marker and let it prompt for the device.
+  function handleLocate() {
+    const params = new URLSearchParams();
+    if (what.trim()) params.set("what", what.trim());
+    params.set("where", "Current location");
+    router.push(`/events?${params.toString()}`);
   }
 
   function handleKey(e: React.KeyboardEvent) {
@@ -64,6 +73,9 @@ export default function HeroSearch() {
                 <X className="w-4 h-4" />
               </button>
             )}
+            <button onClick={handleLocate} className="text-muted hover:text-primary" aria-label="Use my location" title="Use my location">
+              <Locate className="w-4 h-4" />
+            </button>
           </div>
         </div>
 
@@ -121,6 +133,9 @@ export default function HeroSearch() {
                 <X className="w-4 h-4" />
               </button>
             )}
+            <button onClick={handleLocate} className="text-muted hover:text-primary" aria-label="Use my location" title="Use my location">
+              <Locate className="w-5 h-5" />
+            </button>
           </div>
         </div>
 

--- a/e2e/distance-search.spec.ts
+++ b/e2e/distance-search.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const SYDNEY = { latitude: -33.8688, longitude: 151.2093 };
+
+async function stubGeocode(page: Page, result: { latitude: number; longitude: number } | null, delay = 0) {
+  await page.route("**/api/places/geocode**", async (route) => {
+    if (delay) await new Promise((r) => setTimeout(r, delay));
+    await route.fulfill({ json: { result } });
+  });
+}
+
+async function searchWhere(page: Page, query: string) {
+  await page.getByPlaceholder("State, city, or suburb").fill(query);
+  await page.keyboard.press("Enter");
+}
+
+test.describe("distance-based search", () => {
+  test("geocoding a valid suburb sorts events closest-first and shows distance badges", async ({ page }) => {
+    await stubGeocode(page, SYDNEY);
+    await page.goto("/events?view=list");
+    await page.waitForLoadState("networkidle");
+
+    await searchWhere(page, "Sydney");
+
+    // Distance badges appear once geocoding succeeds.
+    await expect(page.locator('[data-testid="event-distance"]').first()).toBeVisible({ timeout: 10000 });
+
+    // Sydney events are all near the origin — badges read like "0km away".
+    const badges = page.locator('[data-testid="event-distance"]');
+    const texts = await badges.allTextContents();
+    expect(texts.length).toBeGreaterThan(0);
+    expect(texts.every((t) => /^[\d.]+km away$/.test(t))).toBe(true);
+  });
+
+  test("loading state shows a spinner while geocoding", async ({ page }) => {
+    await stubGeocode(page, SYDNEY, 1500);
+    await page.goto("/events?view=list");
+    await page.waitForLoadState("networkidle");
+
+    await searchWhere(page, "Sydney");
+
+    await expect(page.locator('[data-testid="geocoding-spinner"]').first()).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="event-distance"]').first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test("falls back to substring matching when geocoding fails", async ({ page }) => {
+    await stubGeocode(page, null);
+    await page.goto("/events?view=list");
+    await page.waitForLoadState("networkidle");
+
+    await searchWhere(page, "Sydney");
+
+    // No distance badges (geocode returned nothing), but substring filtering still applies.
+    await expect(page.locator('[data-testid="event-distance"]').first()).toHaveCount(0);
+    await expect(page.getByText(/Sydney Harbour 10K/).first()).toBeVisible();
+  });
+
+  test("unknown suburb without geocode results shows no events and empty state", async ({ page }) => {
+    await stubGeocode(page, null);
+    await page.goto("/events?view=list");
+    await page.waitForLoadState("networkidle");
+
+    await searchWhere(page, "zzz-no-such-place");
+
+    await expect(page.getByText("No events found.").first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test("clearing the where input resets to normal listing", async ({ page }) => {
+    await stubGeocode(page, SYDNEY);
+    await page.goto("/events?view=list");
+    await page.waitForLoadState("networkidle");
+
+    await searchWhere(page, "Sydney");
+    await expect(page.locator('[data-testid="event-distance"]').first()).toBeVisible({ timeout: 10000 });
+
+    // Clear the input via the X button.
+    await page.getByRole("button", { name: "Clear where" }).first().click();
+    await expect(page.locator('[data-testid="event-distance"]').first()).toHaveCount(0);
+    await expect(page.getByText(/events found/i).first()).toBeVisible();
+  });
+
+  test("use my location button triggers device geolocation", async ({ page }) => {
+    await stubGeocode(page, SYDNEY);
+    await page.context().grantPermissions(["geolocation"]);
+    await page.context().setGeolocation({ latitude: SYDNEY.latitude, longitude: SYDNEY.longitude });
+    await page.goto("/events?view=list");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: "Use my location" }).first().click();
+
+    // GPS resolves to the device position — distance badges appear.
+    await expect(page.locator('[data-testid="event-distance"]').first()).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/lib/distance.ts
+++ b/lib/distance.ts
@@ -1,0 +1,32 @@
+import type { UserEvent } from "@/types";
+import { eventLngLat } from "@/lib/map-events";
+
+export const DEFAULT_RADIUS_KM = 100;
+
+const EARTH_RADIUS_KM = 6371;
+
+/** Great-circle distance between two lat/lng points in kilometres (Haversine). */
+export function haversineDistance(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(a));
+}
+
+/** "1.2km" for sub-10, "12km" otherwise. */
+export function formatDistance(km: number): string {
+  return km < 10 ? `${km.toFixed(1)}km` : `${Math.round(km)}km`;
+}
+
+/** Distance from an origin to an event's resolved coordinates, or null if the event has none. */
+export function eventDistance(
+  origin: { lat: number; lng: number },
+  event: UserEvent
+): number | null {
+  const ll = eventLngLat(event);
+  if (!ll) return null;
+  return haversineDistance(origin.lat, origin.lng, ll.lat, ll.lng);
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,6 +2,7 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { format, parseISO, isAfter, isBefore, startOfDay, addMonths, endOfMonth } from "date-fns";
 import type { UserEvent, FilterState, SortOption, ExperienceLevel } from "@/types";
+import { eventDistance } from "@/lib/distance";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -134,6 +135,11 @@ export function filterEvents(
         event.city.toLowerCase().includes(q) ||
         (event.organizer?.toLowerCase().includes(q) ?? false);
       if (!matches) return false;
+    }
+
+    if (filters.originLat != null && filters.originLng != null && filters.maxDistance != null) {
+      const dist = eventDistance({ lat: filters.originLat, lng: filters.originLng }, event);
+      if (dist === null || dist > filters.maxDistance) return false;
     }
 
     return true;

--- a/src/__tests__/distance.test.ts
+++ b/src/__tests__/distance.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { haversineDistance, formatDistance, eventDistance, DEFAULT_RADIUS_KM } from "@/lib/distance";
+import type { UserEvent } from "@/types";
+
+const baseEvent: UserEvent = {
+  id: "1",
+  title: "Test Event",
+  description: "Desc",
+  date: "2026-08-15",
+  time: "09:00",
+  location: "Venue",
+  city: "Melbourne",
+  state: "vic",
+  type: "running",
+  discipline: "running",
+  format: "individual",
+  level: "open",
+  image: "",
+  registrationUrl: null,
+  registrationType: "startline",
+  feeStructure: "athlete",
+  organiserId: "org-1",
+  fromPrice: null,
+  registrationCount: 0,
+};
+
+describe("haversineDistance", () => {
+  it("returns 0 for identical points", () => {
+    expect(haversineDistance(-33.8688, 151.2093, -33.8688, 151.2093)).toBeCloseTo(0, 1);
+  });
+
+  it("Sydney → Melbourne is roughly 713km", () => {
+    const d = haversineDistance(-33.8688, 151.2093, -37.8136, 144.9631);
+    expect(d).toBeGreaterThan(700);
+    expect(d).toBeLessThan(730);
+  });
+
+  it("Byron Bay → Gold Coast is roughly 65km", () => {
+    const d = haversineDistance(-28.6474, 153.602, -28.0167, 153.4);
+    expect(d).toBeGreaterThan(55);
+    expect(d).toBeLessThan(75);
+  });
+
+  it("is symmetric", () => {
+    const a = haversineDistance(-33.8, 151.2, -37.8, 144.9);
+    const b = haversineDistance(-37.8, 144.9, -33.8, 151.2);
+    expect(a).toBeCloseTo(b, 6);
+  });
+});
+
+describe("formatDistance", () => {
+  it("formats sub-10km with one decimal", () => {
+    expect(formatDistance(0.5)).toBe("0.5km");
+    expect(formatDistance(9.4)).toBe("9.4km");
+  });
+
+  it("formats 10km+ as rounded integers", () => {
+    expect(formatDistance(12)).toBe("12km");
+    expect(formatDistance(87.4)).toBe("87km");
+    expect(formatDistance(1200)).toBe("1200km");
+  });
+});
+
+describe("eventDistance", () => {
+  const origin = { lat: -33.8688, lng: 151.2093 }; // Sydney
+
+  it("computes distance for events with stored coords", () => {
+    const d = eventDistance(origin, { ...baseEvent, latitude: -37.8, longitude: 144.9 });
+    expect(d).not.toBeNull();
+    expect(d!).toBeGreaterThan(700);
+  });
+
+  it("falls back to city/state lookup for events without coords", () => {
+    const d = eventDistance(origin, { ...baseEvent, city: "Melbourne", state: "vic" });
+    expect(d).not.toBeNull();
+    expect(d!).toBeGreaterThan(700);
+  });
+
+  it("returns null when the event has no resolvable coords", () => {
+    expect(eventDistance(origin, { ...baseEvent, city: "", state: "vic" })).toBeNull();
+  });
+});
+
+describe("DEFAULT_RADIUS_KM", () => {
+  it("caps at 100km", () => {
+    expect(DEFAULT_RADIUS_KM).toBe(100);
+  });
+});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -139,6 +139,32 @@ describe("filterEvents", () => {
     expect(result).toHaveLength(1);
     expect(result[0].fromPrice).toBe(150);
   });
+
+  it("excludes events beyond maxDistance", () => {
+    // Origin = Sydney; Melbourne event ~713km away, Sydney event ~0km away.
+    const result = filterEvents(baseEvents, {
+      ...emptyFilters,
+      originLat: -33.8688,
+      originLng: 151.2093,
+      maxDistance: 10,
+    });
+    expect(result.some((e) => e.city === "Melbourne")).toBe(false);
+  });
+
+  it("includes events within maxDistance", () => {
+    const result = filterEvents(baseEvents, {
+      ...emptyFilters,
+      originLat: -33.8688,
+      originLng: 151.2093,
+      maxDistance: 100,
+    });
+    expect(result.some((e) => e.city === "Sydney")).toBe(true);
+  });
+
+  it("is a no-op when no origin is set", () => {
+    const result = filterEvents(baseEvents, { ...emptyFilters, maxDistance: 10 });
+    expect(result.length).toBeGreaterThan(0);
+  });
 });
 
 describe("sortEvents", () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -89,6 +89,9 @@ export interface FilterState {
   priceRange: [number, number] | null;
   dateRange: "this-month" | "next-3" | "all";
   searchQuery: string;
+  originLat?: number;
+  originLng?: number;
+  maxDistance?: number;
 }
 
 export type SortOption = "date" | "price-asc" | "price-desc" | "popular";


### PR DESCRIPTION
## Description

Closes #205.

Builds on the map-centering work from #199 to make the "Where" search filter events by geographic proximity instead of substring matching.

### What changed

- **`lib/distance.ts`** (new) — Haversine distance helpers (`haversineDistance`, `formatDistance`, `eventDistance`). `eventDistance` resolves event coords via the existing `eventLngLat()` fallback (DB lat/lng → city/state lookup), so events without explicit coordinates still get a distance.
- **`components/EventsListing.tsx`** — pressing Enter in "Where" geocodes via the existing `GET /api/places/geocode`, stores a `searchOrigin`, filters events within a 100km radius (`DEFAULT_RADIUS_KM`), sorts closest-first, and stamps `event.distance` onto each event. Falls back to the old substring match when geocoding fails (typo/unknown suburb). Shows a loading spinner while geocoding, and a "Use my location" button that triggers `navigator.geolocation`. Auto-searches an initial `?where=` param on mount (e.g. from the hero search).
- **`components/EventCard.tsx`** — "12km away" badge on cards when `event.distance` is set.
- **`components/HeroSearch.tsx`** — "Use my location" button that lands on `/events?where=Current+location`.
- **`types/index.ts`** / **`lib/utils.ts`** — `FilterState` gains `originLat`/`originLng`/`maxDistance`; `filterEvents` applies the radius gate.

### Tests

- `src/__tests__/distance.test.ts` (new) — haversine, formatting, coord fallback.
- `src/__tests__/utils.test.ts` — radius filter behaviour.
- `e2e/distance-search.spec.ts` (new) — 6 tests stubbing the geocode endpoint via `page.route` (no AWS dependency): closest-first sort + badges, loading spinner, substring fallback, empty state, clearing the search, and "use my location" via granted browser geolocation.

### Verification

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 104 pass
- `pnpm test:e2e` — 106 pass, 2 skipped (Cognito signup, expected)