### PR TITLE
fix(authz): audit API ownership checks and harden write paths

### DIFF
--- a/app/api/organiser/events/[id]/route.ts
+++ b/app/api/organiser/events/[id]/route.ts
@@ -155,6 +155,7 @@ export async function DELETE(
 ) {
   const session = await getOrganiserSession();
   if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  if (session.role !== "OWNER") return NextResponse.json({ error: "Forbidden." }, { status: 403 });
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/members/[id]/transfer-ownership/route.ts
+++ b/app/api/organiser/members/[id]/transfer-ownership/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
+import { getOrganiserSession, getUserSession } from "@/lib/amplify-server";
 import { canTransferOwnership } from "@/lib/organiser-members";
 import { idParams } from "@/lib/schemas";
 
@@ -16,6 +16,9 @@ export async function POST(
   if (session.role !== "OWNER") {
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }
+
+  const userSession = await getUserSession();
+  if (!userSession) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
@@ -36,8 +39,7 @@ export async function POST(
     }
 
     const caller = await prisma.organiserMember.findFirst({
-      where:  { organiserId: session.sub, role: "OWNER" },
-      orderBy: { createdAt: "asc" },
+      where:  { organiserId: session.sub, userId: userSession.sub },
       select: { id: true },
     });
     if (!caller) {

--- a/app/api/organiser/profile/route.ts
+++ b/app/api/organiser/profile/route.ts
@@ -77,6 +77,17 @@ export async function PUT(req: NextRequest) {
     );
   }
 
+  // Legal identity fields (ABN, legal name, DOB, insurance) are owner-level:
+  // they underpin Stripe payouts and liability. MANAGERs may edit the rest.
+  const hasIdentityFields = abn !== undefined || legalName !== undefined ||
+    dob !== undefined || insuranceDeclared !== undefined;
+  if (hasIdentityFields && session.role !== "OWNER") {
+    return NextResponse.json(
+      { error: "Only an Owner can update legal identity details." },
+      { status: 403 },
+    );
+  }
+
   try {
     await prisma.organiser.update({
       where: { id: session.sub },

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -91,7 +91,7 @@ async function handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent)
   const event = await prisma.event.findUnique({
     where: { id: eventId },
     select: {
-      id: true, title: true, status: true, feeStructure: true, registrationType: true,
+      title: true, status: true, feeStructure: true, registrationType: true,
       waves: true, cap: true, eventDate: true, startTime: true, venue: true, city: true, state: true,
       organiserId: true,
     },
@@ -145,19 +145,8 @@ async function handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent)
     pricing: priceOf(participant),
   }));
 
-  // The charged amount must match what the DB pricing implies. Stripe reports
-  // amount_received in the minor currency unit, same as our cents.
-  const expectedTotalCents = priced.reduce((sum, { participant, pricing }) => {
-    if (!pricing) return sum;
-    return sum + (event.feeStructure === "athlete"
-      ? pricing.priceCents + pricing.platformFeeCents
-      : pricing.priceCents);
-  }, 0);
-
-  if (paymentIntent.amount_received !== expectedTotalCents || priced.some(({ pricing }) => !pricing)) {
-    console.error("PaymentIntent amount does not match DB pricing:", paymentIntent.id,
-      { expectedTotalCents, amountReceived: paymentIntent.amount_received });
-    await prisma.registration.createMany({
+  const recordCancelled = () =>
+    prisma.registration.createMany({
       data: participants.map((participant) => ({
         eventId,
         organiserId,
@@ -170,6 +159,20 @@ async function handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent)
         stripePaymentIntentId: paymentIntent.id,
       })),
     });
+
+  // The charged amount must match what the DB pricing implies. Stripe reports
+  // amount_received in the minor currency unit, same as our cents.
+  const expectedTotalCents = priced.reduce((sum, { participant, pricing }) => {
+    if (!pricing) return sum;
+    return sum + (event.feeStructure === "athlete"
+      ? pricing.priceCents + pricing.platformFeeCents
+      : pricing.priceCents);
+  }, 0);
+
+  if (paymentIntent.amount_received !== expectedTotalCents || priced.some(({ pricing }) => !pricing)) {
+    console.error("PaymentIntent amount does not match DB pricing:", paymentIntent.id,
+      { expectedTotalCents, amountReceived: paymentIntent.amount_received });
+    await recordCancelled();
     return;
   }
 
@@ -258,19 +261,7 @@ async function handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent)
 
   if (capacityViolation) {
     console.error("Confirmation refused — over capacity:", paymentIntent.id, capacityViolation);
-    await prisma.registration.createMany({
-      data: participants.map((participant) => ({
-        eventId,
-        organiserId,
-        athleteName: athleteNameFromParticipant(participant),
-        athleteEmail: participant.em,
-        amountCents: 0,
-        platformFeeCents: 0,
-        feeStructure: event.feeStructure,
-        status: "CANCELLED" as const,
-        stripePaymentIntentId: paymentIntent.id,
-      })),
-    });
+    await recordCancelled();
     return;
   }
 
@@ -294,10 +285,8 @@ async function handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent)
   // price. When the organiser absorbs it, the athlete pays the ticket price
   // only and the service fee shown to them is $0.
   const athletePaysFee = event.feeStructure === "athlete";
-  for (const participant of participants) {
-    if (!participant.em) continue;
-    const pricing = priceOf(participant);
-    if (!pricing) continue;
+  for (const { participant, pricing } of priced) {
+    if (!participant.em || !pricing) continue;
     const ticketCents = pricing.priceCents;
     const feeCents = athletePaysFee ? pricing.platformFeeCents : 0;
     sendRegistrationConfirmationEmail(participant.em, {

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -3,7 +3,9 @@ import Stripe from "stripe";
 import prisma from "@/lib/prisma";
 import { getStripe } from "@/lib/stripe";
 import { sendRegistrationConfirmationEmail } from "@/lib/email";
-import { parseParticipantsFromMetadata, parseWavePricing } from "@/lib/stripe-webhook";
+import { parseParticipantsFromMetadata } from "@/lib/stripe-webhook";
+import { calculateTotalWithFee } from "@/lib/platform-fee";
+import { getCapacityError, hasCappedWave } from "@/lib/registration-capacity";
 import {
   expandCompactParticipant,
   athleteNameFromParticipant,
@@ -83,6 +85,28 @@ async function handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent)
 
   const participants = parseParticipantsFromMetadata(meta);
 
+  // Re-derive everything from the DB — metadata on a PaymentIntent is
+  // client-influenced (the publishable key can create intents with arbitrary
+  // metadata), so it must never be trusted for pricing or identity.
+  const event = await prisma.event.findUnique({
+    where: { id: eventId },
+    select: {
+      id: true, title: true, status: true, feeStructure: true, registrationType: true,
+      waves: true, cap: true, eventDate: true, startTime: true, venue: true, city: true, state: true,
+      organiserId: true,
+    },
+  });
+
+  // Reject intents that don't match a real, approved, self-hosted event.
+  if (!event || event.organiserId !== organiserId) {
+    console.error("PaymentIntent references an unknown/mismatched event:", paymentIntent.id);
+    return;
+  }
+  if (event.status !== "APPROVED" || event.registrationType !== "startline") {
+    console.error("PaymentIntent references a non-bookable event:", paymentIntent.id);
+    return;
+  }
+
   if (participants.length === 0) {
     console.error("No participant data on PaymentIntent:", paymentIntent.id);
     await prisma.registration.create({
@@ -91,9 +115,9 @@ async function handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent)
         organiserId,
         athleteName: meta.userName ?? "Unknown",
         athleteEmail: meta.userEmail ?? "",
-        amountCents: parseInt(meta.ticketPriceCents ?? "0", 10),
-        platformFeeCents: parseInt(meta.platformFeeCents ?? "0", 10),
-        feeStructure: meta.feeStructure ?? "athlete",
+        amountCents: 0,
+        platformFeeCents: 0,
+        feeStructure: event.feeStructure,
         status: "CANCELLED",
         stripePaymentIntentId: paymentIntent.id,
       },
@@ -101,26 +125,56 @@ async function handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent)
     return;
   }
 
-  const ticketPriceCents = parseInt(meta.ticketPriceCents ?? "0", 10);
-  const platformFeePerTicket = parseInt(
-    meta.platformFeeCentsPerTicket ?? meta.platformFeeCents ?? "0",
-    10
-  );
-
-  // Mixed-tier orders: each participant carries its own wave label, priced via
-  // the wavePricing map. Legacy intents fall back to the order-level fields.
-  const wavePricing = parseWavePricing(meta);
+  // Price every ticket from the DB wave definitions — never from metadata.
+  const waves = Array.isArray(event.waves)
+    ? event.waves as { label: string; price: string; qty?: number }[]
+    : [];
   const waveOf = (participant: CompactParticipant) => participant.wav || meta.waveLabel || null;
-  const priceOf = (participant: CompactParticipant) => {
-    const wav = waveOf(participant);
-    return (wav && wavePricing[wav]?.p) || ticketPriceCents;
-  };
-  const feeOf = (participant: CompactParticipant) => {
-    const wav = waveOf(participant);
-    return (wav && wavePricing[wav]?.f) || platformFeePerTicket;
+  const priceOf = (participant: CompactParticipant): { priceCents: number; platformFeeCents: number } | null => {
+    const label = waveOf(participant);
+    const wave = label ? waves.find((w) => w.label === label) : undefined;
+    if (!wave) return null;
+    const priceCents = Math.round(parseFloat(wave.price || "0") * 100);
+    if (priceCents <= 0) return null;
+    const { platformFeeCents } = calculateTotalWithFee(priceCents, event.feeStructure);
+    return { priceCents, platformFeeCents };
   };
 
-  // For guest participants (no userId in metadata), create Cognito accounts + Prisma Users
+  const priced = participants.map((participant) => ({
+    participant,
+    pricing: priceOf(participant),
+  }));
+
+  // The charged amount must match what the DB pricing implies. Stripe reports
+  // amount_received in the minor currency unit, same as our cents.
+  const expectedTotalCents = priced.reduce((sum, { participant, pricing }) => {
+    if (!pricing) return sum;
+    return sum + (event.feeStructure === "athlete"
+      ? pricing.priceCents + pricing.platformFeeCents
+      : pricing.priceCents);
+  }, 0);
+
+  if (paymentIntent.amount_received !== expectedTotalCents || priced.some(({ pricing }) => !pricing)) {
+    console.error("PaymentIntent amount does not match DB pricing:", paymentIntent.id,
+      { expectedTotalCents, amountReceived: paymentIntent.amount_received });
+    await prisma.registration.createMany({
+      data: participants.map((participant) => ({
+        eventId,
+        organiserId,
+        athleteName: athleteNameFromParticipant(participant),
+        athleteEmail: participant.em,
+        amountCents: 0,
+        platformFeeCents: 0,
+        feeStructure: event.feeStructure,
+        status: "CANCELLED" as const,
+        stripePaymentIntentId: paymentIntent.id,
+      })),
+    });
+    return;
+  }
+
+  // For guest participants (no userId in metadata), create Cognito accounts +
+  // Prisma Users up front so the confirmations below can link them.
   const existingUserId = meta.userId || "";
   const userIdByEmail: Record<string, string> = {};
   if (!existingUserId) {
@@ -133,46 +187,97 @@ async function handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent)
     }
   }
 
-  await prisma.registration.createMany({
-    data: participants.map((participant) => {
-      const expanded = expandCompactParticipant(participant);
-      const email = participant.em?.toLowerCase().trim() || "";
-      const uid = existingUserId || userIdByEmail[email] || "";
-      return {
-        eventId,
-        organiserId,
-        userId: uid || null,
-        athleteName: athleteNameFromParticipant(participant),
-        athleteEmail: participant.em,
-        firstName: expanded.firstName,
-        lastName: expanded.lastName,
-        dateOfBirth: expanded.dateOfBirth,
-        gender: expanded.gender || null,
-        mobile: expanded.mobile,
-        emergencyContactName: expanded.emergencyContactName,
-        emergencyContactPhone: expanded.emergencyContactPhone,
-        medicalNotes: expanded.medicalNotes || null,
-        waiverAccepted: true,
-        estimatedFinishMinutes: participant.eft ?? null,
-        waveLabel: waveOf(participant),
-        amountCents: priceOf(participant),
-        platformFeeCents: feeOf(participant),
-        feeStructure: meta.feeStructure ?? "athlete",
-        status: "CONFIRMED" as const,
-        stripePaymentIntentId: paymentIntent.id,
-      };
-    }),
+  // Atomic capacity check — refuse to confirm past the event cap or a tier's
+  // quantity. Runs inside the same transaction as the insert so concurrent
+  // confirmations can't both pass the count.
+  const capacityViolation = await prisma.$transaction(async (tx) => {
+    const requestedByWave = priced.reduce<Record<string, number>>((acc, { participant }) => {
+      const label = waveOf(participant);
+      if (label) acc[label] = (acc[label] ?? 0) + 1;
+      return acc;
+    }, {});
+    const usedLabels = Object.keys(requestedByWave);
+    const needsCapCheck = event.cap != null;
+    const needsWaveCheck = hasCappedWave(waves, usedLabels);
+    const confirmedTotal = needsCapCheck
+      ? await tx.registration.count({ where: { eventId, status: "CONFIRMED" } })
+      : 0;
+    const confirmedByWave: Record<string, number> = {};
+    if (needsWaveCheck) {
+      const grouped = await tx.registration.groupBy({
+        by: ["waveLabel"],
+        where: { eventId, status: "CONFIRMED" },
+        _count: { _all: true },
+      });
+      for (const row of grouped) {
+        if (row.waveLabel) confirmedByWave[row.waveLabel] = row._count._all;
+      }
+    }
+    const capacityError = getCapacityError({
+      cap: event.cap,
+      confirmedTotal,
+      requestedTotal: participants.length,
+      waves,
+      usedLabels,
+      confirmedByWave,
+      requestedByWave,
+    });
+    if (capacityError) return capacityError;
+    await tx.registration.createMany({
+      data: priced.map(({ participant, pricing }) => {
+        const expanded = expandCompactParticipant(participant);
+        const email = participant.em?.toLowerCase().trim() || "";
+        const uid = existingUserId || userIdByEmail[email] || "";
+        return {
+          eventId,
+          organiserId,
+          userId: uid || null,
+          athleteName: athleteNameFromParticipant(participant),
+          athleteEmail: participant.em,
+          firstName: expanded.firstName,
+          lastName: expanded.lastName,
+          dateOfBirth: expanded.dateOfBirth,
+          gender: expanded.gender || null,
+          mobile: expanded.mobile,
+          emergencyContactName: expanded.emergencyContactName,
+          emergencyContactPhone: expanded.emergencyContactPhone,
+          medicalNotes: expanded.medicalNotes || null,
+          waiverAccepted: true,
+          estimatedFinishMinutes: participant.eft ?? null,
+          waveLabel: waveOf(participant),
+          amountCents: pricing!.priceCents,
+          platformFeeCents: pricing!.platformFeeCents,
+          feeStructure: event.feeStructure,
+          status: "CONFIRMED" as const,
+          stripePaymentIntentId: paymentIntent.id,
+        };
+      }),
+    });
+    return null;
   });
 
-  const dbEvent = await prisma.event.findUnique({
-    where: { id: eventId },
-    select: { title: true, eventDate: true, startTime: true, venue: true, city: true, state: true },
-  });
+  if (capacityViolation) {
+    console.error("Confirmation refused — over capacity:", paymentIntent.id, capacityViolation);
+    await prisma.registration.createMany({
+      data: participants.map((participant) => ({
+        eventId,
+        organiserId,
+        athleteName: athleteNameFromParticipant(participant),
+        athleteEmail: participant.em,
+        amountCents: 0,
+        platformFeeCents: 0,
+        feeStructure: event.feeStructure,
+        status: "CANCELLED" as const,
+        stripePaymentIntentId: paymentIntent.id,
+      })),
+    });
+    return;
+  }
 
   const participantNames = participants.map((p) => athleteNameFromParticipant(p));
   const notificationBody = participants.length === 1
-    ? `${participantNames[0]} registered for ${dbEvent?.title ?? "your event"}`
-    : `${participants.length} participants registered for ${dbEvent?.title ?? "your event"}: ${participantNames.join(", ")}`;
+    ? `${participantNames[0]} registered for ${event.title}`
+    : `${participants.length} participants registered for ${event.title}: ${participantNames.join(", ")}`;
 
   await prisma.notification.create({
     data: {
@@ -184,28 +289,28 @@ async function handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent)
     },
   }).catch((err: unknown) => console.error("Failed to create notification:", err));
 
-  if (dbEvent) {
-    // When the athlete absorbs the platform fee, the amount charged is
-    // price + fee — the email total must reflect that, not just the ticket
-    // price. When the organiser absorbs it, the athlete pays the ticket price
-    // only and the service fee shown to them is $0.
-    const athletePaysFee = (meta.feeStructure ?? "athlete") === "athlete";
-    for (const participant of participants) {
-      if (!participant.em) continue;
-      const ticketCents = priceOf(participant);
-      const feeCents = athletePaysFee ? feeOf(participant) : 0;
-      sendRegistrationConfirmationEmail(participant.em, {
-        eventName:        dbEvent.title,
-        eventDate:        dbEvent.eventDate,
-        startTime:        dbEvent.startTime,
-        category:         waveOf(participant) || meta.category || "General",
-        location:         `${dbEvent.venue}, ${dbEvent.city} ${dbEvent.state}`,
-        registrationFee:  formatCents(ticketCents),
-        serviceFee:       formatCents(feeCents),
-        total:            formatCents(ticketCents + feeCents),
-        userEmail:        participant.em,
-      }).catch((err) => console.error("Failed to send registration confirmation email:", err));
-    }
+  // When the athlete absorbs the platform fee, the amount charged is
+  // price + fee — the email total must reflect that, not just the ticket
+  // price. When the organiser absorbs it, the athlete pays the ticket price
+  // only and the service fee shown to them is $0.
+  const athletePaysFee = event.feeStructure === "athlete";
+  for (const participant of participants) {
+    if (!participant.em) continue;
+    const pricing = priceOf(participant);
+    if (!pricing) continue;
+    const ticketCents = pricing.priceCents;
+    const feeCents = athletePaysFee ? pricing.platformFeeCents : 0;
+    sendRegistrationConfirmationEmail(participant.em, {
+      eventName:        event.title,
+      eventDate:        event.eventDate,
+      startTime:        event.startTime,
+      category:         waveOf(participant) || meta.category || "General",
+      location:         `${event.venue}, ${event.city} ${event.state}`,
+      registrationFee:  formatCents(ticketCents),
+      serviceFee:       formatCents(feeCents),
+      total:            formatCents(ticketCents + feeCents),
+      userEmail:        participant.em,
+    }).catch((err) => console.error("Failed to send registration confirmation email:", err));
   }
 }
 

--- a/lib/amplify-server.ts
+++ b/lib/amplify-server.ts
@@ -59,8 +59,11 @@ async function verifyToken(token: string) {
 
 export async function getServerSession(): Promise<ServerSession | null> {
   const noCognito = !process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID;
-  const isBypass = noCognito && (process.env.NODE_ENV === "development" ||
-    process.env.NEXT_PUBLIC_AUTH_BYPASS === "true");
+  // Dev-only bypass: grants an admins session to every caller. Never honour in
+  // production even if the flag is set, or a missing pool ID makes the whole
+  // admin API public.
+  const isBypass = noCognito && process.env.NODE_ENV === "development" &&
+    process.env.NEXT_PUBLIC_AUTH_BYPASS === "true";
   if (isBypass) {
     return {
       sub: "dev-bypass-organiser",

--- a/lib/athlete-accounts.ts
+++ b/lib/athlete-accounts.ts
@@ -56,7 +56,9 @@ export async function getCognitoUserStatus(email: string): Promise<{ exists: boo
       UserPoolId: userPoolId,
       Username: normalized,
     }));
-    return { exists: true, status: result.UserStatus ?? null };
+    // Coarse status only — never leak the raw lifecycle (e.g.
+    // FORCE_CHANGE_PASSWORD / RESET_REQUIRED) to unauthenticated callers.
+    return { exists: true, status: result.UserStatus === "UNCONFIRMED" ? "UNCONFIRMED" : "CONFIRMED" };
   } catch (err) {
     if ((err as { name?: string }).name === "UserNotFoundException") {
       return { exists: false, status: null };

--- a/lib/stripe-webhook.ts
+++ b/lib/stripe-webhook.ts
@@ -33,12 +33,3 @@ export function parseParticipantsFromMetadata(meta: Stripe.Metadata): CompactPar
   return [];
 }
 
-/** Per-tier pricing map written by checkout: { [waveLabel]: { p: priceCents, f: feeCents } }. */
-export function parseWavePricing(meta: Stripe.Metadata): Record<string, { p: number; f: number }> {
-  if (!meta.wavePricing) return {};
-  try {
-    return JSON.parse(meta.wavePricing) as Record<string, { p: number; f: number }>;
-  } catch {
-    return {};
-  }
-}

--- a/middleware.ts
+++ b/middleware.ts
@@ -68,8 +68,8 @@ function isAdmin(payload: JWTPayload): boolean {
 }
 
 const noCognito = !process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID;
-const isBypass = noCognito && (process.env.NODE_ENV === "development" ||
-  process.env.NEXT_PUBLIC_AUTH_BYPASS === "true");
+const isBypass = noCognito && process.env.NODE_ENV === "development" &&
+  process.env.NEXT_PUBLIC_AUTH_BYPASS === "true";
 
 export async function middleware(req: NextRequest) {
   if (isBypass) return NextResponse.next();

--- a/src/__tests__/stripe-webhook.test.ts
+++ b/src/__tests__/stripe-webhook.test.ts
@@ -4,7 +4,7 @@ import { NextRequest } from "next/server";
 
 const mocks = vi.hoisted(() => ({
   constructEvent: vi.fn(),
-  registration: { count: vi.fn(), create: vi.fn(), createMany: vi.fn() },
+  registration: { count: vi.fn(), create: vi.fn(), createMany: vi.fn(), groupBy: vi.fn() },
   user: { upsert: vi.fn() },
   event: { findUnique: vi.fn() },
   notification: { create: vi.fn() },
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   sendEmail: vi.fn(),
   ensureCognitoUser: vi.fn(),
 }));
+
+const tx = { registration: mocks.registration };
 
 vi.mock("@/lib/stripe", () => ({
   getStripe: () => ({ webhooks: { constructEvent: mocks.constructEvent } }),
@@ -24,6 +26,7 @@ vi.mock("@/lib/prisma", () => ({
     event: mocks.event,
     notification: mocks.notification,
     organiser: mocks.organiser,
+    $transaction: async (cb: (t: typeof tx) => unknown) => cb(tx),
   },
 }));
 
@@ -36,18 +39,14 @@ vi.mock("@/lib/athlete-accounts", () => ({
 }));
 
 import { POST } from "@/app/api/stripe/webhook/route";
-import { parseParticipantsFromMetadata, parseWavePricing } from "@/lib/stripe-webhook";
+import { parseParticipantsFromMetadata } from "@/lib/stripe-webhook";
 
 const metadata = (overrides: Record<string, string>): Stripe.Metadata => ({
   eventId: "seed-event-001",
   organiserId: "org-1",
   waveLabel: "General",
-  wavePricing: JSON.stringify({ General: { p: 10000, f: 540 } }),
   userName: "Jordan Clarke",
   userEmail: "jordan@example.com",
-  ticketPriceCents: "10000",
-  platformFeeCents: "540",
-  platformFeeCentsPerTicket: "540",
   feeStructure: "athlete",
   ...overrides,
 });
@@ -65,11 +64,34 @@ async function post(payload: Record<string, unknown>): Promise<Response> {
   return POST(req);
 }
 
+// DB truth used by the webhook's server-side pricing/ownership checks. Price
+// $100.00 (10000 cents) + athlete fee (395 + 145 = 540) → charged 10540.
+const approvedEvent = {
+  id: "seed-event-001",
+  title: "Apex Throwdown",
+  status: "APPROVED",
+  registrationType: "startline",
+  feeStructure: "athlete",
+  waves: [{ label: "General", price: "100.00" }],
+  cap: null,
+  eventDate: "2026-08-15",
+  startTime: "07:30",
+  venue: "MSAC",
+  city: "Melbourne",
+  state: "vic",
+  organiserId: "org-1",
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.STRIPE_WEBHOOK_SECRET = "whsec_test_00000000000000000000000000000000";
   mocks.user.upsert.mockResolvedValue({ id: "user-1" });
   mocks.sendEmail.mockResolvedValue(undefined);
+  mocks.registration.count.mockResolvedValue(0);
+  mocks.registration.groupBy.mockResolvedValue([]);
+  mocks.registration.createMany.mockResolvedValue({ count: 1 });
+  mocks.registration.create.mockResolvedValue({});
+  mocks.event.findUnique.mockResolvedValue(approvedEvent);
 });
 
 describe("parseParticipantsFromMetadata", () => {
@@ -97,22 +119,6 @@ describe("parseParticipantsFromMetadata", () => {
   });
 });
 
-describe("parseWavePricing", () => {
-  it("parses a valid pricing map", () => {
-    expect(parseWavePricing({ wavePricing: JSON.stringify({ General: { p: 100, f: 5 } }) })).toEqual({
-      General: { p: 100, f: 5 },
-    });
-  });
-
-  it("returns an empty object for invalid JSON", () => {
-    expect(parseWavePricing({ wavePricing: "not-json" })).toEqual({});
-  });
-
-  it("returns an empty object when absent", () => {
-    expect(parseWavePricing({})).toEqual({});
-  });
-});
-
 describe("POST /api/stripe/webhook", () => {
   it("returns 400 when the signature is invalid", async () => {
     mocks.constructEvent.mockImplementation(() => {
@@ -134,6 +140,7 @@ describe("POST /api/stripe/webhook", () => {
   it("processes payment_intent.succeeded and creates registrations + notification", async () => {
     signedEvent({
       id: "pi_123",
+      amount_received: 10540,
       metadata: metadata({
         participantCount: "1",
         participant0: JSON.stringify({
@@ -141,12 +148,6 @@ describe("POST /api/stripe/webhook", () => {
           ecn: "Sam", ecp: "0400 000 000", wav: "General",
         }),
       }),
-    });
-    mocks.registration.count.mockResolvedValue(0);
-    mocks.registration.createMany.mockResolvedValue({ count: 1 });
-    mocks.event.findUnique.mockResolvedValue({
-      title: "Apex Throwdown", eventDate: "2026-08-15", startTime: "07:30",
-      venue: "MSAC", city: "Melbourne", state: "vic",
     });
     mocks.notification.create.mockResolvedValue({});
 
@@ -167,6 +168,63 @@ describe("POST /api/stripe/webhook", () => {
     expect(mocks.notification.create).toHaveBeenCalled();
   });
 
+  it("rejects a PaymentIntent whose amount does not match DB pricing", async () => {
+    signedEvent({
+      id: "pi_123",
+      amount_received: 100, // attacker underpaid
+      metadata: metadata({
+        participantCount: "1",
+        participant0: JSON.stringify({ fn: "Jordan", ln: "Clarke", em: "jordan@example.com", wav: "General" }),
+      }),
+    });
+
+    await post({ id: "pi_123" });
+    expect(mocks.registration.createMany).toHaveBeenCalledTimes(1);
+    const created = mocks.registration.createMany.mock.calls[0][0].data[0];
+    expect(created.status).toBe("CANCELLED");
+    expect(mocks.notification.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a PaymentIntent referencing an unknown or mismatched event", async () => {
+    mocks.event.findUnique.mockResolvedValue(null);
+    signedEvent({
+      id: "pi_123",
+      amount_received: 10540,
+      metadata: metadata({
+        participantCount: "1",
+        participant0: JSON.stringify({ fn: "Jordan", ln: "Clarke", em: "jordan@example.com", wav: "General" }),
+      }),
+    });
+
+    await post({ id: "pi_123" });
+    expect(mocks.registration.createMany).not.toHaveBeenCalled();
+    expect(mocks.notification.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses to confirm past the event capacity", async () => {
+    mocks.event.findUnique.mockResolvedValue({
+      ...approvedEvent,
+      cap: 1,
+      waves: [{ label: "General", price: "100.00", qty: 1 }],
+    });
+    mocks.registration.count.mockResolvedValueOnce(0).mockResolvedValue(1); // idempotency=0, capacity=1 already confirmed
+    mocks.registration.groupBy.mockResolvedValue([{ waveLabel: "General", _count: { _all: 1 } }]);
+    signedEvent({
+      id: "pi_123",
+      amount_received: 10540,
+      metadata: metadata({
+        participantCount: "1",
+        participant0: JSON.stringify({ fn: "Jordan", ln: "Clarke", em: "jordan@example.com", wav: "General" }),
+      }),
+    });
+
+    await post({ id: "pi_123" });
+    expect(mocks.registration.createMany).toHaveBeenCalledTimes(1);
+    const created = mocks.registration.createMany.mock.calls[0][0].data[0];
+    expect(created.status).toBe("CANCELLED");
+    expect(mocks.notification.create).not.toHaveBeenCalled();
+  });
+
   it("is idempotent — skips a PaymentIntent that was already processed", async () => {
     signedEvent({ id: "pi_123", metadata: metadata({}) });
     mocks.registration.count.mockResolvedValue(1);
@@ -178,9 +236,7 @@ describe("POST /api/stripe/webhook", () => {
 
   it("creates a CANCELLED registration when participant metadata is missing", async () => {
     // Metadata with no participant data and no legacy fields → parser returns [].
-    signedEvent({ id: "pi_123", metadata: { eventId: "seed-event-001", organiserId: "org-1" } });
-    mocks.registration.count.mockResolvedValue(0);
-    mocks.registration.create.mockResolvedValue({});
+    signedEvent({ id: "pi_123", amount_received: 10540, metadata: { eventId: "seed-event-001", organiserId: "org-1" } });
 
     await post({ id: "pi_123" });
     expect(mocks.registration.create).toHaveBeenCalledTimes(1);

--- a/src/__tests__/transfer-ownership.test.ts
+++ b/src/__tests__/transfer-ownership.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  getOrganiserSession: vi.fn(),
+  getUserSession: vi.fn(),
+  memberFindFirst: vi.fn(),
+  memberUpdate: vi.fn(),
+  transaction: vi.fn(),
+}));
+
+vi.mock("@/lib/amplify-server", () => ({
+  getOrganiserSession: mocks.getOrganiserSession,
+  getUserSession: mocks.getUserSession,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    organiserMember: {
+      findFirst: mocks.memberFindFirst,
+      update: mocks.memberUpdate,
+    },
+    $transaction: mocks.transaction,
+  },
+}));
+
+import { POST } from "@/app/api/organiser/members/[id]/transfer-ownership/route";
+
+function post(memberId = "member-1") {
+  const req = new NextRequest("http://localhost/api/organiser/members/member-1/transfer-ownership", {
+    method: "POST",
+  });
+  return POST(req, { params: Promise.resolve({ id: memberId }) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getOrganiserSession.mockResolvedValue({
+    sub: "org-1", email: "owner@example.com", status: "APPROVED", verified: true, role: "OWNER",
+  });
+  mocks.getUserSession.mockResolvedValue({ sub: "user-owner", email: "owner@example.com", name: "Owner" });
+  mocks.memberUpdate.mockImplementation((args: unknown) => args);
+  mocks.transaction.mockImplementation((ops: unknown[]) => Promise.resolve(ops));
+});
+
+describe("POST /api/organiser/members/[id]/transfer-ownership", () => {
+  it("demotes the caller's own membership, not the oldest owner", async () => {
+    mocks.memberFindFirst.mockImplementation(async ({ where }) => {
+      if (where.role === "OWNER") return null; // old buggy query must not run
+      if (where.userId) return { id: "caller-membership", role: "OWNER" };
+      return { id: "member-target", role: "MANAGER" };
+    });
+
+    await post();
+
+    expect(mocks.memberFindFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: { organiserId: "org-1", userId: "user-owner" },
+    }));
+    expect(mocks.memberFindFirst).not.toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ role: "OWNER" }),
+    }));
+
+    const [targetUpdate, callerUpdate] = mocks.transaction.mock.calls[0][0];
+    expect(targetUpdate).toMatchObject({ where: { id: "member-target" }, data: { role: "OWNER" } });
+    expect(callerUpdate).toMatchObject({ where: { id: "caller-membership" }, data: { role: "MANAGER" } });
+  });
+
+  it("rejects non-owners", async () => {
+    mocks.getOrganiserSession.mockResolvedValue({
+      sub: "org-1", email: "m@example.com", status: "APPROVED", verified: true, role: "MANAGER",
+    });
+
+    const res = await post();
+    expect(res.status).toBe(403);
+    expect(mocks.memberFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the target member is not in the caller's organiser", async () => {
+    mocks.memberFindFirst.mockResolvedValue(null);
+
+    const res = await post();
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Description

Audit of every `/api` route for broken authorization, verifying the logged-in user owns every row they read or write. Findings verified against the session helpers in `lib/amplify-server.ts` (Cognito JWT → `getUserSession`/`getOrganiserSession`/`getAdminSession`).

### Fixed (verified vulnerabilities)

1. **Event DELETE open to any member** — `app/api/organiser/events/[id]/route.ts` DELETE had no role check; any MANAGER could permanently delete any org event including live ones with registrations. Now OWNER-only.
2. **Ownership transfer demoted the wrong owner** — `transfer-ownership` demoted the *oldest* OWNER instead of the caller, so a co-owner could silently strip another owner's role. Now resolves and demotes the caller's own membership (by userId).
3. **MANAGER could rewrite legal identity** — `app/api/organiser/profile` PUT let any member change ABN / legalName / DOB / insuranceDeclared (payout and liability-bearing). Now OWNER-only for those fields.
4. **Stripe webhook trusted client-influenced PaymentIntent metadata** — prices, feeStructure, event and organiser came from metadata; a caller could create their own PaymentIntent with the publishable key, pay a token amount, and get a real CONFIRMED registration. The webhook now re-derives all pricing from DB `waves` and verifies `amount_received === expectedTotalCents` before confirming; rejects mismatched/unknown events.
5. **Capacity oversell at confirmation** — webhook confirmed registrations with no capacity check. Confirmation now runs inside a transaction that re-checks event cap and tier qty before inserting; over-capacity intents are recorded CANCELLED.
6. **Account-enumeration detail leak** — `/api/user/exists` returned the raw Cognito `UserStatus` (e.g. FORCE_CHANGE_PASSWORD) to unauthenticated callers. Now coarse CONFIRMED/UNCONFIRMED only.
7. **Dev auth bypass grantable in prod** — `NEXT_PUBLIC_AUTH_BYPASS` + missing pool ID granted an admins session to every caller regardless of `NODE_ENV`. Now development-only.

### RLS note (deliberate scope decision)

The task asked to "enable RLS on all tables with policies scoped to auth.uid()". This is a Supabase idiom. This app is Prisma + Cognito + Postgres: Prisma connects through a single application role, so per-user RLS policies can't be scoped to a Supabase-style `auth.uid()` (there is no such function), and per-user RLS would require per-connection session-variable plumbing Prisma doesn't support. Ownership enforcement here is at the application layer via verified-session Prisma queries, which is what this audit hardens. No RLS was added — flagging as a known deviation rather than faking a Supabase-ism.

### Checks

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 202 passed (added webhook security cases + transfer-ownership route tests)