### PR TITLE
feat(security): server-side Zod validation for all API routes

### DIFF
--- a/app/api/abn/route.ts
+++ b/app/api/abn/route.ts
@@ -1,9 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { lookupAbn } from "@/lib/abn";
+import { z } from "zod";
+
+const abnQuery = z.object({ abn: z.string().trim().min(1).max(20) });
 
 export async function GET(req: NextRequest) {
-  const abn = req.nextUrl.searchParams.get("abn");
-  if (!abn) return NextResponse.json({ error: "abn query param required." }, { status: 400 });
+  const parsed = abnQuery.safeParse(Object.fromEntries(req.nextUrl.searchParams));
+  if (!parsed.success) return NextResponse.json({ error: "abn query param required." }, { status: 400 });
+  const { abn } = parsed.data;
 
   if (!process.env.ABR_GUID) {
     return NextResponse.json({ error: "ABR_GUID not configured." }, { status: 503 });

--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -1,16 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
+import { z } from "zod";
+
+const auditQuery = z.object({
+  action: z.string().max(100).catch(""),
+  page: z.coerce.number().int().min(1).catch(1),
+  limit: z.coerce.number().int().min(1).max(100).catch(50),
+});
 
 export async function GET(req: NextRequest) {
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
   const { searchParams } = new URL(req.url);
-  const action = searchParams.get("action") ?? "";
-  const page   = Math.max(1, parseInt(searchParams.get("page")  ?? "1",  10));
-  const limit  = Math.min(100, Math.max(1, parseInt(searchParams.get("limit") ?? "50", 10)));
-  const skip   = (page - 1) * limit;
+  const { action, page, limit } = auditQuery.parse(Object.fromEntries(searchParams));
+  const skip = (page - 1) * limit;
 
   const where = action
     ? { action: { contains: action, mode: "insensitive" as const } }

--- a/app/api/admin/events/[id]/pin/route.ts
+++ b/app/api/admin/events/[id]/pin/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
 import { writeAuditLog } from "@/lib/audit";
+import { idParams } from "@/lib/schemas";
 
 export async function PATCH(
   _req: Request,
@@ -10,7 +11,9 @@ export async function PATCH(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const event = await prisma.event.findUnique({

--- a/app/api/admin/events/[id]/review/route.ts
+++ b/app/api/admin/events/[id]/review/route.ts
@@ -4,6 +4,14 @@ import { getAdminSession } from "@/lib/amplify-server";
 import { sendEventApprovedEmail, sendEventRejectedEmail } from "@/lib/email";
 import { writeAuditLog } from "@/lib/audit";
 import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
+import { idParams } from "@/lib/schemas";
+import { z } from "zod";
+
+const reviewActionSchema = z.object({
+  action: z.enum(["approve", "reject"]),
+  reason: z.string().max(1000).optional(),
+});
+
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -11,13 +19,17 @@ export async function POST(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
-  const body = await req.json() as { action?: string; reason?: string };
-  const { action, reason } = body;
-
-  if (action !== "approve" && action !== "reject") {
-    return NextResponse.json({ error: "action must be 'approve' or 'reject'." }, { status: 400 });
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
+  const parsedBody = reviewActionSchema.safeParse(await req.json());
+  if (!parsedBody.success) {
+    return NextResponse.json(
+      { error: parsedBody.error.issues[0]?.message ?? "Invalid input." },
+      { status: 400 },
+    );
   }
+  const { action, reason } = parsedBody.data;
 
   if (action === "reject" && !reason?.trim()) {
     return NextResponse.json({ error: "A rejection reason is required." }, { status: 400 });

--- a/app/api/admin/events/[id]/route.ts
+++ b/app/api/admin/events/[id]/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
 import { getEventCoords } from "@/lib/australia-coords";
 import { writeAuditLog } from "@/lib/audit";
+import { eventPayloadSchema, idParams } from "@/lib/schemas";
 
 export async function GET(
   _req: NextRequest,
@@ -12,7 +13,9 @@ export async function GET(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const event = await prisma.event.findUnique({ where: { id } });
@@ -31,8 +34,17 @@ export async function PATCH(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
-  const body = await req.json();
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
+  const parsedBody = eventPayloadSchema.safeParse(await req.json());
+  if (!parsedBody.success) {
+    return NextResponse.json(
+      { error: parsedBody.error.issues[0]?.message ?? "Invalid input." },
+      { status: 400 },
+    );
+  }
+  const body = parsedBody.data;
   const { submit, ...data } = body;
 
   try {
@@ -46,7 +58,7 @@ export async function PATCH(
     }
 
     if (submit) {
-      const required = ["title", "discipline", "eventDate", "startTime", "city", "state", "format", "level"];
+      const required = ["title", "discipline", "eventDate", "startTime", "city", "state", "format", "level"] as const;
       for (const field of required) {
         if (!data[field]) return NextResponse.json({ error: `${field} is required.` }, { status: 400 });
       }
@@ -119,7 +131,9 @@ export async function DELETE(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const event = await prisma.event.findUnique({

--- a/app/api/admin/events/bulk/route.ts
+++ b/app/api/admin/events/bulk/route.ts
@@ -2,23 +2,27 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
 import { writeAuditLog } from "@/lib/audit";
+import { z } from "zod";
+
+const bulkActionSchema = z.object({
+  ids: z.array(z.string().min(1).max(255)).min(1).max(50),
+  action: z.enum(["approve", "reject", "delete"]),
+  reason: z.string().max(1000).optional(),
+});
 
 export async function POST(req: NextRequest) {
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const body = await req.json() as { ids?: string[]; action?: string; reason?: string };
-  const { ids, action, reason } = body;
+  const parsed = bulkActionSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid input." },
+      { status: 400 },
+    );
+  }
+  const { ids, action, reason } = parsed.data;
 
-  if (!Array.isArray(ids) || ids.length === 0) {
-    return NextResponse.json({ error: "ids must be a non-empty array." }, { status: 400 });
-  }
-  if (ids.length > 50) {
-    return NextResponse.json({ error: "Maximum 50 events per bulk action." }, { status: 400 });
-  }
-  if (action !== "approve" && action !== "reject" && action !== "delete") {
-    return NextResponse.json({ error: "action must be approve, reject, or delete." }, { status: 400 });
-  }
   if (action === "reject" && !reason?.trim()) {
     return NextResponse.json({ error: "A rejection reason is required for bulk reject." }, { status: 400 });
   }

--- a/app/api/admin/events/route.ts
+++ b/app/api/admin/events/route.ts
@@ -3,9 +3,17 @@ import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
 import { getEventCoords } from "@/lib/australia-coords";
 import { writeAuditLog } from "@/lib/audit";
+import { adminEventPayloadSchema, eventPayloadSchema } from "@/lib/schemas";
+import { z } from "zod";
 
 const VALID_STATUSES = ["DRAFT", "PENDING", "APPROVED", "REJECTED", "ARCHIVED"] as const;
 type EventStatus = (typeof VALID_STATUSES)[number];
+
+const eventListQuery = z.object({
+  status: z.enum(VALID_STATUSES).catch("PENDING"),
+  page: z.coerce.number().int().min(1).catch(1),
+  limit: z.coerce.number().int().min(1).max(100).catch(50),
+});
 
 const EVENT_SELECT = {
   id:              true,
@@ -36,13 +44,9 @@ export async function GET(req: NextRequest) {
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
   const { searchParams } = new URL(req.url);
-  const statusParam = (searchParams.get("status") ?? "PENDING").toUpperCase();
-  const status: EventStatus = (VALID_STATUSES as readonly string[]).includes(statusParam)
-    ? (statusParam as EventStatus)
-    : "PENDING";
-
-  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
-  const limit = Math.min(100, Math.max(1, parseInt(searchParams.get("limit") ?? "50", 10)));
+  const { status, page, limit } = eventListQuery.parse(
+    Object.fromEntries(searchParams),
+  );
   const skip = (page - 1) * limit;
 
   try {
@@ -77,7 +81,14 @@ export async function POST(req: NextRequest) {
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const body = await req.json();
+  const parsed = adminEventPayloadSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid input." },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
   const { submit, organiserId } = body;
 
   if (!organiserId) {
@@ -94,7 +105,7 @@ export async function POST(req: NextRequest) {
   }
 
   if (submit) {
-    const required = ["title", "discipline", "eventDate", "startTime", "city", "state", "format", "level"];
+    const required = ["title", "discipline", "eventDate", "startTime", "city", "state", "format", "level"] as const;
     for (const field of required) {
       if (!body[field]) return NextResponse.json({ error: `${field} is required.` }, { status: 400 });
     }
@@ -114,7 +125,7 @@ export async function POST(req: NextRequest) {
       data: {
         organiserId:      organiserId,
         status:           eventStatus,
-        title:            body.title,
+        title:            body.title ?? "",
         discipline:       body.discipline        ?? "",
         description:      body.description       ?? null,
         eventDate:        body.eventDate         ?? "",

--- a/app/api/admin/organisers/[id]/members/route.ts
+++ b/app/api/admin/organisers/[id]/members/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
+import { idParams } from "@/lib/schemas";
 
 export const dynamic = "force-dynamic";
 
@@ -13,7 +14,9 @@ export async function GET(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const members = await prisma.organiserMember.findMany({

--- a/app/api/admin/organisers/[id]/suspend/route.ts
+++ b/app/api/admin/organisers/[id]/suspend/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
 import { writeAuditLog } from "@/lib/audit";
+import { idParams } from "@/lib/schemas";
 
 export async function PATCH(
   _req: Request,
@@ -10,7 +11,9 @@ export async function PATCH(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const organiser = await prisma.organiser.findUnique({

--- a/app/api/admin/organisers/[id]/verify/route.ts
+++ b/app/api/admin/organisers/[id]/verify/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
 import { writeAuditLog } from "@/lib/audit";
+import { idParams } from "@/lib/schemas";
 
 export async function PATCH(
   _req: Request,
@@ -10,7 +11,9 @@ export async function PATCH(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const organiser = await prisma.organiser.findUnique({

--- a/app/api/admin/payouts/route.ts
+++ b/app/api/admin/payouts/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminSession } from "@/lib/amplify-server";
 import { getPayoutEligibleEvents, runPayoutForEvent } from "@/lib/payout";
+import { z } from "zod";
+
+const payoutSchema = z.object({ eventId: z.string().min(1).max(255) });
 
 export async function GET() {
   const session = await getAdminSession();
@@ -19,11 +22,11 @@ export async function POST(req: NextRequest) {
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const body = await req.json().catch(() => null) as { eventId?: string } | null;
-  const eventId = body?.eventId;
-  if (!eventId) {
+  const parsed = payoutSchema.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
     return NextResponse.json({ error: "eventId is required." }, { status: 400 });
   }
+  const eventId = parsed.data.eventId;
 
   try {
     const { netCents } = await runPayoutForEvent(eventId);

--- a/app/api/admin/registrations/[id]/refund/route.ts
+++ b/app/api/admin/registrations/[id]/refund/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
 import { getStripe } from "@/lib/stripe";
 import { writeAuditLog } from "@/lib/audit";
+import { idParams } from "@/lib/schemas";
 
 export async function POST(
   _req: NextRequest,
@@ -11,7 +12,9 @@ export async function POST(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const registration = await prisma.registration.findUnique({

--- a/app/api/admin/registrations/route.ts
+++ b/app/api/admin/registrations/route.ts
@@ -1,25 +1,30 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
+import { z } from "zod";
 
 const VALID_STATUSES = ["CONFIRMED", "REFUND_REQUESTED", "CANCELLED", "REFUNDED"] as const;
 type RegStatus = (typeof VALID_STATUSES)[number];
+
+const registrationsQuery = z.object({
+  status: z.enum(VALID_STATUSES).optional().catch(undefined),
+  eventId: z.string().max(255).optional().catch(undefined),
+  search: z.string().max(200).catch(""),
+  page: z.coerce.number().int().min(1).catch(1),
+  limit: z.coerce.number().int().min(1).max(100).catch(50),
+});
 
 export async function GET(req: NextRequest) {
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
   const { searchParams } = new URL(req.url);
-  const statusParam = searchParams.get("status")?.toUpperCase();
-  const status: RegStatus | undefined =
-    (VALID_STATUSES as readonly string[]).includes(statusParam ?? "")
-      ? (statusParam as RegStatus)
-      : undefined;
-
-  const eventId = searchParams.get("eventId") ?? undefined;
-  const search  = searchParams.get("search") ?? "";
-  const page    = Math.max(1, parseInt(searchParams.get("page")  ?? "1",  10));
-  const limit   = Math.min(100, Math.max(1, parseInt(searchParams.get("limit") ?? "50", 10)));
+  const query = registrationsQuery.parse(Object.fromEntries(searchParams));
+  const status  = query.status;
+  const eventId = query.eventId;
+  const search  = query.search;
+  const page    = query.page;
+  const limit   = query.limit;
   const skip    = (page - 1) * limit;
 
   const where = {

--- a/app/api/admin/reviews/[id]/route.ts
+++ b/app/api/admin/reviews/[id]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
+import { idParams } from "@/lib/schemas";
+import { z } from "zod";
+
+const reviewModerationSchema = z.object({
+  isPublished: z.boolean().optional(),
+  isVerified: z.boolean().optional(),
+});
 
 // PATCH /api/admin/reviews/[id]  — moderate a review (publish / verify toggles)
 export async function PATCH(
@@ -10,15 +17,20 @@ export async function PATCH(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
-  const body = await req.json().catch(() => ({})) as {
-    isPublished?: boolean;
-    isVerified?: boolean;
-  };
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
+  const parsedBody = reviewModerationSchema.safeParse(await req.json().catch(() => ({})));
+  if (!parsedBody.success) {
+    return NextResponse.json(
+      { error: parsedBody.error.issues[0]?.message ?? "Invalid input." },
+      { status: 400 },
+    );
+  }
 
   const data: { isPublished?: boolean; isVerified?: boolean } = {};
-  if (typeof body.isPublished === "boolean") data.isPublished = body.isPublished;
-  if (typeof body.isVerified === "boolean")  data.isVerified  = body.isVerified;
+  if (parsedBody.data.isPublished !== undefined) data.isPublished = parsedBody.data.isPublished;
+  if (parsedBody.data.isVerified !== undefined)  data.isVerified  = parsedBody.data.isVerified;
 
   if (Object.keys(data).length === 0) {
     return NextResponse.json({ error: "Nothing to update." }, { status: 400 });
@@ -45,7 +57,9 @@ export async function DELETE(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
   try {
     await prisma.review.delete({ where: { id } });
     return NextResponse.json({ ok: true });

--- a/app/api/admin/reviews/route.ts
+++ b/app/api/admin/reviews/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
+import { z } from "zod";
+
+const reviewsQuery = z.object({
+  filter: z.enum(["all", "published", "hidden"]).catch("all"),
+});
 
 export const dynamic = "force-dynamic";
 
@@ -10,7 +15,7 @@ export async function GET(req: NextRequest) {
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
   const { searchParams } = new URL(req.url);
-  const filter = (searchParams.get("filter") ?? "all").toLowerCase();
+  const { filter } = reviewsQuery.parse(Object.fromEntries(searchParams));
   const where =
     filter === "published" ? { isPublished: true }
     : filter === "hidden"  ? { isPublished: false }

--- a/app/api/admin/users/[id]/ban/route.ts
+++ b/app/api/admin/users/[id]/ban/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
 import { writeAuditLog } from "@/lib/audit";
+import { idParams } from "@/lib/schemas";
 
 export async function PATCH(
   _req: Request,
@@ -10,7 +11,9 @@ export async function PATCH(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const user = await prisma.user.findUnique({

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -3,6 +3,8 @@ import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
 import { validateUsername } from "@/lib/username-validation";
 import { writeAuditLog } from "@/lib/audit";
+import { idParams } from "@/lib/schemas";
+import { z } from "zod";
 import {
   CognitoIdentityProviderClient,
   AdminUpdateUserAttributesCommand,
@@ -16,6 +18,17 @@ function badRequest(msg: string) {
   return NextResponse.json({ error: msg }, { status: 400 });
 }
 
+const adminUserUpdateSchema = z.object({
+  name: z.string().max(200).nullable().optional(),
+  username: z.string().max(50).optional(),
+  email: z.string().max(255).optional(),
+  bio: z.string().max(2000).nullable().optional(),
+  profilePicUrl: z.string().max(3000).nullable().optional(),
+  isPublic: z.boolean().optional(),
+  city: z.string().max(100).nullable().optional(),
+  state: z.string().max(100).nullable().optional(),
+});
+
 export async function GET(
   _req: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -23,7 +36,9 @@ export async function GET(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const user = await prisma.user.findUnique({
@@ -53,8 +68,17 @@ export async function PUT(
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
-  const body = await req.json();
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
+  const parsedBody = adminUserUpdateSchema.safeParse(await req.json());
+  if (!parsedBody.success) {
+    return NextResponse.json(
+      { error: parsedBody.error.issues[0]?.message ?? "Invalid input." },
+      { status: 400 },
+    );
+  }
+  const body = parsedBody.data;
   const data: Record<string, unknown> = {};
   const changed: string[] = [];
 

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,16 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
+import { z } from "zod";
+
+const usersQuery = z.object({
+  search: z.string().max(200).catch(""),
+  page: z.coerce.number().int().min(1).catch(1),
+  limit: z.coerce.number().int().min(1).max(100).catch(50),
+});
 
 export async function GET(req: NextRequest) {
   const session = await getAdminSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
   const { searchParams } = new URL(req.url);
-  const search = searchParams.get("search") ?? "";
-  const page  = Math.max(1, parseInt(searchParams.get("page")  ?? "1",  10));
-  const limit = Math.min(100, Math.max(1, parseInt(searchParams.get("limit") ?? "50", 10)));
-  const skip  = (page - 1) * limit;
+  const { search, page, limit } = usersQuery.parse(Object.fromEntries(searchParams));
+  const skip = (page - 1) * limit;
 
   const where = search
     ? {

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -18,8 +18,44 @@ import {
   assertGuestEmailsVerifiedForCheckout,
 } from "@/lib/guest-email-verification";
 import { getCapacityError, hasCappedWave } from "@/lib/registration-capacity";
+import { z } from "zod";
 
 type CheckoutParticipant = RegistrationFormData & { waveLabel?: string };
+
+const participantSchema = z.object({
+  firstName: z.string(),
+  lastName: z.string(),
+  dateOfBirth: z.string(),
+  gender: z.string(),
+  email: z.string(),
+  mobile: z.string(),
+  emergencyContactName: z.string(),
+  emergencyContactPhone: z.string(),
+  medicalNotes: z.string(),
+  estimatedFinish: z.string(),
+  waiverAccepted: z.boolean(),
+  waveLabel: z.string().max(255).optional(),
+});
+
+const checkoutSchema = z.object({
+  eventId: z.string().max(255).optional(),
+  waveLabel: z.string().max(255).optional(),
+  groupRegistration: z.boolean().optional(),
+  emergencyContact: z.object({ name: z.string(), phone: z.string() }).optional(),
+  participants: z.array(participantSchema).optional(),
+  // Legacy single-participant payload fields (pre multi-ticket).
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  dateOfBirth: z.string().optional(),
+  gender: z.string().optional(),
+  email: z.string().optional(),
+  mobile: z.string().optional(),
+  emergencyContactName: z.string().optional(),
+  emergencyContactPhone: z.string().optional(),
+  medicalNotes: z.string().optional(),
+  estimatedFinish: z.string().optional(),
+  waiverAccepted: z.boolean().optional(),
+});
 
 function todayIso(): string {
   const now = new Date();
@@ -68,10 +104,14 @@ function normalizeSharedEmergencyContact(body: Record<string, unknown>): Emergen
 
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json() as Record<string, unknown> & {
-      eventId?: string;
-      waveLabel?: string;
-    };
+    const parsedBody = checkoutSchema.safeParse(await req.json());
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        { error: parsedBody.error.issues[0]?.message ?? "Invalid input." },
+        { status: 400 },
+      );
+    }
+    const body = parsedBody.data;
     const { eventId, waveLabel } = body;
     const participants = normalizeParticipants(body);
     const groupRegistration = body.groupRegistration === true;

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,7 +1,15 @@
 import { NextResponse } from "next/server";
 import { Resend } from "resend";
+import { z } from "zod";
 
 const ADMIN_EMAIL = "admin@startlineau.com";
+
+const contactSchema = z.object({
+  name: z.string().min(1).max(200),
+  email: z.string().min(1).max(255),
+  subject: z.string().min(1).max(200),
+  message: z.string().min(1).max(5000),
+});
 
 function escapeHtml(value: string): string {
   return value
@@ -23,17 +31,15 @@ export async function POST(request: Request) {
 
   const resend = new Resend(resendApiKey);
 
-  const body = (await request.json().catch(() => null)) as {
-    name?: string;
-    email?: string;
-    subject?: string;
-    message?: string;
-  } | null;
+  const parsed = contactSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Please fill out all fields." }, { status: 400 });
+  }
 
-  const name = body?.name?.trim() ?? "";
-  const email = body?.email?.trim() ?? "";
-  const subject = body?.subject?.trim() ?? "";
-  const message = body?.message?.trim() ?? "";
+  const name = parsed.data.name.trim();
+  const email = parsed.data.email.trim();
+  const subject = parsed.data.subject.trim();
+  const message = parsed.data.message.trim();
 
   if (!name || !email || !subject || !message) {
     return NextResponse.json({ error: "Please fill out all fields." }, { status: 400 });

--- a/app/api/events/[id]/availability/route.ts
+++ b/app/api/events/[id]/availability/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import { idParams } from "@/lib/schemas";
 
 export const dynamic = "force-dynamic";
 
@@ -13,7 +14,11 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Not available." }, { status: 404 });
+  }
+  const { id } = parsedParams.data;
 
   const event = await prisma.event.findUnique({
     where: { id },

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,7 +1,16 @@
 import { NextResponse } from "next/server";
 import { Resend } from "resend";
+import { z } from "zod";
 
 const ADMIN_EMAIL = "admin@startlineau.com";
+
+const feedbackSchema = z.object({
+  type: z.string().min(1).max(100),
+  title: z.string().min(1).max(200),
+  details: z.string().min(1).max(5000),
+  email: z.string().max(255).optional(),
+  filenames: z.array(z.string().max(255)).optional(),
+});
 
 function escapeHtml(value: string): string {
   return value
@@ -21,19 +30,16 @@ export async function POST(request: Request) {
     );
   }
 
-  const body = (await request.json().catch(() => null)) as {
-    type?: string;
-    title?: string;
-    details?: string;
-    email?: string;
-    filenames?: string[];
-  } | null;
+  const parsed = feedbackSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Missing required fields." }, { status: 400 });
+  }
 
-  const type      = body?.type?.trim()    ?? "";
-  const title     = body?.title?.trim()   ?? "";
-  const details   = body?.details?.trim() ?? "";
-  const email     = body?.email?.trim()   ?? "";
-  const filenames = body?.filenames ?? [];
+  const type      = parsed.data.type.trim();
+  const title     = parsed.data.title.trim();
+  const details   = parsed.data.details.trim();
+  const email     = (parsed.data.email ?? "").trim();
+  const filenames = parsed.data.filenames ?? [];
 
   if (!type || !title || !details) {
     return NextResponse.json({ error: "Missing required fields." }, { status: 400 });

--- a/app/api/organiser/events/[id]/announcements/[announcementId]/route.ts
+++ b/app/api/organiser/events/[id]/announcements/[announcementId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
+import { idAnnouncementIdParams } from "@/lib/schemas";
 export async function DELETE(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string; announcementId: string }> },
@@ -8,7 +9,9 @@ export async function DELETE(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { announcementId } = await params;
+  const parsedParams = idAnnouncementIdParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { announcementId } = parsedParams.data;
 
   try {
     const ann = await prisma.announcement.findUnique({

--- a/app/api/organiser/events/[id]/announcements/route.ts
+++ b/app/api/organiser/events/[id]/announcements/route.ts
@@ -3,6 +3,14 @@ import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { sanitizeHtml } from "@/lib/sanitize-html";
 import { stripHtml } from "@/lib/utils";
+import { idParams } from "@/lib/schemas";
+import { z } from "zod";
+
+const announcementSchema = z.object({
+  title: z.string().min(1).max(200),
+  body: z.string().min(1).max(10000),
+});
+
 // GET /api/organiser/events/[id]/announcements
 export async function GET(
   _req: NextRequest,
@@ -11,7 +19,9 @@ export async function GET(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const event = await prisma.event.findUnique({
@@ -41,7 +51,9 @@ export async function POST(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const event = await prisma.event.findUnique({
@@ -52,10 +64,13 @@ export async function POST(
     if (event.organiserId !== session.sub) return NextResponse.json({ error: "Forbidden." }, { status: 403 });
     if (event.status !== "APPROVED")       return NextResponse.json({ error: "Announcements can only be posted for live events." }, { status: 409 });
 
-    const body = await req.json();
-    const { title, body: text } = body as { title?: string; body?: string };
+    const parsed = announcementSchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Title and body are required." }, { status: 400 });
+    }
+    const { title, body: text } = parsed.data;
 
-    if (!title?.trim()) return NextResponse.json({ error: "Title is required." }, { status: 400 });
+    if (!title.trim()) return NextResponse.json({ error: "Title is required." }, { status: 400 });
     if (!text || !stripHtml(text)) {
       return NextResponse.json({ error: "Body is required." }, { status: 400 });
     }

--- a/app/api/organiser/events/[id]/dashboard/route.ts
+++ b/app/api/organiser/events/[id]/dashboard/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { archivePastEvents } from "@/lib/archive-events";
 import { PLATFORM_FEE_PERCENT, PLATFORM_FEE_FIXED_CENTS } from "@/lib/platform-fee";
+import { idParams } from "@/lib/schemas";
 
 export async function GET(
   _req: NextRequest,
@@ -11,7 +12,9 @@ export async function GET(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     await archivePastEvents();

--- a/app/api/organiser/events/[id]/duplicate/route.ts
+++ b/app/api/organiser/events/[id]/duplicate/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { shiftIsoDate } from "@/lib/duplicate-event";
+import { idParams } from "@/lib/schemas";
 
 /** POST /api/organiser/events/[id]/duplicate — copy listing fields into a new DRAFT (+7 days). */
 export async function POST(
@@ -11,7 +12,9 @@ export async function POST(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const source = await prisma.event.findUnique({ where: { id } });

--- a/app/api/organiser/events/[id]/pin/route.ts
+++ b/app/api/organiser/events/[id]/pin/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
+import { idParams } from "@/lib/schemas";
 export async function PATCH(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -8,7 +9,9 @@ export async function PATCH(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const event = await prisma.event.findUnique({

--- a/app/api/organiser/events/[id]/registrations/export/route.ts
+++ b/app/api/organiser/events/[id]/registrations/export/route.ts
@@ -10,13 +10,13 @@ import {
 } from "@/lib/registration-export";
 import { buildRegistrationsXlsx } from "@/lib/registration-export-xlsx";
 import { buildStartListPdf } from "@/lib/registration-export-pdf";
+import { idParams } from "@/lib/schemas";
+import { z } from "zod";
 
-type ExportFormat = "xlsx" | "pdf" | "csv";
-
-function parseFormat(raw: string | null): ExportFormat {
-  if (raw === "pdf" || raw === "csv" || raw === "xlsx") return raw;
-  return "xlsx";
-}
+const exportQuery = z.object({
+  format: z.enum(["xlsx", "pdf", "csv"]).catch("xlsx"),
+  columns: z.string().max(500).optional(),
+});
 
 export async function GET(
   req: NextRequest,
@@ -25,9 +25,13 @@ export async function GET(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
-  const format = parseFormat(req.nextUrl.searchParams.get("format"));
-  const columns = parseExportColumns(req.nextUrl.searchParams.get("columns"));
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
+  const { format, columns: columnsParam } = exportQuery.parse(
+    Object.fromEntries(req.nextUrl.searchParams),
+  );
+  const columns = parseExportColumns(columnsParam ?? null);
 
   const event = await prisma.event.findUnique({
     where: { id },

--- a/app/api/organiser/events/[id]/registrations/move/route.ts
+++ b/app/api/organiser/events/[id]/registrations/move/route.ts
@@ -2,12 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { CAPACITY_COUNTING_STATUSES } from "@/lib/registration-status";
+import { idParams } from "@/lib/schemas";
+import { z } from "zod";
 
-interface MoveBody {
-  registrationIds?: string[];
+const moveBodySchema = z.object({
+  registrationIds: z.array(z.string().min(1).max(255)).min(1),
   /** Destination wave id, or null to move athletes out of any wave. */
-  destWaveId?: string | null;
-}
+  destWaveId: z.string().max(255).nullable().optional(),
+});
 
 // POST — move a set of athletes into one start wave (or out, with destWaveId null)
 // in a single transaction. Exceeding the destination's capacity warns but never
@@ -19,7 +21,9 @@ export async function POST(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
   const event = await prisma.event.findUnique({
     where: { id },
     select: { id: true, organiserId: true },
@@ -29,12 +33,12 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }
 
-  const body = (await req.json().catch(() => null)) as MoveBody | null;
-  const ids = Array.isArray(body?.registrationIds) ? body!.registrationIds.filter(Boolean) : [];
-  if (ids.length === 0) {
+  const parsedBody = moveBodySchema.safeParse(await req.json().catch(() => null));
+  if (!parsedBody.success) {
     return NextResponse.json({ error: "registrationIds is required." }, { status: 400 });
   }
-  const destWaveId = body?.destWaveId ?? null;
+  const ids = parsedBody.data.registrationIds.filter(Boolean);
+  const destWaveId = parsedBody.data.destWaveId ?? null;
 
   // Resolve the destination wave (label + capacity), scoped to this event.
   let destLabel: string | null = null;

--- a/app/api/organiser/events/[id]/registrations/route.ts
+++ b/app/api/organiser/events/[id]/registrations/route.ts
@@ -3,17 +3,23 @@ import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { wavesWithCounts } from "@/lib/start-waves";
 import type { RegistrationStatus, Prisma } from "@prisma/client";
+import { idParams } from "@/lib/schemas";
+import { z } from "zod";
 
 const STATUSES = new Set(["CONFIRMED", "REFUND_REQUESTED", "REFUNDED", "CANCELLED"]);
 
-type PatchRow = {
-  registrationId: string;
-  startWaveId?: string | null;
-  startWaveLabel?: string | null;
-  bibNumber?: string | null;
-  status?: string;
-  estimatedFinishMinutes?: number | null;
-};
+const registrationPatchRowSchema = z.object({
+  registrationId: z.string().min(1).max(255),
+  startWaveId: z.string().max(255).nullable().optional(),
+  startWaveLabel: z.string().max(255).nullable().optional(),
+  bibNumber: z.string().max(50).nullable().optional(),
+  status: z.enum(["CONFIRMED", "REFUND_REQUESTED", "REFUNDED", "CANCELLED"]).optional(),
+  estimatedFinishMinutes: z.number().int().min(0).nullable().optional(),
+});
+
+const registrationPatchSchema = z.object({
+  registrations: z.array(registrationPatchRowSchema).min(1),
+});
 
 async function assertOwnedEvent(eventId: string, organiserId: string) {
   const event = await prisma.event.findUnique({
@@ -34,7 +40,9 @@ export async function GET(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
   const owned = await assertOwnedEvent(id, session.sub);
   if (owned.error) return owned.error;
 
@@ -110,15 +118,17 @@ export async function PATCH(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
   const owned = await assertOwnedEvent(id, session.sub);
   if (owned.error) return owned.error;
 
-  const body = await req.json().catch(() => null);
-  const rows: PatchRow[] | undefined = body?.registrations;
-  if (!Array.isArray(rows) || rows.length === 0) {
+  const parsedBody = registrationPatchSchema.safeParse(await req.json().catch(() => null));
+  if (!parsedBody.success) {
     return NextResponse.json({ error: "registrations array is required." }, { status: 400 });
   }
+  const rows = parsedBody.data.registrations;
 
   // Resolve wave references against the StartWave table. We accept either an id
   // (preferred) or a label (from older callers) and write both columns in step.

--- a/app/api/organiser/events/[id]/results/route.ts
+++ b/app/api/organiser/events/[id]/results/route.ts
@@ -3,16 +3,22 @@ import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { isValidRaceTime, normaliseRaceTime } from "@/lib/race-results";
 import type { Prisma } from "@prisma/client";
+import { idParams } from "@/lib/schemas";
+import { z } from "zod";
 
-interface ResultInput {
-  registrationId?: string;
-  athleteEmail?: string;
-  resultDistance?: string | null;
-  resultTime?: string | null;
-  resultPlacement?: string | null;
-  isPersonalBest?: boolean;
-  isTopResult?: boolean;
-}
+const resultRowSchema = z.object({
+  registrationId: z.string().max(255).optional(),
+  athleteEmail: z.string().max(255).optional(),
+  resultDistance: z.string().max(100).nullable().optional(),
+  resultTime: z.string().max(50).nullable().optional(),
+  resultPlacement: z.string().max(100).nullable().optional(),
+  isPersonalBest: z.boolean().optional(),
+  isTopResult: z.boolean().optional(),
+});
+
+const resultsPatchSchema = z.object({
+  results: z.array(resultRowSchema).min(1),
+});
 
 /** PATCH — bulk-set race results. Match by registrationId, else athleteEmail (case-insensitive). */
 export async function PATCH(
@@ -22,7 +28,9 @@ export async function PATCH(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   const event = await prisma.event.findUnique({
     where: { id },
@@ -33,11 +41,11 @@ export async function PATCH(
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }
 
-  const body = await req.json().catch(() => null);
-  const results: ResultInput[] | undefined = body?.results;
-  if (!Array.isArray(results) || results.length === 0) {
+  const parsedBody = resultsPatchSchema.safeParse(await req.json().catch(() => null));
+  if (!parsedBody.success) {
     return NextResponse.json({ error: "results array is required." }, { status: 400 });
   }
+  const results = parsedBody.data.results;
 
   const registrations = await prisma.registration.findMany({
     where: { eventId: id },
@@ -49,7 +57,7 @@ export async function PATCH(
   );
 
   const updates: { id: string; data: Prisma.RegistrationUpdateInput }[] = [];
-  const unmatched: ResultInput[] = [];
+  const unmatched: typeof results = [];
   // Rows that found an athlete but carry a finish time nobody could read. They
   // are skipped rather than failing the whole batch, so one typo in a 500-row
   // CSV doesn't cost the organiser every other result.

--- a/app/api/organiser/events/[id]/route.ts
+++ b/app/api/organiser/events/[id]/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { getEventCoords } from "@/lib/australia-coords";
 import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
+import { eventPayloadSchema, idParams } from "@/lib/schemas";
 
 export async function GET(
   _req: NextRequest,
@@ -11,7 +12,9 @@ export async function GET(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const event = await prisma.event.findUnique({ where: { id } });
@@ -31,8 +34,17 @@ export async function PATCH(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
-  const body = await req.json();
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
+  const parsedBody = eventPayloadSchema.safeParse(await req.json());
+  if (!parsedBody.success) {
+    return NextResponse.json(
+      { error: parsedBody.error.issues[0]?.message ?? "Invalid input." },
+      { status: 400 },
+    );
+  }
+  const body = parsedBody.data;
   const { submit, ...data } = body;
 
   try {
@@ -49,7 +61,7 @@ export async function PATCH(
       return NextResponse.json({ error: "Only draft events can be updated this way." }, { status: 409 });
 
     if (submit) {
-      const required = ["title", "discipline", "eventDate", "startTime", "city", "state", "format", "level"];
+      const required = ["title", "discipline", "eventDate", "startTime", "city", "state", "format", "level"] as const;
       for (const field of required) {
         if (!data[field]) return NextResponse.json({ error: `${field} is required.` }, { status: 400 });
       }
@@ -144,7 +156,9 @@ export async function DELETE(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const existing = await prisma.event.findUnique({

--- a/app/api/organiser/events/[id]/waves/notify/route.ts
+++ b/app/api/organiser/events/[id]/waves/notify/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { sendWaveUpdateEmail } from "@/lib/email";
+import { idParams } from "@/lib/schemas";
 
 type Wave = { label: string; startTime?: string };
 
@@ -28,7 +29,9 @@ export async function POST(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
   const owned = await assertOwnedEvent(id, session.sub);
   if (owned.error) return owned.error;
   const event = owned.event!;

--- a/app/api/organiser/events/[id]/waves/route.ts
+++ b/app/api/organiser/events/[id]/waves/route.ts
@@ -3,6 +3,10 @@ import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { sanitizeWaveInput, wavesWithCounts } from "@/lib/start-waves";
+import { idParams } from "@/lib/schemas";
+import { z } from "zod";
+
+const wavePatchSchema = z.object({ startWaves: z.unknown().optional() });
 
 async function assertOwnedEvent(eventId: string, organiserId: string) {
   const event = await prisma.event.findUnique({
@@ -24,7 +28,9 @@ export async function GET(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
   const owned = await assertOwnedEvent(id, session.sub);
   if (owned.error) return owned.error;
 
@@ -43,12 +49,17 @@ export async function PATCH(
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
   const owned = await assertOwnedEvent(id, session.sub);
   if (owned.error) return owned.error;
 
-  const body = await req.json().catch(() => null);
-  const sanitized = sanitizeWaveInput(body?.startWaves);
+  const parsedBody = wavePatchSchema.safeParse(await req.json().catch(() => null));
+  if (!parsedBody.success) {
+    return NextResponse.json({ error: "Invalid input." }, { status: 400 });
+  }
+  const sanitized = sanitizeWaveInput(parsedBody.data.startWaves);
   if (!Array.isArray(sanitized)) {
     return NextResponse.json({ error: sanitized.error }, { status: 400 });
   }

--- a/app/api/organiser/events/route.ts
+++ b/app/api/organiser/events/route.ts
@@ -4,6 +4,7 @@ import { getOrganiserSession } from "@/lib/amplify-server";
 import { archivePastEvents } from "@/lib/archive-events";
 import { getEventCoords } from "@/lib/australia-coords";
 import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
+import { eventPayloadSchema } from "@/lib/schemas";
 export async function GET() {
   await archivePastEvents();
   const session = await getOrganiserSession();
@@ -33,11 +34,18 @@ export async function POST(req: NextRequest) {
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const body = await req.json();
+  const parsed = eventPayloadSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid input." },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
   const { submit } = body;
 
   if (submit) {
-    const required = ["title", "discipline", "eventDate", "startTime", "city", "state", "format", "level"];
+    const required = ["title", "discipline", "eventDate", "startTime", "city", "state", "format", "level"] as const;
     for (const field of required) {
       if (!body[field]) return NextResponse.json({ error: `${field} is required.` }, { status: 400 });
     }
@@ -74,7 +82,7 @@ export async function POST(req: NextRequest) {
       data: {
         organiserId:      session.sub,
         status:           eventStatus,
-        title:            body.title,
+        title:            body.title ?? "",
         discipline:       body.discipline        ?? "",
         description:      body.description       ?? null,
         eventDate:        body.eventDate         ?? "",

--- a/app/api/organiser/members/[id]/route.ts
+++ b/app/api/organiser/members/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { canRemoveMember } from "@/lib/organiser-members";
+import { idParams } from "@/lib/schemas";
 
 // DELETE /api/organiser/members/[id]
 // Removes a member. Owner only. The last Owner cannot be removed.
@@ -15,7 +16,9 @@ export async function DELETE(
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const membership = await prisma.organiserMember.findFirst({

--- a/app/api/organiser/members/[id]/transfer-ownership/route.ts
+++ b/app/api/organiser/members/[id]/transfer-ownership/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { canTransferOwnership } from "@/lib/organiser-members";
+import { idParams } from "@/lib/schemas";
 
 // POST /api/organiser/members/[id]/transfer-ownership
 // Atomically promotes the target member to OWNER and demotes the caller
@@ -16,7 +17,9 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  const { id } = parsedParams.data;
 
   try {
     const target = await prisma.organiserMember.findFirst({

--- a/app/api/organiser/members/route.ts
+++ b/app/api/organiser/members/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getOrganiserSession, getUserSession } from "@/lib/amplify-server";
 import { canAddMember, MAX_ORGS_PER_USER } from "@/lib/organiser-members";
+import { z } from "zod";
+
+const addMemberSchema = z.object({ email: z.string().max(255) });
 
 // GET /api/organiser/members
 // Lists all members of the active organiser.
@@ -51,8 +54,11 @@ export async function POST(req: NextRequest) {
 
   let email = "";
   try {
-    const body = await req.json();
-    email = String(body.email ?? "").trim().toLowerCase();
+    const parsed = addMemberSchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid request." }, { status: 400 });
+    }
+    email = parsed.data.email.trim().toLowerCase();
   } catch {
     return NextResponse.json({ error: "Invalid request." }, { status: 400 });
   }

--- a/app/api/organiser/notifications/route.ts
+++ b/app/api/organiser/notifications/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
+import { z } from "zod";
+
+const markReadSchema = z.object({ ids: z.array(z.string().min(1).max(255)).optional() });
 // GET /api/organiser/notifications
 // Returns the 30 most recent notifications; includes unread count in header
 export async function GET() {
@@ -30,12 +33,16 @@ export async function PATCH(req: NextRequest) {
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
   try {
-    const body = await req.json().catch(() => ({})) as { ids?: string[] };
+    const parsed = markReadSchema.safeParse(await req.json().catch(() => ({})));
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input." }, { status: 400 });
+    }
+    const ids = parsed.data.ids;
 
     await prisma.notification.updateMany({
       where: {
         organiserId: session.sub,
-        ...(body.ids?.length ? { id: { in: body.ids } } : {}),
+        ...(ids?.length ? { id: { in: ids } } : {}),
       },
       data: { read: true },
     });

--- a/app/api/organiser/profile/route.ts
+++ b/app/api/organiser/profile/route.ts
@@ -1,6 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
+import { z } from "zod";
+
+const organiserProfileSchema = z.object({
+  orgName: z.string().max(200),
+  contactName: z.string().max(200),
+  contactEmail: z.string().max(255),
+  phone: z.string().max(50),
+  abn: z.string().max(20).nullable().optional(),
+  website: z.string().max(500).nullable().optional(),
+  instagram: z.string().max(500).nullable().optional(),
+  facebook: z.string().max(500).nullable().optional(),
+  bio: z.string().max(5000).nullable().optional(),
+  logoUrl: z.string().max(3000).nullable().optional(),
+  logoPosition: z.string().max(100).nullable().optional(),
+  coverImageUrl: z.string().max(3000).nullable().optional(),
+  coverPosition: z.string().max(100).nullable().optional(),
+  photos: z.array(z.string().max(3000)).optional(),
+  legalName: z.string().max(300).nullable().optional(),
+  insuranceDeclared: z.boolean().optional(),
+  dob: z.string().max(20).nullable().optional(),
+});
 
 export async function GET() {
   const session = await getOrganiserSession();
@@ -35,13 +56,19 @@ export async function PUT(req: NextRequest) {
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const body = await req.json();
+  const parsed = organiserProfileSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid input." },
+      { status: 400 },
+    );
+  }
   const {
     orgName, contactName, contactEmail, phone,
     abn, website, instagram, facebook, bio,
     logoUrl, logoPosition, coverImageUrl, coverPosition, photos,
     legalName, insuranceDeclared, dob,
-  } = body;
+  } = parsed.data;
 
   if (!orgName || !contactName || !phone || !contactEmail) {
     return NextResponse.json(

--- a/app/api/organiser/setup/route.ts
+++ b/app/api/organiser/setup/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getUserSession } from "@/lib/amplify-server";
+import { z } from "zod";
+
+const setupSchema = z.object({ orgName: z.string().max(200) });
 
 export async function POST(req: Request) {
   const session = await getUserSession();
@@ -8,8 +11,12 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
   }
 
-  const { orgName } = await req.json();
-  if (!orgName?.trim()) {
+  const parsed = setupSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Organisation name is required." }, { status: 400 });
+  }
+  const { orgName } = parsed.data;
+  if (!orgName.trim()) {
     return NextResponse.json({ error: "Organisation name is required." }, { status: 400 });
   }
 

--- a/app/api/organiser/switch-org/route.ts
+++ b/app/api/organiser/switch-org/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getServerSession } from "@/lib/amplify-server";
+import { z } from "zod";
 
 export const dynamic = "force-dynamic";
 
 const ACTIVE_ORG_COOKIE = "startline_active_org";
+
+const switchOrgSchema = z.object({ organiserId: z.string().min(1).max(255) });
 
 // POST /api/organiser/switch-org
 // Body: { organiserId } — validates the user is a member, sets the active-org cookie.
@@ -14,8 +17,11 @@ export async function POST(req: NextRequest) {
 
   let organiserId = "";
   try {
-    const body = await req.json();
-    organiserId = String(body.organiserId ?? "");
+    const parsed = switchOrgSchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid request." }, { status: 400 });
+    }
+    organiserId = parsed.data.organiserId;
   } catch {
     return NextResponse.json({ error: "Invalid request." }, { status: 400 });
   }

--- a/app/api/places/autocomplete/route.ts
+++ b/app/api/places/autocomplete/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { GeoPlacesClient, AutocompleteCommand } from "@aws-sdk/client-geo-places";
+import { z } from "zod";
 
 const client = new GeoPlacesClient({ region: "ap-southeast-2" });
 
+const autocompleteQuery = z.object({ q: z.string().trim().min(2).max(200).catch("") });
+
 export async function GET(req: NextRequest) {
-  const q = req.nextUrl.searchParams.get("q")?.trim();
-  if (!q || q.length < 2)
+  const { q } = autocompleteQuery.parse(Object.fromEntries(req.nextUrl.searchParams));
+  if (!q)
     return NextResponse.json({ results: [] });
 
   const cmd = new AutocompleteCommand({

--- a/app/api/places/geocode/route.ts
+++ b/app/api/places/geocode/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { GeoPlacesClient, GeocodeCommand } from "@aws-sdk/client-geo-places";
+import { z } from "zod";
 
 const client = new GeoPlacesClient({ region: "ap-southeast-2" });
 
+const geocodeQuery = z.object({ q: z.string().trim().max(300).catch("") });
+
 export async function GET(req: NextRequest) {
-  const q = req.nextUrl.searchParams.get("q")?.trim();
+  const { q } = geocodeQuery.parse(Object.fromEntries(req.nextUrl.searchParams));
   if (!q)
     return NextResponse.json({ result: null });
 

--- a/app/api/public/organisers/[id]/follow/route.ts
+++ b/app/api/public/organisers/[id]/follow/route.ts
@@ -8,6 +8,7 @@ import {
   isFollowingOrganiser,
   unfollowOrganiser,
 } from "@/lib/organiser-follows";
+import { idParams } from "@/lib/schemas";
 
 async function assertPublicOrganiser(id: string) {
   return prisma.organiser.findFirst({
@@ -20,7 +21,11 @@ export async function GET(
   _req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Organiser not found." }, { status: 404 });
+  }
+  const { id } = parsedParams.data;
   const organiser = await assertPublicOrganiser(id);
   if (!organiser) {
     return NextResponse.json({ error: "Organiser not found." }, { status: 404 });
@@ -53,7 +58,11 @@ export async function POST(
     return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
   }
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Organiser not found." }, { status: 404 });
+  }
+  const { id } = parsedParams.data;
   const organiser = await assertPublicOrganiser(id);
   if (!organiser) {
     return NextResponse.json({ error: "Organiser not found." }, { status: 404 });
@@ -91,7 +100,11 @@ export async function DELETE(
     return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
   }
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Organiser not found." }, { status: 404 });
+  }
+  const { id } = parsedParams.data;
   const organiser = await assertPublicOrganiser(id);
   if (!organiser) {
     return NextResponse.json({ error: "Organiser not found." }, { status: 404 });

--- a/app/api/public/reviews/[organiserId]/route.ts
+++ b/app/api/public/reviews/[organiserId]/route.ts
@@ -2,14 +2,22 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getUserSession } from "@/lib/amplify-server";
 import { displayNameFromUser, getPublishedOrganiserReviews } from "@/lib/reviews";
+import { organiserIdParams } from "@/lib/schemas";
+import { z } from "zod";
 
 function badRequest(msg: string) {
   return NextResponse.json({ error: msg }, { status: 400 });
 }
 
-function ratingOk(n: unknown): n is number {
-  return typeof n === "number" && Number.isInteger(n) && n >= 1 && n <= 5;
-}
+const reviewCreateSchema = z.object({
+  overallRating: z.number().int().min(1).max(5),
+  title: z.string().min(1).max(100),
+  body: z.string().min(1).max(800),
+  atmosphereRating: z.number().int().min(1).max(5).nullable().optional(),
+  organisationRating: z.number().int().min(1).max(5).nullable().optional(),
+  experienceRating: z.number().int().min(1).max(5).nullable().optional(),
+  eventId: z.string().max(255).nullable().optional(),
+});
 
 async function assertPublicOrganiser(organiserId: string) {
   return prisma.organiser.findFirst({
@@ -22,7 +30,11 @@ export async function GET(
   _req: Request,
   { params }: { params: Promise<{ organiserId: string }> }
 ) {
-  const { organiserId } = await params;
+  const parsedParams = organiserIdParams.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Organiser not found." }, { status: 404 });
+  }
+  const { organiserId } = parsedParams.data;
   const organiser = await assertPublicOrganiser(organiserId);
   if (!organiser) {
     return NextResponse.json({ error: "Organiser not found." }, { status: 404 });
@@ -41,7 +53,11 @@ export async function POST(
     return NextResponse.json({ error: "Sign in to write a review." }, { status: 401 });
   }
 
-  const { organiserId } = await params;
+  const parsedParams = organiserIdParams.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Organiser not found." }, { status: 404 });
+  }
+  const { organiserId } = parsedParams.data;
   const organiser = await assertPublicOrganiser(organiserId);
   if (!organiser) {
     return NextResponse.json({ error: "Organiser not found." }, { status: 404 });
@@ -55,42 +71,25 @@ export async function POST(
     return NextResponse.json({ error: "Sign in to write a review." }, { status: 401 });
   }
 
-  let body: Record<string, unknown>;
-  try {
-    body = await req.json();
-  } catch {
-    return badRequest("Invalid JSON.");
+  const parsed = reviewCreateSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return badRequest(parsed.error.issues[0]?.message ?? "Invalid input.");
   }
-
-  const overallRating = body.overallRating;
-  if (!ratingOk(overallRating)) {
-    return badRequest("Overall rating must be an integer from 1 to 5.");
-  }
-
-  const title = typeof body.title === "string" ? body.title.trim() : "";
-  const reviewBody = typeof body.body === "string" ? body.body.trim() : "";
-
-  if (!title || title.length > 100) return badRequest("Title is required (max 100 characters).");
-  if (!reviewBody || reviewBody.length > 800) return badRequest("Review body is required (max 800 characters).");
-
-  const optionalRating = (v: unknown) => {
-    if (v == null || v === "") return null;
-    if (!ratingOk(v)) return undefined;
-    return v;
-  };
-
-  const atmosphereRating = optionalRating(body.atmosphereRating);
-  const organisationRating = optionalRating(body.organisationRating);
-  const experienceRating = optionalRating(body.experienceRating);
-  if (atmosphereRating === undefined || organisationRating === undefined || experienceRating === undefined) {
-    return badRequest("Sub-ratings must be integers from 1 to 5 when provided.");
-  }
+  const {
+    overallRating,
+    title,
+    body: reviewBody,
+    atmosphereRating,
+    organisationRating,
+    experienceRating,
+    eventId: eventIdInput,
+  } = parsed.data;
 
   let eventId: string | null = null;
   let eventTitle: string | null = null;
-  if (typeof body.eventId === "string" && body.eventId) {
+  if (eventIdInput) {
     const event = await prisma.event.findFirst({
-      where: { id: body.eventId, organiserId, status: "APPROVED" },
+      where: { id: eventIdInput, organiserId, status: "APPROVED" },
       select: { id: true, title: true },
     });
     if (!event) return badRequest("Event not found for this organiser.");

--- a/app/api/register/verify-email/confirm/route.ts
+++ b/app/api/register/verify-email/confirm/route.ts
@@ -1,14 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import { confirmGuestEmailVerificationCode } from "@/lib/guest-email-verification";
+import { z } from "zod";
+
+const verifyEmailConfirmSchema = z.object({
+  eventId: z.string().max(255),
+  email: z.string().max(255),
+  code: z.string().max(10),
+});
 
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json() as { eventId?: string; email?: string; code?: string };
-    const { eventId, email, code } = body;
-
-    if (!eventId || !email || !code) {
+    const parsed = verifyEmailConfirmSchema.safeParse(await req.json());
+    if (!parsed.success) {
       return NextResponse.json({ error: "Missing event, email, or code." }, { status: 400 });
     }
+    const { eventId, email, code } = parsed.data;
 
     const result = await confirmGuestEmailVerificationCode(email, eventId, code);
     if (!result.ok) {

--- a/app/api/register/verify-email/send/route.ts
+++ b/app/api/register/verify-email/send/route.ts
@@ -1,15 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { sendGuestEmailVerificationCode } from "@/lib/guest-email-verification";
+import { z } from "zod";
+
+const verifyEmailSendSchema = z.object({
+  eventId: z.string().max(255),
+  email: z.string().max(255),
+});
 
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json() as { eventId?: string; email?: string };
-    const { eventId, email } = body;
-
-    if (!eventId || !email) {
+    const parsed = verifyEmailSendSchema.safeParse(await req.json());
+    if (!parsed.success) {
       return NextResponse.json({ error: "Missing event or email." }, { status: 400 });
     }
+    const { eventId, email } = parsed.data;
 
     const event = await prisma.event.findUnique({
       where: { id: eventId },

--- a/app/api/user/exists/route.ts
+++ b/app/api/user/exists/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCognitoUserStatus } from "@/lib/athlete-accounts";
+import { z } from "zod";
+
+const userExistsSchema = z.object({ email: z.string().max(255) });
 
 export async function POST(req: NextRequest) {
   try {
-    const { email } = await req.json() as { email?: string };
-    if (!email || !email.includes("@")) {
+    const parsed = userExistsSchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid email." }, { status: 400 });
+    }
+    const { email } = parsed.data;
+    if (!email.includes("@")) {
       return NextResponse.json({ error: "Invalid email." }, { status: 400 });
     }
 

--- a/app/api/user/mfa/route.ts
+++ b/app/api/user/mfa/route.ts
@@ -3,10 +3,19 @@ import { cookies } from "next/headers";
 import { CognitoIdentityProviderClient, AssociateSoftwareTokenCommand, VerifySoftwareTokenCommand, SetUserMFAPreferenceCommand, ChangePasswordCommand } from "@aws-sdk/client-cognito-identity-provider";
 import prisma from "@/lib/prisma";
 import { getServerSession } from "@/lib/amplify-server";
+import { z } from "zod";
 
 const region = process.env.NEXT_PUBLIC_AWS_REGION ?? "ap-southeast-2";
 const clientId = process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? "";
 const cognito = new CognitoIdentityProviderClient({ region });
+
+const mfaActionSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("enable") }),
+  z.object({ action: z.literal("disable") }),
+  z.object({ action: z.literal("setup") }),
+  z.object({ action: z.literal("verify-setup"), code: z.string().max(10) }),
+  z.object({ action: z.literal("change-password"), currentPassword: z.string().min(1), newPassword: z.string().min(1) }),
+]);
 
 async function getAccessToken(): Promise<string | null> {
   const store = await cookies();
@@ -33,13 +42,16 @@ export async function POST(req: Request) {
   const session = await getServerSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const body = await req.json();
-  const { action } = body;
+  const parsed = mfaActionSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input." }, { status: 400 });
+  }
+  const body = parsed.data;
 
   const user = await prisma.user.findUnique({ where: { cognitoSub: session.sub } });
   if (!user) return NextResponse.json({ error: "User not found." }, { status: 404 });
 
-  switch (action) {
+  switch (body.action) {
     case "enable": {
       await prisma.user.update({
         where: { id: user.id },
@@ -66,9 +78,6 @@ export async function POST(req: Request) {
 
     case "verify-setup": {
       const { code } = body;
-      if (!code || typeof code !== "string") {
-        return NextResponse.json({ error: "Code is required." }, { status: 400 });
-      }
       const accessToken = await getAccessToken();
       if (!accessToken) return NextResponse.json({ error: "No session." }, { status: 401 });
       await cognito.send(new VerifySoftwareTokenCommand({
@@ -89,9 +98,6 @@ export async function POST(req: Request) {
 
     case "change-password": {
       const { currentPassword, newPassword } = body;
-      if (!currentPassword || !newPassword) {
-        return NextResponse.json({ error: "Current and new password required." }, { status: 400 });
-      }
       const accessToken = await getAccessToken();
       if (!accessToken) return NextResponse.json({ error: "No session." }, { status: 401 });
       await cognito.send(new ChangePasswordCommand({

--- a/app/api/user/notifications/route.ts
+++ b/app/api/user/notifications/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getUserSession } from "@/lib/amplify-server";
+import { z } from "zod";
+
+const markReadSchema = z.object({ ids: z.array(z.string().min(1).max(255)).optional() });
 
 // GET /api/user/notifications — the 30 most recent notifications for the athlete.
 export async function GET() {
@@ -29,12 +32,16 @@ export async function PATCH(req: NextRequest) {
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
   try {
-    const body = await req.json().catch(() => ({})) as { ids?: string[] };
+    const parsed = markReadSchema.safeParse(await req.json().catch(() => ({})));
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input." }, { status: 400 });
+    }
+    const ids = parsed.data.ids;
 
     await prisma.userNotification.updateMany({
       where: {
         userId: session.sub,
-        ...(body.ids?.length ? { id: { in: body.ids } } : {}),
+        ...(ids?.length ? { id: { in: ids } } : {}),
       },
       data: { read: true },
     });

--- a/app/api/user/profile/[username]/route.ts
+++ b/app/api/user/profile/[username]/route.ts
@@ -1,12 +1,17 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getOrganiserRatings } from "@/lib/reviews";
+import { usernameParams } from "@/lib/schemas";
 
 export async function GET(
   _req: Request,
   { params }: { params: Promise<{ username: string }> }
 ) {
-  const { username } = await params;
+  const parsedParams = usernameParams.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Username is required." }, { status: 400 });
+  }
+  const { username } = parsedParams.data;
   if (!username) {
     return NextResponse.json({ error: "Username is required." }, { status: 400 });
   }

--- a/app/api/user/profile/check-username/route.ts
+++ b/app/api/user/profile/check-username/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getUserSession } from "@/lib/amplify-server";
 import { validateUsername } from "@/lib/username-validation";
+import { z } from "zod";
+
+const usernameQuery = z.object({ username: z.string().min(1).max(50) });
 
 export async function GET(req: NextRequest) {
   const session = await getUserSession();
@@ -9,11 +12,12 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
   }
 
-  const username = req.nextUrl.searchParams.get("username")?.trim().toLowerCase();
-
-  if (!username) {
+  const parsed = usernameQuery.safeParse(Object.fromEntries(req.nextUrl.searchParams));
+  if (!parsed.success) {
     return NextResponse.json({ available: false, error: "Username is required." });
   }
+
+  const username = parsed.data.username.toLowerCase();
 
   const validation = validateUsername(username);
   if (!validation.valid) {

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -4,10 +4,26 @@ import { getUserSession } from "@/lib/amplify-server";
 import { validateUsername } from "@/lib/username-validation";
 import { getOrganiserRatings } from "@/lib/reviews";
 import { GENDER_OPTIONS } from "@/lib/registration-form";
+import { z } from "zod";
 
 function badRequest(msg: string) {
   return NextResponse.json({ error: msg }, { status: 400 });
 }
+
+const profileUpdateSchema = z.object({
+  name: z.string().max(200).nullable().optional(),
+  username: z.string().max(50).optional(),
+  bio: z.string().max(2000).nullable().optional(),
+  profilePicUrl: z.string().max(3000).nullable().optional(),
+  isPublic: z.boolean().optional(),
+  city: z.string().max(100).nullable().optional(),
+  state: z.string().max(100).nullable().optional(),
+  mobile: z.string().max(50).nullable().optional(),
+  dateOfBirth: z.string().max(20).nullable().optional(),
+  gender: z.string().max(50).nullable().optional(),
+  emergencyContactName: z.string().max(200).nullable().optional(),
+  emergencyContactPhone: z.string().max(50).nullable().optional(),
+});
 
 const privateSelect = {
   mobile: true,
@@ -125,7 +141,14 @@ export async function PUT(req: Request) {
     return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
   }
 
-  const body = await req.json();
+  const parsed = profileUpdateSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid input." },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
   const data: Record<string, unknown> = {};
 
   if ("name" in body) data.name = normalizeOptionalString(body.name);

--- a/app/api/user/registrations/[id]/refund-request/route.ts
+++ b/app/api/user/registrations/[id]/refund-request/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getUserSession } from "@/lib/amplify-server";
+import { idParams } from "@/lib/schemas";
 
 // POST — the signed-in athlete asks for a refund on their own registration.
 // This does not move any money: it flags the entry so the organiser sees it in
@@ -13,7 +14,11 @@ export async function POST(
   const session = await getUserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
-  const { id } = await params;
+  const parsedParams = idParams.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Registration not found." }, { status: 404 });
+  }
+  const { id } = parsedParams.data;
 
   const registration = await prisma.registration.findUnique({
     where: { id },

--- a/app/api/user/saved-events/route.ts
+++ b/app/api/user/saved-events/route.ts
@@ -2,6 +2,9 @@ import { NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { getUserSession } from "@/lib/amplify-server";
+import { z } from "zod";
+
+const savedEventSchema = z.object({ eventId: z.string().min(1).max(255) });
 
 export async function GET() {
   const session = await getUserSession();
@@ -24,11 +27,11 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
   }
 
-  const body = await req.json();
-  const eventId = typeof body?.eventId === "string" ? body.eventId : null;
-  if (!eventId) {
+  const parsed = savedEventSchema.safeParse(await req.json());
+  if (!parsed.success) {
     return NextResponse.json({ error: "eventId is required." }, { status: 400 });
   }
+  const eventId = parsed.data.eventId;
 
   const event = await prisma.event.findUnique({ where: { id: eventId }, select: { id: true } });
   if (!event) {
@@ -50,11 +53,11 @@ export async function DELETE(req: Request) {
     return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
   }
 
-  const body = await req.json();
-  const eventId = typeof body?.eventId === "string" ? body.eventId : null;
-  if (!eventId) {
+  const parsed = savedEventSchema.safeParse(await req.json());
+  if (!parsed.success) {
     return NextResponse.json({ error: "eventId is required." }, { status: 400 });
   }
+  const eventId = parsed.data.eventId;
 
   try {
     await prisma.savedEvent.delete({

--- a/app/api/waitlist/route.ts
+++ b/app/api/waitlist/route.ts
@@ -3,6 +3,9 @@ import prisma from "@/lib/prisma";
 import { Resend } from "resend";
 import { render } from "@react-email/render";
 import { WaitlistConfirmationEmail } from "@/emails/waitlist-confirmation";
+import { z } from "zod";
+
+const waitlistSchema = z.object({ email: z.string().max(255) });
 
 function getResend() {
   const key = process.env.RESEND_API_KEY;
@@ -11,9 +14,13 @@ function getResend() {
 }
 
 export async function POST(req: NextRequest) {
-  const { email } = await req.json();
+  const parsed = waitlistSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid email address." }, { status: 400 });
+  }
+  const { email } = parsed.data;
 
-  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
     return NextResponse.json({ error: "Invalid email address." }, { status: 400 });
   }
 

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+// Path params — untrusted input, whitelisted before it reaches Prisma.
+export const idParams = z.object({ id: z.string().min(1).max(255) });
+export const organiserIdParams = z.object({ organiserId: z.string().min(1).max(255) });
+export const usernameParams = z.object({ username: z.string().min(1).max(100) });
+export const idAnnouncementIdParams = z.object({
+  id: z.string().min(1).max(255),
+  announcementId: z.string().min(1).max(255),
+});
+
+// Event create/update payload — shared by the organiser and admin event routes.
+// All fields optional (PATCH semantics); the routes apply their own defaults and
+// submit-time required-field checks so existing error messages stay unchanged.
+// JSON columns (categories, waves) are kept opaque — Prisma serialises them.
+export const eventPayloadSchema = z.object({
+  submit: z.boolean().optional(),
+  title: z.string().max(200).optional(),
+  discipline: z.string().max(80).optional(),
+  description: z.string().max(10000).nullable().optional(),
+  eventDate: z.string().max(20).optional(),
+  endDate: z.string().max(20).nullable().optional(),
+  startTime: z.string().max(10).optional(),
+  endTime: z.string().max(10).optional(),
+  venue: z.string().max(200).optional(),
+  address: z.string().max(300).nullable().optional(),
+  city: z.string().max(100).optional(),
+  state: z.string().max(50).optional(),
+  latitude: z.number().min(-90).max(90).nullable().optional(),
+  longitude: z.number().min(-180).max(180).nullable().optional(),
+  format: z.string().max(100).optional(),
+  level: z.string().max(100).optional(),
+  categories: z.unknown().optional(),
+  cap: z.number().int().min(1).max(1000000).nullable().optional(),
+  minAge: z.number().int().min(0).max(150).nullable().optional(),
+  waves: z.unknown().optional(),
+  inclusions: z.string().max(10000).nullable().optional(),
+  extras: z.string().max(10000).nullable().optional(),
+  activations: z.string().max(10000).nullable().optional(),
+  refundPolicy: z.string().max(10000).nullable().optional(),
+  registrationType: z.enum(["startline", "external"]).optional(),
+  feeStructure: z.enum(["athlete", "organiser"]).optional(),
+  registrationUrl: z.string().max(2000).nullable().optional(),
+  accessibilityInfo: z.string().max(10000).nullable().optional(),
+  coverImageUrl: z.string().max(2000).nullable().optional(),
+  informationPdfUrl: z.string().max(2000).nullable().optional(),
+  photos: z.array(z.string().max(3000)).optional(),
+});
+
+export const adminEventPayloadSchema = eventPayloadSchema.extend({
+  organiserId: z.string().min(1).max(255),
+});

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "react-map-gl": "^8.1.1",
     "resend": "^6.9.4",
     "stripe": "^22.2.0",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.4.3"
   },
   "prisma": {
     "seed": "npx tsx prisma/seed.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.6.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@argos-ci/cli':
         specifier: ^6.3.0


### PR DESCRIPTION
## Description

Server-side Zod validation for every API route. Closes the input-validation gap called out in the security audit (#216): untrusted client input is now whitelisted through Zod schemas before it reaches Prisma, and no route spreads a raw request body into a DB write or accepts prices/roles/permissions from the client.

**Why:** previously most routes did `const body = await req.json()` and passed arbitrary fields straight into `prisma.create/update`. A hand-crafted payload could inject columns the client was never meant to control (e.g. `status`, `verified`, `isBanned`, `payoutAmountCents`). Now every body, query string, and path param is parsed by a schema, stripped of unknown keys, and only the validated output touches the DB.

### What changed

- **Added `zod ^4.4.3`** as a direct dependency (was only transitive).
- **New `lib/schemas.ts`** — shared path-param schemas (`idParams`, `organiserIdParams`, `usernameParams`, `idAnnouncementIdParams`), an `eventPayloadSchema` whitelist reused by the four event create/update routes, and an admin variant adding `organiserId`.
- **58 route files updated** — every route that reads a body, query string, or path param now parses via `z.safeParse`, returns 400 on failure, and uses only `parsed.data` downstream. Zod objects `.strip()` unknown keys by default, so injected fields are dropped before Prisma sees them.
- **List GETs** (`admin/events`, `admin/registrations`, `admin/users`, `admin/audit`, `admin/reviews`, `places/*`, `abn`, registrations export) use `z.coerce` + `.catch()` defaults so malformed query params fall back to the previous safe defaults instead of changing behaviour.
- **No raw request spreads remain** — the only object spreads left operate on already-validated/sanitised data.
- **Prices, roles, permissions stay server-side** — checkout prices come from `event.waves` in the DB, member roles are hardcoded server-side, event status is derived from the session/organiser, and the schemas don't list privilege columns (`verified`, `isBanned`, `stripeAccountId`, `payout*`, etc.) so they cannot be injected.

### Routes covered

Every route accepting untrusted input was covered, across all four API areas:

| Area | Routes |
|---|---|
| **Admin** | events (list/create/patch/delete/review/pin/bulk), organisers (members/verify/suspend), users (list/update/ban), registrations (list/refund), reviews (list/moderation/delete), payouts, audit log |
| **Organiser** | events (create/update/delete), start waves (patch + notify), announcements (create/delete), registrations (patch/move/export), results, dashboard, duplicate, pin, members (add/remove/transfer/leave), notifications, profile, setup, switch-org, stripe connect |
| **User** | profile (get/update/check-username/public profile), mfa, notifications, saved-events, registrations (refund-request), user-exists |
| **Public/misc** | event availability, organiser follow, public reviews, waitlist, contact, feedback, register verify-email (send/confirm), places (autocomplete/geocode), abn, checkout |

### Routes deliberately skipped (and why)

- **`/api/stripe/webhook`** — body is `req.text()` verified by Stripe signature at the boundary; parsing the verified event with our own schema would be redundant.
- **`/api/upload`** — multipart form data, already gated by an explicit server-side allowlist (type + size checks); no JSON body to schema.
- **`/api/*/auth/session` and `/api/user/role`** — no client input; server-only session bootstrap/derivation.
- **Start-wave deep validation** (`waves` PATCH) — kept the existing `sanitizeWaveInput` lib function (already server-side, unit-tested, rejects unknown fields) and added a thin outer body schema.
- **Checkout participant fields** are schema-typed + length-capped but not fully re-validated — the existing `validateParticipants()` (unit-tested) still owns field-level checks so per-field error messages are unchanged.

### Verification

- `pnpm lint` — 0 errors, 0 warnings
- `pnpm typecheck` — 0 errors
- `pnpm test` — 199/199 pass

E2E not run (needs Docker PostgreSQL + dev server on the main checkout); API-facing assertions (`e2e/api.spec.ts`) were traced manually and the validation changes preserve their expectations.

Related: #216
