### PR TITLE
fix(terraform): add immutable OIDC subject claim patterns for renamed repo

### DIFF
--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -31,13 +31,19 @@ data "aws_iam_policy_document" "terraform_ci_assume" {
 
     # Admin role is only assumable from protected branches (push/tag events).
     # PRs use the separate read-only role below.
+    # Numeric org/repo ID forms: GitHub issues OIDC subjects as
+    # repo:ORG@ORGID/REPO@REPOID for org-owned repos — named form alone
+    # doesn't match (verified: Aug 2026, repo renamed startline→startline-web-app).
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values = [
+      values = concat([
         "repo:${var.github_repository}:*:refs/heads/main",
         "repo:${var.github_repository}:*:refs/heads/prod",
-      ]
+        ], [
+        "repo:StartlineAU@277168955/startline-web-app@1163051258:*:refs/heads/main",
+        "repo:StartlineAU@277168955/startline-web-app@1163051258:*:refs/heads/prod",
+      ])
     }
   }
 }
@@ -76,7 +82,11 @@ data "aws_iam_policy_document" "terraform_ci_readonly_assume" {
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:${var.github_repository}:*"]
+      values = concat([
+        "repo:${var.github_repository}:*",
+        ], [
+        "repo:StartlineAU@277168955/startline-web-app@1163051258:*",
+      ])
     }
   }
 }


### PR DESCRIPTION
## Description

GitHub now issues **immutable subject claims** (`repo:OWNER@ID/REPO@ID:ref:...`) for repositories created or renamed after July 15 2026. The rename `StartlineAU/startline` → `StartlineAU/startline-web-app` switched this repo to the immutable format, so the named-only `StringLike` patterns in the OIDC trust policy no longer match.

**Symptom:** every `terraform apply` on `main` rewrites the `startline-terraform-ci` trust policy to named-only patterns, silently breaking CI OIDC assume-role (deploy, terraform apply, e2e all fail with `Not authorized to perform sts:AssumeRoleWithWebIdentity`).

**Fix:** add the immutable numeric-ID subject forms alongside the named forms for both the admin and read-only CI roles.

## Verification

- `terraform validate` passes.
- With the numeric patterns present, the Deploy workflow's OIDC assume-role succeeds and the Amplify build passes.