### PR TITLE
chore(dev): isolated postgres database per git worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Next.js 15 (App Router) fitness event discovery platform. Three portals:
 - **Dev:** `pnpm dev` (Turbopack). **Build:** `pnpm build` (standalone `next.config.ts`). `@/*` → root.
 - **Docker:** PostgreSQL 15 on :5432 + Mailpit (SMTP :1025, UI :8026). Start: `docker compose up -d` on main checkout only.
 - **Worktree?** `git worktree list`. If worktree, Docker infra runs on main checkout — just `pnpm dev`, never `docker compose up`.
+- **Per-worktree DB:** run `./scripts/dev-db.sh` on first use of a new worktree (creates an isolated `startline_<branch>` DB, applies migrations, points `.env.local` at it). Then **always run `pnpm prisma:seed`** — skip only if you specifically need an empty DB.
 - **Env vars:** Loaded from `.env.local` (gitignored). See `.env.example` + `terraform/` for setup steps.
 
 ## Environment variables
@@ -117,6 +118,36 @@ Use `gh` CLI — **not** GitHub MCP (fails for this private org repo).
 **`main` and `prod` are protected.** Always PR, never push directly.
 
 PR conventions: scan open issues, link with `Closes #N`. Follow `.github/PULL_REQUEST_TEMPLATE.md`. CI runs are informational, non-blocking.
+
+### Issue fields (Priority / Effort)
+
+Issues use GitHub's Task-type custom fields (`Priority`, `Effort`). They are
+**not** labels and are **not** in `gh issue list/view --json` output (REST).
+Read them via GraphQL `issueFieldValues`:
+
+```bash
+gh api graphql -f query='query { repository(owner:"StartlineAU", name:"startline-web-app") { issues(states:OPEN, first:100){ nodes { number title milestone { title } issueFieldValues(first:20){ nodes { ... on IssueFieldSingleSelectValue { value field { ... on IssueFieldSingleSelect { name } } } } } } } } }'
+```
+
+`issueFieldValues` is a union of `IssueFieldSingleSelectValue` (has `name`/`value`/
+`field`), `IssueFieldTextValue`, `IssueFieldNumberValue`, `IssueFieldDateValue`,
+`IssueFieldMultiSelectValue` (all expose `value` + `field`). `field` is another
+union exposing `name` (e.g. `Priority`, `Effort`).
+
+**When creating a new issue, set `Priority` + `Effort` immediately** (they don't
+default). They're single-select fields; set via `setIssueFieldValue` with the
+field's `singleSelectOptionId`. Field/option IDs:
+
+```
+Priority:  IFSS_kgDOAnp8Qg   Urgent=IFSSO_kgDOBFZBjQ High=IFSSO_kgDOBFZBjg Medium=IFSSO_kgDOBFZBjw Low=IFSSO_kgDOBFZBkA
+Effort:    IFSS_kgDOAnp8RQ   High=IFSSO_kgDOBFZBkQ Medium=IFSSO_kgDOBFZBkg Low=IFSSO_kgDOBFZBkw
+```
+
+```bash
+gh api graphql -f query='mutation { setIssueFieldValue(input: { issueId: "ISSUE_NODE_ID", issueFields: [ { fieldId: "IFSS_kgDOAnp8Qg", singleSelectOptionId: "IFSSO_kgDOBFZBjg" }, { fieldId: "IFSS_kgDOAnp8RQ", singleSelectOptionId: "IFSSO_kgDOBFZBkg" } ] }) { issue { number } } }'
+```
+
+Get `issueId` (node ID) and re-verify all issues via the read query above.
 
 Configured in `opencode.json`: stripe, resend, aws, cloudflare.
 

--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# ponytail: one shared Postgres container, one database per worktree.
+# Migrations are tracked per-database, so worktrees never clobber each other's _prisma_migrations.
+set -euo pipefail
+
+BRANCH=$(git branch --show-current)
+SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '_' | sed 's/_\+/_/g; s/^_//; s/_$//')
+DB="startline_${SLUG:-main}"
+
+# ponytail: find postgres by container name, not compose project (worktree dirnames differ from main).
+PG=$(docker ps --format '{{.Names}}' | grep -E 'postgres' | head -1 || true)
+if [ -z "$PG" ]; then
+  echo "No postgres container running. Start infra on the main checkout:" >&2
+  echo "  docker compose up -d" >&2
+  exit 1
+fi
+
+if ! docker exec "$PG" psql -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$DB'" | grep -q 1; then
+  docker exec "$PG" createdb -U postgres "$DB"
+  echo "created database $DB"
+fi
+
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/$DB?schema=public"
+
+npx prisma migrate dev
+
+if grep -q '^DATABASE_URL=' .env.local 2>/dev/null; then
+  sed -i '' "s|^DATABASE_URL=.*|DATABASE_URL=$DATABASE_URL|" .env.local
+else
+  printf '\nDATABASE_URL=%s\n' "$DATABASE_URL" >> .env.local
+fi
+echo "worktree DB ready: $DB (not seeded — run 'pnpm prisma:seed' unless an empty DB is needed)"


### PR DESCRIPTION
## Description

Worktrees sharing the single `startline` Postgres database clobber each other's `_prisma_migrations` tracking when each runs `prisma migrate dev`.

Adds `scripts/dev-db.sh` — on first use of a worktree it:

- derives a `startline_<branch-slug>` database from the current branch
- creates it idempotently in the shared Postgres container (same :5432, no new containers/ports)
- applies migrations and points the worktree's `.env.local` DATABASE_URL at it

Seeding stays explicit: run `pnpm prisma:seed` per worktree (documented in AGENTS.md), skip only when an empty DB is needed.

Migrations are tracked per-database, so worktree `migrate dev` can reset freely without affecting siblings. Note: git-merge conflicts between branches that both add `prisma/migrations/<timestamp>` dirs are inherent and out of scope.

No open issue; raised directly.