### PR TITLE
feat: Capacitor native app port — web-layer adjustments (Phase 3)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -23,6 +23,12 @@
   --color-muted-light: 160 165 174;
   --color-muted-dark: 110 115 123;
   color-scheme: dark;
+
+  /* Notch / home-indicator insets (Capacitor: viewport-fit=cover) */
+  --sat: env(safe-area-inset-top, 0px);
+  --sab: env(safe-area-inset-bottom, 0px);
+  --sal: env(safe-area-inset-left, 0px);
+  --sar: env(safe-area-inset-right, 0px);
 }
 
 * {
@@ -37,6 +43,8 @@ body {
   /* `clip` prevents horizontal overflow without creating a scroll container —
      `hidden` here silently disables every position:sticky descendant. */
   overflow-x: clip;
+  /* Disable WebView bounce/pull-to-refresh on native */
+  overscroll-behavior-y: none;
 }
 
 body {
@@ -174,6 +182,40 @@ input[type="radio"] {
   .animate-slide-up {
     animation: slideUp 0.3s ease-out;
   }
+
+  /* Notch / home-indicator insets for fixed chrome */
+  .pt-safe { padding-top: var(--sat); }
+  .pb-safe { padding-bottom: var(--sab); }
+  .pl-safe { padding-left: var(--sal); }
+  .pr-safe { padding-right: var(--sar); }
+  .px-safe { padding-left: var(--sal); padding-right: var(--sar); }
+
+  /* Fixed-bar page offsets that include the top safe-area inset */
+  .pt-safe-14 { padding-top: calc(3.5rem + var(--sat)); }
+  .pt-safe-16 { padding-top: calc(4rem + var(--sat)); }
+
+  /* Bottom-inset padding for fixed bottom bars (home indicator). Additive
+     with the element's existing py-* (0.75rem base here). */
+  .safe-area-bottom { padding-bottom: calc(0.75rem + var(--sab)); }
+
+  /* Full-height dynamic viewport (mobile browser/WebView chrome) */
+  .h-dvh { height: 100dvh; }
+  .min-h-dvh { min-height: 100dvh; }
+}
+
+/* 100vh is taller than the visible area when mobile browser chrome
+   collapses or the WebView keyboard opens — dvh tracks the visible viewport. */
+.min-h-screen { min-height: 100dvh; }
+
+/* Fixed top bars are h-14 and extend under the notch (viewport-fit=cover);
+   every page offsets content with pt-14. Fold the inset into the offset so
+   content clears the taller bar on notched devices. (Desktop: inset = 0.) */
+.pt-14 { padding-top: calc(3.5rem + var(--sat)); }
+
+/* Let Mapbox own touch gestures inside its canvas so the WebView
+   doesn't steal pinch-zoom / drags from the map. */
+.mapboxgl-canvas {
+  touch-action: none;
 }
 
 @keyframes fadeIn {
@@ -405,7 +447,7 @@ input[type="radio"] {
 /* ------ Waitlist Page ------ */
 
 .waitlist-stage {
-  min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
-﻿import type { Metadata } from "next";
+﻿import type { Metadata, Viewport } from "next";
 import { Inter, Chakra_Petch } from "next/font/google";
+import NativeLinkHandler from "@/components/NativeLinkHandler";
 import "./globals.css";
 
 const inter = Inter({
@@ -14,6 +15,12 @@ const chakraPetch = Chakra_Petch({
 });
 
 const SITE_URL = "https://www.startlineau.com";
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+};
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -92,6 +99,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body
         className={`${inter.variable} ${chakraPetch.variable} bg-dark-darker text-light font-sans antialiased`}
       >
+        <NativeLinkHandler />
         {children}
       </body>
     </html>

--- a/app/organiser/how-it-works/page.tsx
+++ b/app/organiser/how-it-works/page.tsx
@@ -549,7 +549,7 @@ export default function HowItWorksPage() {
                   {activeTab === "home" && (
                     <div>
                       {/* Hero */}
-                      <div className="relative px-8 pt-14 pb-12 overflow-hidden"
+                      <div className="relative px-8 pt-[3.5rem] pb-12 overflow-hidden"
                         style={{ background: "linear-gradient(135deg, #0a1a04 0%, #111305 40%, #0f0f0f 70%)" }}>
                         <div className="absolute inset-0 opacity-20"
                           style={{ backgroundImage: "radial-gradient(ellipse at 75% 40%, #65a30d 0%, transparent 55%)" }} />

--- a/app/organiser/onboarding/page.tsx
+++ b/app/organiser/onboarding/page.tsx
@@ -165,7 +165,7 @@ export default function OnboardingPage() {
       </div>
 
       {/* ── Logo bar ── */}
-      <div className="fixed top-0 left-0 right-0 z-40 h-16 flex items-center justify-center">
+      <div className="fixed top-0 left-0 right-0 z-40 flex items-center justify-center pt-safe pb-2">
         <Image src="/images/logo-title.svg" alt="Startline" width={140} height={36} className="h-8 w-auto" />
       </div>
 

--- a/app/organiser/payments/page.tsx
+++ b/app/organiser/payments/page.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import {
   Skeleton, PageHeaderSkeleton, PageShellSkeleton,
 } from "@/components/ui/skeleton";
+import { isNative, openExternal } from "@/lib/capacitor";
 
 export const dynamic = "force-dynamic";
 
@@ -31,6 +32,14 @@ interface Profile {
 function maskAccountId(id: string) {
   if (id.length <= 8) return id;
   return id.slice(0, 8) + "•".repeat(id.length - 8);
+}
+
+async function goToStripe(url: string) {
+  if (isNative()) {
+    await openExternal(url);
+  } else {
+    window.location.href = url;
+  }
 }
 
 function PaymentsContent() {
@@ -119,7 +128,7 @@ function PaymentsContent() {
         setError(data.error ?? "Failed to generate Stripe onboarding link. Please try again.");
         return;
       }
-      window.location.href = data.url;
+      await goToStripe(data.url);
     } finally {
       setConnecting(false);
     }
@@ -134,7 +143,7 @@ function PaymentsContent() {
         setError(data.error ?? "Failed to generate Stripe link.");
         return;
       }
-      window.location.href = data.url;
+      await goToStripe(data.url);
     } finally {
       setConnecting(false);
     }

--- a/components/NativeLinkHandler.tsx
+++ b/components/NativeLinkHandler.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { isNative, openExternal } from "@/lib/capacitor";
+
+export default function NativeLinkHandler() {
+  useEffect(() => {
+    if (!isNative()) return;
+
+    const onClick = (e: MouseEvent) => {
+      const target = e.target as Element;
+      const anchor = target.closest?.('a[target="_blank"]') as HTMLAnchorElement | null;
+      const href = anchor?.getAttribute("href");
+      if (!href) return;
+      e.preventDefault();
+      const url = new URL(href, window.location.origin).toString();
+      openExternal(url);
+    };
+
+    document.addEventListener("click", onClick);
+    return () => document.removeEventListener("click", onClick);
+  }, []);
+
+  return null;
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -126,7 +126,7 @@ export default function NavBar() {
 
   return (
     <>
-      <nav className="fixed top-0 left-0 right-0 z-50 bg-dark-darker/80 backdrop-blur-xl border-b border-white/[0.05]">
+      <nav className="fixed top-0 left-0 right-0 z-50 bg-dark-darker/80 backdrop-blur-xl border-b border-white/[0.05] pt-safe">
         <div className="flex items-center justify-between h-14 max-w-[1200px] mx-auto px-4 sm:px-6 gap-4">
 
           {/* ── Logo ── */}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -100,7 +100,7 @@ export default function NavBar() {
                 <button key={m.organiserId} onClick={() => switchOrganiser(m.organiserId)}
                   className="w-full flex items-center gap-3 px-4 py-2.5 font-headline text-[12px] font-bold uppercase tracking-widest text-left text-white/60 hover:text-white hover:bg-white/10 transition-colors">
                   {m.logoUrl
-                    ? <img src={m.logoUrl} alt="" className="w-5 h-5 rounded object-cover shrink-0" />
+                    ? <Image src={m.logoUrl} alt="" width={20} height={20} className="w-5 h-5 rounded object-cover shrink-0" />
                     : <Building2 className="w-3.5 h-3.5 shrink-0 text-primary/70" />}
                   <span className="truncate flex-1">{m.organiserName ?? "Organisation"}</span>
                   {m.role === "OWNER"
@@ -174,7 +174,7 @@ export default function NavBar() {
                 <button onClick={() => setIsUserOpen(o => !o)}
                   className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-white/10 transition-colors">
                   {profilePic ? (
-                    <img src={profilePic} alt="" className="w-7 h-7 rounded-lg object-cover shrink-0" />
+                    <Image src={profilePic} alt="" width={28} height={28} className="w-7 h-7 rounded-lg object-cover shrink-0" />
                   ) : (
                     <span className="w-7 h-7 rounded-lg bg-primary text-dark font-headline font-black italic text-sm flex items-center justify-center shrink-0">
                       {initial}
@@ -252,7 +252,7 @@ export default function NavBar() {
                     <button key={m.organiserId} onClick={() => { setIsMenuOpen(false); switchOrganiser(m.organiserId); }}
                       className="w-full flex items-center gap-3 px-4 py-3 font-headline text-[13px] font-bold uppercase tracking-widest text-primary hover:bg-white/10 transition-colors text-left">
                       {m.logoUrl
-                        ? <img src={m.logoUrl} alt="" className="w-5 h-5 rounded object-cover shrink-0" />
+                        ? <Image src={m.logoUrl} alt="" width={20} height={20} className="w-5 h-5 rounded object-cover shrink-0" />
                         : <Building2 className="w-4 h-4 shrink-0" />}
                       {m.organiserName ?? "Organisation"}
                     </button>

--- a/components/admin/AdminNavBar.tsx
+++ b/components/admin/AdminNavBar.tsx
@@ -76,7 +76,7 @@ export default function AdminNavBar() {
 
   return (
     <>
-      <nav className="fixed top-0 left-0 right-0 z-50 bg-dark-darker/80 backdrop-blur-xl border-b-2 border-primary">
+      <nav className="fixed top-0 left-0 right-0 z-50 bg-dark-darker/80 backdrop-blur-xl border-b-2 border-primary pt-safe">
         <div className="grid grid-cols-[1fr_auto_1fr] items-center h-14 max-w-[1200px] mx-auto px-4 sm:px-6 gap-4">
 
           {/* ── Logo ── */}

--- a/components/event/EventFormWizard.tsx
+++ b/components/event/EventFormWizard.tsx
@@ -1852,7 +1852,7 @@ export default function EventFormWizard({
             </div>
 
             {/* Live preview sidebar */}
-            <aside className="hidden lg:block border-l border-dark-lighter bg-dark p-6 sticky top-[152px] h-[calc(100vh-152px)] overflow-y-auto">
+            <aside className="hidden lg:block border-l border-dark-lighter bg-dark p-6 sticky top-[152px] h-[calc(100dvh-152px)] overflow-y-auto">
               <LivePreview form={form} />
             </aside>
           </div>

--- a/components/event/EventFormWizard.tsx
+++ b/components/event/EventFormWizard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, startTransition } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import {
   ArrowLeft, ArrowRight, Check, Plus, Trash2,
   Upload, X, MapPin, Calendar, Users,
@@ -927,8 +928,7 @@ const MAX_GALLERY_PHOTOS = 8;
 function GalleryThumb({ src, onRemove }: { src: string; onRemove: () => void }) {
   return (
     <div className="relative aspect-square rounded-md overflow-hidden border border-dark-lighter">
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src={src} alt="" className="w-full h-full object-cover" />
+      <Image src={src} alt="" fill unoptimized className="object-cover" />
       <button type="button" onClick={onRemove}
         className="absolute top-1.5 right-1.5 w-6 h-6 rounded-full bg-dark/70 text-muted hover:text-white flex items-center justify-center transition-colors">
         <X className="w-3.5 h-3.5" />
@@ -964,8 +964,7 @@ function MediaStep({ form, update }: { form: FormState; update: (p: Partial<Form
         <label className="block cursor-pointer">
           {coverSrc ? (
             <div className="relative rounded-md overflow-hidden border border-primary/40 aspect-video">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={coverSrc} alt="Cover preview" className="w-full h-full object-cover" />
+              <Image src={coverSrc} alt="Cover preview" fill unoptimized className="object-cover" />
               <button type="button" onClick={e => { e.preventDefault(); update({ coverImage: null, coverImageUrl: "" }); }}
                 className="absolute top-3 right-3 w-8 h-8 rounded-full bg-dark/70 text-muted hover:text-white flex items-center justify-center transition-colors">
                 <X className="w-4 h-4" />
@@ -1118,11 +1117,12 @@ function LivePreview({ form }: { form: FormState }) {
         {/* Image */}
         <div className="relative w-full aspect-video overflow-hidden rounded-t-2xl">
           {coverSrc ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            <Image
               src={coverSrc}
               alt=""
-              className="absolute inset-0 w-full h-full object-cover brightness-[0.55]"
+              fill
+              unoptimized
+              className="object-cover brightness-[0.55]"
             />
           ) : (
             <div className="absolute inset-0 placeholder-stripes scan-grid" />
@@ -1274,8 +1274,7 @@ function EventFullPreview({ form, onClose }: { form: FormState; onClose: () => v
           {/* ── Banner — mirrors the public event page ── */}
           <div className="relative overflow-hidden w-full" style={{ aspectRatio: "4/3", maxHeight: "420px" }}>
             {coverSrc ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img src={coverSrc} alt="" className="absolute inset-0 w-full h-full object-cover" />
+              <Image src={coverSrc} alt="" fill unoptimized className="object-cover" />
             ) : (
               <div className="absolute inset-0 placeholder-stripes scan-grid" />
             )}
@@ -1385,8 +1384,7 @@ function EventFullPreview({ form, onClose }: { form: FormState; onClose: () => v
                     <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 sm:gap-3">
                       {gallery.map((src, i) => (
                         <div key={i} className="relative aspect-video rounded-xl overflow-hidden bg-dark">
-                          {/* eslint-disable-next-line @next/next/no-img-element */}
-                          <img src={src} alt="" className="absolute inset-0 w-full h-full object-cover" />
+                          <Image src={src} alt="" fill unoptimized className="object-cover" />
                         </div>
                       ))}
                     </div>

--- a/components/organiser/OrganiserNavBar.tsx
+++ b/components/organiser/OrganiserNavBar.tsx
@@ -253,7 +253,7 @@ export default function OrganiserNavBar() {
               <button onClick={() => { setIsUserOpen(o => !o); setNotifOpen(false); }}
                 className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-white/10 transition-colors">
                 {orgLogo ? (
-                  <img src={orgLogo} alt="" className="w-7 h-7 rounded-lg object-cover shrink-0" />
+                  <Image src={orgLogo} alt="" width={28} height={28} className="w-7 h-7 rounded-lg object-cover shrink-0" />
                 ) : (
                   <span className="w-7 h-7 rounded-lg bg-primary text-dark font-headline font-black italic text-sm flex items-center justify-center shrink-0">
                     {initial}
@@ -284,7 +284,7 @@ export default function OrganiserNavBar() {
                             className={`w-full flex items-center gap-3 px-4 py-2.5 font-headline text-[12px] font-bold uppercase tracking-widest text-left transition-colors
                               ${isActive ? "text-primary bg-primary/10" : "text-white/60 hover:text-white hover:bg-white/10"}`}>
                             {m.logoUrl
-                              ? <img src={m.logoUrl} alt="" className="w-5 h-5 rounded object-cover shrink-0" />
+                              ? <Image src={m.logoUrl} alt="" width={20} height={20} className="w-5 h-5 rounded object-cover shrink-0" />
                               : <Building2 className="w-3.5 h-3.5 shrink-0 text-white/40" />}
                             <span className="truncate flex-1">{m.organiserName ?? "Organisation"}</span>
                             {m.role === "OWNER"
@@ -362,7 +362,7 @@ export default function OrganiserNavBar() {
                     <button key={m.organiserId} onClick={() => { setIsMenuOpen(false); switchOrganiser(m.organiserId); }}
                       className="w-full flex items-center gap-3 px-4 py-3 font-headline text-[12px] font-bold uppercase tracking-widest text-primary hover:bg-white/10 transition-colors text-left">
                       {m.logoUrl
-                        ? <img src={m.logoUrl} alt="" className="w-5 h-5 rounded object-cover shrink-0" />
+                        ? <Image src={m.logoUrl} alt="" width={20} height={20} className="w-5 h-5 rounded object-cover shrink-0" />
                         : <Users className="w-4 h-4 shrink-0" />}
                       {m.organiserName ?? "Organisation"}
                     </button>

--- a/components/organiser/PhotoCarousel.tsx
+++ b/components/organiser/PhotoCarousel.tsx
@@ -148,11 +148,12 @@ export default function PhotoCarousel({ photos, isOrganiser, onUpload, uploading
               onClick={e => e.stopPropagation()}
             />
           ) : (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            <Image
               src={lightbox}
               alt="Event photo"
-              className="max-w-full max-h-[85vh] rounded-xl object-contain shadow-2xl"
+              fill
+              unoptimized
+              className="object-contain rounded-xl shadow-2xl"
               onClick={e => e.stopPropagation()}
             />
           )}

--- a/e2e/admin-full-control.spec.ts
+++ b/e2e/admin-full-control.spec.ts
@@ -201,10 +201,15 @@ test.describe("admin user editing", () => {
     await expect(page.getByText("Edit user")).toBeVisible();
 
     await page.getByPlaceholder("Full name").fill(newName);
+
+    const listRefetch = page.waitForResponse(
+      (r) => r.url().includes("/api/admin/users") && r.request().method() === "GET",
+    );
     await page.getByRole("button", { name: /save changes/i }).click();
+    await listRefetch;
 
     await expect(page.getByText("Edit user")).not.toBeVisible({ timeout: 10000 });
-    await expect(page.getByText(newName, { exact: false })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(newName, { exact: false })).toBeVisible();
 
     // Audit log records the edit.
     const auditRes = await page.request.get("/api/admin/audit?action=EDIT_USER&limit=50");

--- a/lib/capacitor.ts
+++ b/lib/capacitor.ts
@@ -1,0 +1,22 @@
+import { Capacitor } from "@capacitor/core";
+
+export function isNative(): boolean {
+  return Capacitor.isNativePlatform();
+}
+
+export function isIOS(): boolean {
+  return isNative() && Capacitor.getPlatform() === "ios";
+}
+
+export function isAndroid(): boolean {
+  return isNative() && Capacitor.getPlatform() === "android";
+}
+
+export async function openExternal(url: string): Promise<void> {
+  if (isNative()) {
+    const { Browser } = await import("@capacitor/browser");
+    await Browser.open({ url });
+  } else {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -33,7 +33,7 @@ const nextConfig: NextConfig = {
             value: [
               "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
               "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://api.mapbox.com",
-              "connect-src 'self' https://js.stripe.com https://api.mapbox.com https://events.mapbox.com https://*.tiles.mapbox.com https://cognito-idp.ap-southeast-2.amazonaws.com",
+              "connect-src 'self' https://js.stripe.com https://api.mapbox.com https://events.mapbox.com https://*.tiles.mapbox.com https://cognito-idp.ap-southeast-2.amazonaws.com capacitor:// http://localhost",
               "img-src 'self' data: blob: https://*.tiles.mapbox.com https://api.mapbox.com https:",
               "worker-src blob: 'self'",
               "style-src 'self' 'unsafe-inline' https://api.mapbox.com",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@aws-sdk/client-geo-places": "^3.1079.0",
     "@aws-sdk/client-s3": "^3.1041.0",
     "@aws-sdk/s3-request-presigner": "^3.1041.0",
+    "@capacitor/browser": "^8.0.4",
+    "@capacitor/core": "^8.4.2",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.0.0",
     "@radix-ui/react-checkbox": "^1.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1041.0
         version: 3.1053.0
+      '@capacitor/browser':
+        specifier: ^8.0.4
+        version: 8.0.4(@capacitor/core@8.4.2)
+      '@capacitor/core':
+        specifier: ^8.4.2
+        version: 8.4.2
       '@prisma/adapter-pg':
         specifier: ^7.8.0
         version: 7.8.0
@@ -577,6 +583,14 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@capacitor/browser@8.0.4':
+    resolution: {integrity: sha512-ORZ4u/y+7aMuu6yVuk6SP529fUZyqcbnuHB1q5McpA3o2SYfVoi28iB8rsQjI2ad1qlKJd29ZUuGtspXLBDlWg==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
+
+  '@capacitor/core@8.4.2':
+    resolution: {integrity: sha512-fQPRb3JXRaU2pnufDUvqOjhsrYxDQeFRZyaj/sHydIUxD2NxOGHKMpmKUdI+U4OOmKuGZyvRpi7TSJU+7Bjbmg==}
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -6218,6 +6232,14 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@capacitor/browser@8.0.4(@capacitor/core@8.4.2)':
+    dependencies:
+      '@capacitor/core': 8.4.2
+
+  '@capacitor/core@8.4.2':
+    dependencies:
+      tslib: 2.8.1
 
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
     dependencies:


### PR DESCRIPTION
Part of StartlineAU/startline-mobile-app#1 — the Capacitor port that wraps the production site in a native shell.

## What this does

Prepares the web app to run inside a Capacitor WebView (iOS/Android) alongside normal browsers. No breaking changes — all additions are guarded by `isNative()` checks or are pure CSS that evaluates to zero change on desktop.

### Changes

**Safe areas & notch handling** (`app/globals.css`, `app/layout.tsx`, navbars)
- `viewport-fit=cover` so the WebView renders edge-to-edge
- CSS vars `--sat` / `--sab` / `--sal` / `--sar` for safe-area insets
- `.pt-14` now includes the top inset globally (desktop: inset=0, no change)
- Fixed top navbars get `pt-safe` so logos clear the notch
- Bottom CTA bar on event pages uses additive `safe-area-bottom` for the home indicator

**Native-aware helpers** (`lib/capacitor.ts`)
- `isNative()`, `isIOS()`, `isAndroid()` — detect Capacitor runtime
- `openExternal(url)` — Browser plugin on native, `window.open` on web

**Stripe Connect** (`app/organiser/payments/page.tsx`)
- Detects native platform → opens Stripe onboarding in the device's system browser
- Web: keeps existing `window.location.href` redirect

**External links** (`components/NativeLinkHandler.tsx`)
- Global click handler mounted in root layout
- Intercepts all `target="_blank"` links on native → opens in system browser
- Covers Stripe Express login, external registration links, footer links, etc.

**CSP headers** (`next.config.ts`)
- Added `capacitor://` (iOS bridge) and `http://localhost` (Android bridge) to `connect-src`

**Mapbox touch** (`app/globals.css`)
- `.mapboxgl-canvas { touch-action: none }` — prevents WebView from stealing pinch-zoom/drag

**100vh fix** (`app/globals.css`)
- `.min-h-screen { min-height: 100dvh }` global override — dvh tracks the visible viewport when keyboard opens
- EventFormWizard sidebar and waitlist page updated from 100vh → 100dvh

**Pull-to-refresh** (`app/globals.css`)
- `overscroll-behavior-y: none` on html/body

**New deps**
- `@capacitor/core ^8.4.2`
- `@capacitor/browser ^8.0.4`

### Trade-offs
- Stripe Connect return URL lands in the device's system browser, not back in the app. Universal links/app links needed if bounce-back is required — separate follow-up.
- `target="_blank"` on internal navigation links (Terms/Privacy in onboarding) opens in the system browser rather than in-app. Acceptable for v1, could be scoped to external hosts only later.