### PR TITLE
fix(terraform): use renamed repo in OIDC trust + Amplify source

### DIFF
--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -4,7 +4,7 @@
 variable "github_repository" {
   description = "GitHub repository for terraform CI in 'org/repo' form."
   type        = string
-  default     = "StartlineAU/startline"
+  default     = "StartlineAU/startline-web-app"
 }
 
 resource "aws_iam_openid_connect_provider" "github" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,7 +27,7 @@ variable "cloudflare_account_id" {
 variable "amplify_repository_url" {
   description = "HTTPS Git URL for Amplify. Set to null to create the app without a connected repository."
   type        = string
-  default     = "https://github.com/StartlineAU/startline"
+  default     = "https://github.com/StartlineAU/startline-web-app"
 }
 
 variable "amplify_environment_variables" {


### PR DESCRIPTION
## Description

The repo was renamed `StartlineAU/startline` → `StartlineAU/startline-web-app`, but two Terraform references still pointed at the old name:

1. **`terraform/github_oidc.tf`** — the `github_repository` variable used by the OIDC trust policy. PR workflows (e2e, gitleaks) do `sts:AssumeRoleWithWebIdentity` with a token claiming `repo:StartlineAU/startline-web-app:*`, which no longer matched `repo:StartlineAU/startline:*`. Both failed with `Not authorized to perform sts:AssumeRoleWithWebIdentity`.
2. **`terraform/variables.tf`** — the Amplify repository URL still pointed at the old repo name.

## Fix

Update both defaults to `StartlineAU/startline-web-app`. Once merged, `terraform apply` on `main` updates the IAM trust policies and Amplify source, unblocking CI on the renamed repo.