### PR TITLE
test: re-enable 9 flaky e2e tests and fix their races

### DIFF
--- a/e2e/admin-full-control.spec.ts
+++ b/e2e/admin-full-control.spec.ts
@@ -188,34 +188,39 @@ test.describe("admin event editing", () => {
 });
 
 test.describe("admin user editing", () => {
-  // TODO: flaky — refetch can return stale list after save. See issue #227.
-  // test("can edit a user's name and see the update in the list", async ({ page }) => {
-  //   await adminLogin(page);
-  //   const newName = `E2E Updated User ${ts()}`;
-  //
-  //   await page.goto("/admin/users");
-  //   await page.waitForLoadState("networkidle");
-  //
-  //   await page.getByPlaceholder(/search by name, email, or username/i).fill("harper.jones@startline.test");
-  //   await page.getByRole("button", { name: /search/i }).click();
-  //
-  //   await page.getByRole("button", { name: /edit/i }).first().click();
-  //   await expect(page.getByText("Edit user")).toBeVisible();
-  //
-  //   await page.getByPlaceholder("Full name").fill(newName);
-  //
-  //   await page.getByRole("button", { name: /save changes/i }).click();
-  //
-  //   await expect(page.getByText("Edit user")).not.toBeVisible({ timeout: 10000 });
-  //   await expect(page.getByText(newName, { exact: false })).toBeVisible({ timeout: 15000 });
-  //
-  //   // Audit log records the edit.
-  //   const auditRes = await page.request.get("/api/admin/audit?action=EDIT_USER&limit=50");
-  //   const audit = await auditRes.json();
-  //   const logs = Array.isArray(audit.logs) ? audit.logs : [];
-  //   expect(
-  //     logs.some((l: { meta: { fields?: string[] } | null }) =>
-  //       Array.isArray(l.meta?.fields) && l.meta!.fields!.includes("name")),
-  //   ).toBeTruthy();
-  // });
+  test("can edit a user's name and see the update in the list", async ({ page }) => {
+    await adminLogin(page);
+    const newName = `E2E Updated User ${ts()}`;
+
+    await page.goto("/admin/users");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByPlaceholder(/search by name, email, or username/i).fill("harper.jones@startline.test");
+    await page.getByRole("button", { name: /search/i }).click();
+
+    // The list refetches on search — wait until it collapses to the single
+    // match before grabbing an Edit button, or the click can hit a stale row.
+    await expect(page.getByRole("button", { name: /edit/i })).toHaveCount(1, { timeout: 15000 });
+
+    await page.getByRole("button", { name: /edit/i }).first().click();
+    await expect(page.getByText("Edit user")).toBeVisible();
+
+    await page.getByPlaceholder("Full name").fill(newName);
+
+    await page.getByRole("button", { name: /save changes/i }).click();
+
+    // Await the dialog closing, then assert on the refetched list with a
+    // retrying expectation rather than racing a waitForResponse.
+    await expect(page.getByText("Edit user")).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(newName, { exact: false })).toBeVisible({ timeout: 15000 });
+
+    // Audit log records the edit.
+    const auditRes = await page.request.get("/api/admin/audit?action=EDIT_USER&limit=50");
+    const audit = await auditRes.json();
+    const logs = Array.isArray(audit.logs) ? audit.logs : [];
+    expect(
+      logs.some((l: { meta: { fields?: string[] } | null }) =>
+        Array.isArray(l.meta?.fields) && l.meta!.fields!.includes("name")),
+    ).toBeTruthy();
+  });
 });

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -236,14 +236,15 @@ test.describe("admin registrations page", () => {
 });
 
 test.describe("admin reviews page", () => {
-  // TODO: flaky — argos snapshot under parallel load. See issue #227.
-  // test("reviews page visual snapshot", async ({ page }) => {
-  //
-  //   await adminLogin(page);
-  //   await page.goto("/admin/reviews");
-  //   await page.waitForLoadState("networkidle");
-  //   await argosScreenshot(page, "admin-reviews");
-  // });
+  test("reviews page visual snapshot", async ({ page }) => {
+
+    await adminLogin(page);
+    await page.goto("/admin/reviews");
+    await page.waitForLoadState("networkidle");
+    // Wait for the client-side reviews fetch to settle (skeleton → rows/empty).
+    await expect(page.getByRole("status", { name: "Loading" })).toHaveCount(0, { timeout: 15000 });
+    await argosScreenshot(page, "admin-reviews");
+  });
 });
 
 test.describe("admin users page", () => {

--- a/e2e/distance-search.spec.ts
+++ b/e2e/distance-search.spec.ts
@@ -15,35 +15,36 @@ async function searchWhere(page: Page, query: string) {
 }
 
 test.describe("distance-based search", () => {
-  // TODO: flaky — geocoding timing under parallel load. See issue #227.
-  // test("geocoding a valid suburb sorts events closest-first and shows distance badges", async ({ page }) => {
-  //   await stubGeocode(page, SYDNEY);
-  //   await page.goto("/events?view=list");
-  //   await page.waitForLoadState("networkidle");
-  //
-  //   await searchWhere(page, "Sydney");
-  //
-  //   // Distance badges appear once geocoding succeeds.
-  //   await expect(page.locator('[data-testid="event-distance"]').first()).toBeVisible({ timeout: 10000 });
-  //
-  //   // Sydney events are all near the origin — badges read like "0km away".
-  //   const badges = page.locator('[data-testid="event-distance"]');
-  //   const texts = await badges.allTextContents();
-  //   expect(texts.length).toBeGreaterThan(0);
-  //   expect(texts.every((t) => /^[\d.]+km away$/.test(t))).toBe(true);
-  // });
+  test("geocoding a valid suburb sorts events closest-first and shows distance badges", async ({ page }) => {
+    await stubGeocode(page, SYDNEY);
+    await page.goto("/events?view=list");
+    await expect(page.getByPlaceholder("State, city, or suburb")).toBeVisible();
 
-  // TODO: flaky — geocoding timing under parallel load. See issue #227.
-  // test("loading state shows a spinner while geocoding", async ({ page }) => {
-  //   await stubGeocode(page, SYDNEY, 1500);
-  //   await page.goto("/events?view=list");
-  //   await page.waitForLoadState("networkidle");
-  //
-  //   await searchWhere(page, "Sydney");
-  //
-  //   await expect(page.locator('[data-testid="geocoding-spinner"]').first()).toBeVisible({ timeout: 3000 });
-  //   await expect(page.locator('[data-testid="event-distance"]').first()).toBeVisible({ timeout: 10000 });
-  // });
+    await searchWhere(page, "Sydney");
+
+    // Distance badges appear once geocoding succeeds.
+    await expect(page.locator('[data-testid="event-distance"]').first()).toBeVisible({ timeout: 10000 });
+
+    // Sydney events are all near the origin — badges read like "0km away".
+    // Poll the settled list instead of snapshotting allTextContents mid-render.
+    await expect
+      .poll(async () => {
+        const texts = await page.locator('[data-testid="event-distance"]').allTextContents();
+        return texts.length > 0 && texts.every((t) => /^[\d.]+km away$/.test(t));
+      }, { timeout: 10000 })
+      .toBe(true);
+  });
+
+  test("loading state shows a spinner while geocoding", async ({ page }) => {
+    await stubGeocode(page, SYDNEY, 1500);
+    await page.goto("/events?view=list");
+    await expect(page.getByPlaceholder("State, city, or suburb")).toBeVisible();
+
+    await searchWhere(page, "Sydney");
+
+    await expect(page.locator('[data-testid="geocoding-spinner"]').first()).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="event-distance"]').first()).toBeVisible({ timeout: 10000 });
+  });
 
   test("falls back to substring matching when geocoding fails", async ({ page }) => {
     await stubGeocode(page, null);

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 export async function goToHomepage(page: Page): Promise<void> {
   await page.goto("/");
@@ -44,4 +44,23 @@ export async function adminLogin(page: Page, _email = "marcus.stirling@startline
   ]);
   await page.goto("/admin/dashboard");
   await page.waitForURL("**/admin/dashboard**", { timeout: 15000 });
+}
+
+// Resets a seeded registration on seed-event-001 back to a known state so
+// tests that mutate shared seed rows stay idempotent across runs/retries.
+// Uses the organiser API so the bypass cookie covers auth.
+export async function resetRegistration(
+  page: Page,
+  athleteName: string,
+  patch: Record<string, string | null>,
+): Promise<void> {
+  const res = await page.request.get("/api/organiser/events/seed-event-001/registrations");
+  expect(res.ok()).toBeTruthy();
+  const { registrations } = await res.json();
+  const reg = registrations.find((r: { name: string }) => r.name === athleteName);
+  expect(reg, `expected a seeded registration for ${athleteName}`).toBeTruthy();
+  const patchRes = await page.request.patch("/api/organiser/events/seed-event-001/registrations", {
+    data: { registrations: [{ registrationId: reg.id, ...patch }] },
+  });
+  expect(patchRes.ok()).toBeTruthy();
 }

--- a/e2e/new-listing.spec.ts
+++ b/e2e/new-listing.spec.ts
@@ -189,31 +189,30 @@ test.describe("new listing wizard", () => {
     await expect(price).toHaveValue("12.50");
   });
 
-  // TODO: flaky — save outcome race under parallel load. See issue #227.
-  // test("draft without a cut-off time saves without a silent failure", async ({ page }) => {
-  //   await organiserLogin(page);
-  //   await page.goto("/organiser/new-listing");
-  //   await page.waitForLoadState("networkidle");
-  //
-  //   // Minimal draft: title only, endTime left empty (it's optional).
-  //   // Regression: the API used to coerce empty endTime to null, which the
-  //   // required schema column rejected — every such save 500ed.
-  //   await page.getByPlaceholder(/Apex Throwdown/i).fill("E2E No Cutoff Draft");
-  //   await page.getByRole("button", { name: /save draft/i }).click();
-  //
-  //   // Success navigates to the dashboard; if the test env lacks an organiser
-  //   // profile the API errors instead — either way the user must see an
-  //   // outcome, never stay stuck on a silently-failed save.
-  //   const errorBanner = page.getByText(/unauthorised|failed to save|went wrong/i).first();
-  //   await expect
-  //     .poll(
-  //       async () =>
-  //         page.url().includes("/organiser/dashboard") ||
-  //         (await errorBanner.isVisible().catch(() => false)),
-  //       { timeout: 20000 },
-  //     )
-  //     .toBe(true);
-  // });
+  test("draft without a cut-off time saves without a silent failure", async ({ page }) => {
+    await organiserLogin(page);
+    await page.goto("/organiser/new-listing");
+    await page.waitForLoadState("networkidle");
+
+    // Minimal draft: title only, endTime left empty (it's optional).
+    // Regression: the API used to coerce empty endTime to null, which the
+    // required schema column rejected — every such save 500ed.
+    await page.getByPlaceholder(/Apex Throwdown/i).fill("E2E No Cutoff Draft");
+    await page.getByRole("button", { name: /save draft/i }).click();
+
+    // Success navigates to the dashboard; if the test env lacks an organiser
+    // profile the API errors instead — either way the user must see an
+    // outcome, never stay stuck on a silently-failed save.
+    const errorBanner = page.getByText(/unauthorised|failed to save|went wrong/i).first();
+    await expect
+      .poll(
+        async () =>
+          page.url().includes("/organiser/dashboard") ||
+          (await errorBanner.isVisible().catch(() => false)),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+  });
 
   test("shows validation errors on empty submit", async ({ page }) => {
     await organiserLogin(page);

--- a/e2e/organiser.spec.ts
+++ b/e2e/organiser.spec.ts
@@ -62,31 +62,33 @@ test.describe("new listing wizard", () => {
     await argosScreenshot(page, "new-listing-step3");
   });
 
-  // TODO: flaky — wizard timing under parallel load. See issue #227.
-  // test("new listing step 4 visual snapshot", async ({ page }) => {
-  //
-  //   await organiserLogin(page);
-  //   await page.goto("/organiser/new-listing");
-  //   await page.waitForLoadState("networkidle");
-  //   await page.getByPlaceholder(/Apex Throwdown/i).fill("E2E Visual Test Event");
-  //   await page.getByRole("button", { name: /continue/i }).click();
-  //   await page.waitForTimeout(500);
-  //   await page.getByText("Pick start date").click();
-  //   await page.getByRole("button", { name: /today/i }).click();
-  //   const timeInputs4 = page.locator('input[type="time"]');
-  //   await timeInputs4.first().fill("09:00");
-  //   const addrInput4 = page.getByPlaceholder(/start typing an address/i);
-  //   await addrInput4.fill("1 Test St, Sydney NSW 2000");
-  //   await page.getByRole("button", { name: /continue/i }).click();
-  //   await page.waitForTimeout(500);
-  //   await page.getByRole("button", { name: /startline/i }).first().click();
-  //   const price4 = page.locator('input[placeholder="129"]');
-  //   if (await price4.isVisible()) await price4.fill("50");
-  //   await page.getByRole("button", { name: /no refunds/i }).click();
-  //   await page.getByRole("button", { name: /continue/i }).click();
-  //   await page.waitForTimeout(500);
-  //   await argosScreenshot(page, "new-listing-step4");
-  // });
+  test("new listing step 4 visual snapshot", async ({ page }) => {
+
+    await organiserLogin(page);
+    await page.goto("/organiser/new-listing");
+    await page.waitForLoadState("networkidle");
+    await page.getByPlaceholder(/Apex Throwdown/i).fill("E2E Visual Test Event");
+    await page.getByRole("button", { name: /continue/i }).click();
+    await page.waitForTimeout(500);
+    await page.getByText("Pick start date").click();
+    await page.getByRole("button", { name: /today/i }).click();
+    const timeInputs4 = page.locator('input[type="time"]');
+    await timeInputs4.first().fill("09:00");
+    const addrInput4 = page.getByPlaceholder(/start typing an address/i);
+    await addrInput4.fill("1 Test St, Sydney NSW 2000");
+    await page.getByRole("button", { name: /continue/i }).click();
+    await page.waitForTimeout(500);
+    await page.getByRole("button", { name: /startline/i }).first().click();
+    const price4 = page.locator('input[placeholder="129"]');
+    if (await price4.isVisible()) await price4.fill("50");
+    await page.getByRole("button", { name: /no refunds/i }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+    // Step 4 only renders after the tickets step settles — wait on the UI
+    // state instead of a fixed timeout so the screenshot is never of a
+    // half-transitioned wizard.
+    await expect(page.getByText(/cover image/i).first()).toBeVisible({ timeout: 15000 });
+    await argosScreenshot(page, "new-listing-step4");
+  });
 
   test("new listing final review visual snapshot", async ({ page }) => {
 

--- a/e2e/race-management.spec.ts
+++ b/e2e/race-management.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { organiserLogin } from "./helpers";
+import { organiserLogin, resetRegistration } from "./helpers";
 
 const EVENT_ID = "seed-event-001";
 const DASHBOARD = `/organiser/events/${EVENT_ID}/dashboard`;
@@ -35,25 +35,26 @@ test.describe("race management", () => {
     await expect(page.getByText("Bree Collins")).toHaveCount(0);
   });
 
-  // TODO: flaky — mutates shared seeded athlete wave state. See issue #227.
-  // test("moves an athlete into a wave in bulk", async ({ page }) => {
-  //   await organiserLogin(page);
-  //   await page.goto(MANAGE);
-  //   await page.waitForLoadState("networkidle");
-  //
-  //   // Oscar starts with no wave (in the Unassigned group). Select and move him.
-  //   await page.getByRole("checkbox", { name: /select oscar de luca/i }).click();
-  //   await page.getByLabel(/destination wave/i).click();
-  //   await page.getByRole("option", { name: "Wave A" }).click();
-  //   await page.getByRole("button", { name: /^move$/i }).click();
-  //
-  //   // The board reports the move; find him again and confirm his wave followed.
-  //   await expect(page.getByText(/moved 1 athlete to wave a/i)).toBeVisible();
-  //   await page.getByPlaceholder(/search any wave/i).fill("Oscar De Luca");
-  //   await expect(page.getByText("Oscar De Luca")).toBeVisible();
-  //   // exact avoids also matching the "Moved 1 athlete to Wave A." status line.
-  //   await expect(page.getByText("Wave A", { exact: true })).toBeVisible();
-  // });
+  test("moves an athlete into a wave in bulk", async ({ page }) => {
+    await organiserLogin(page);
+    // Restore the seeded state: Oscar is unassigned until this test moves him.
+    await resetRegistration(page, "Oscar De Luca", { startWaveId: null });
+    await page.goto(MANAGE);
+    await page.waitForLoadState("networkidle");
+
+    // Oscar starts with no wave (in the Unassigned group). Select and move him.
+    await page.getByRole("checkbox", { name: /select oscar de luca/i }).click();
+    await page.getByLabel(/destination wave/i).click();
+    await page.getByRole("option", { name: "Wave A" }).click();
+    await page.getByRole("button", { name: /^move$/i }).click();
+
+    // The board reports the move; find him again and confirm his wave followed.
+    await expect(page.getByText(/moved 1 athlete to wave a/i)).toBeVisible();
+    await page.getByPlaceholder(/search any wave/i).fill("Oscar De Luca");
+    await expect(page.getByText("Oscar De Luca")).toBeVisible();
+    // exact avoids also matching the "Moved 1 athlete to Wave A." status line.
+    await expect(page.getByText("Wave A", { exact: true })).toBeVisible();
+  });
 
   test("drags an athlete into another wave", async ({ page }) => {
     await organiserLogin(page);
@@ -395,32 +396,33 @@ test.describe("race management", () => {
     ).toBeVisible();
   });
 
-  // TODO: flaky — mutates shared seeded registration state across runs. See issue #227.
-  // test("a refund-requested athlete moves to the Refunds tab and leaves the board", async ({ page }) => {
-  //   await organiserLogin(page);
-  //   await page.goto(MANAGE);
-  //   await page.waitForLoadState("networkidle");
-  //
-  //   // Flag a confirmed athlete as refund-requested via the board edit dialog.
-  //   await page.getByPlaceholder(/search any wave/i).fill("Cameron Nguyen");
-  //   await page.getByRole("button", { name: /edit cameron nguyen/i }).click();
-  //   const editDialog = page.getByRole("dialog");
-  //   await editDialog.getByLabel(/^status$/i).click();
-  //   await editDialog.getByRole("option", { name: /refund requested/i }).click();
-  //   await editDialog.getByRole("button", { name: /^save$/i }).click();
-  //   await expect(page.getByRole("dialog")).toHaveCount(0);
-  //
-  //   // Shows up under Refunds with the right status...
-  //   await page.getByRole("button", { name: /refunds/i }).click();
-  //   const refundRow = page.locator("tr", { hasText: "Cameron Nguyen" });
-  //   await expect(refundRow).toBeVisible();
-  //   await expect(refundRow.getByText(/refund requested/i)).toBeVisible();
-  //
-  //   // ...and is no longer in the allocation board, which only holds confirmed athletes.
-  //   await page.getByRole("button", { name: /before race/i }).click();
-  //   await page.getByPlaceholder(/search any wave/i).fill("Cameron Nguyen");
-  //   await expect(page.getByText("Cameron Nguyen")).toHaveCount(0);
-  // });
+  test("a refund-requested athlete moves to the Refunds tab and leaves the board", async ({ page }) => {
+    await organiserLogin(page);
+    // Restore the seeded state: Cameron is CONFIRMED until this test flags him.
+    await resetRegistration(page, "Cameron Nguyen", { status: "CONFIRMED" });
+    await page.goto(MANAGE);
+    await page.waitForLoadState("networkidle");
+
+    // Flag a confirmed athlete as refund-requested via the board edit dialog.
+    await page.getByPlaceholder(/search any wave/i).fill("Cameron Nguyen");
+    await page.getByRole("button", { name: /edit cameron nguyen/i }).click();
+    const editDialog = page.getByRole("dialog");
+    await editDialog.getByLabel(/^status$/i).click();
+    await editDialog.getByRole("option", { name: /refund requested/i }).click();
+    await editDialog.getByRole("button", { name: /^save$/i }).click();
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+
+    // Shows up under Refunds with the right status...
+    await page.getByRole("button", { name: /refunds/i }).click();
+    const refundRow = page.locator("tr", { hasText: "Cameron Nguyen" });
+    await expect(refundRow).toBeVisible();
+    await expect(refundRow.getByText(/refund requested/i)).toBeVisible();
+
+    // ...and is no longer in the allocation board, which only holds confirmed athletes.
+    await page.getByRole("button", { name: /before race/i }).click();
+    await page.getByPlaceholder(/search any wave/i).fill("Cameron Nguyen");
+    await expect(page.getByText("Cameron Nguyen")).toHaveCount(0);
+  });
 });
 
 test.describe("athlete refund requests", () => {

--- a/e2e/user-profile.spec.ts
+++ b/e2e/user-profile.spec.ts
@@ -84,24 +84,34 @@ test.describe("user profile: race history", () => {
     await expect(page.getByText("#testing").last()).toBeVisible();
   });
 
-  // TODO: flaky — save/activity refetch race under parallel load. See issue #227.
-  // test("saving an event from the listing appears on the activity Saved tab", async ({ page }) => {
-  //   await page.goto("/events");
-  //   await page.waitForLoadState("networkidle");
-  //
-  //   // The first matching save button may live in a hidden list container —
-  //   // target a visible one instead.
-  //   const saveButtons = page.locator('[aria-label="Save event"]:visible');
-  //   await expect(saveButtons.first()).toBeVisible();
-  //   await saveButtons.first().click();
-  //   await expect(page.getByRole("button", { name: /unsave event/i }).first()).toBeVisible();
-  //
-  //   await page.goto("/activity");
-  //   await page.waitForLoadState("networkidle");
-  //
-  //   await page.getByRole("button", { name: /saved/i }).click();
-  //   await expect(page.getByText("Saved", { exact: false }).first()).toBeVisible();
-  // });
+  test("saving an event from the listing appears on the activity Saved tab", async ({ page }) => {
+    // Take the event from the rendered listing itself (not /api/events, which
+    // can include dates the listing filters out) so the card is guaranteed to
+    // exist before we click its save button.
+    await page.goto("/events?view=list");
+    const card = page.locator('a[href^="/events/"]').first();
+    await expect(card).toBeVisible({ timeout: 15000 });
+    const eventId = (await card.getAttribute("href"))!.split("/").pop()!;
+    const title = await card.locator("h3").innerText();
+
+    // Idempotent across runs: start with this event unsaved, then reload so
+    // the heart reflects the fresh saved-state.
+    await page.request.delete("/api/user/saved-events", { data: { eventId } });
+    await page.reload();
+    await expect(card).toBeVisible({ timeout: 15000 });
+
+    await card.locator('[aria-label="Save event"]').click();
+    await expect(card.locator('[aria-label="Unsave event"]')).toBeVisible();
+
+    await page.goto("/activity");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: /saved/i }).click();
+    await expect(page.getByText(title, { exact: false }).first()).toBeVisible({ timeout: 15000 });
+
+    // Cleanup — leave the DB saved-free for the next run.
+    await page.request.delete("/api/user/saved-events", { data: { eventId } });
+  });
 
   test("Following tab lists followed organisers and can unfollow", async ({ page }) => {
     // Re-follow Coastal so the test is deterministic even if a prior run


### PR DESCRIPTION
## Description

Closes #227. Re-enables the nine e2e tests disabled in PR #220 (commit `9cfc64e`) and fixes the underlying DB-state and timing races so the full suite passes reliably under the shared Turbopack dev server + 2-worker parallel load.

**Verification:** full `pnpm test:e2e` suite is green — 164 passed, 0 failed, 0 flaky, 4 expected skips (Cognito signup ×2, Stripe webhook in CI, one conditional refund). Re-enabled tests also passed two consecutive targeted runs.

## Changes

**New helper** — `e2e/helpers.ts:resetRegistration()`: resets a seeded `seed-event-001` registration (wave/status/bib) via the organiser PATCH API so DB-mutating tests are idempotent across runs and retries.

| Test | Fix |
|---|---|
| `admin-full-control` "edit user's name" | Root cause was clicking an Edit button from the **stale unfiltered list** before the search refetch collapsed rows (it edited the wrong user). Wait for the list to collapse to one row (`Edit` button count = 1) before clicking; assert with retrying `toBeVisible` instead of `waitForResponse`. |
| `race-management` "moves athlete into a wave in bulk" | Reset Oscar De Luca to unassigned at test start (`resetRegistration`). |
| `race-management` "refund-requested athlete → Refunds" | Reset Cameron Nguyen to `CONFIRMED` at test start. |
| `distance-search` "sorts closest-first" + "spinner" | Replace `networkidle` with an explicit wait on the search input; assert the settled badge list via `expect.poll` instead of one-shot `allTextContents()`. |
| `user-profile` "saving an event → Saved tab" | Take the event card from the rendered listing (not `/api/events`, which can return dates the listing filters out → card never renders). Unsave-first + reload for idempotency; assert the specific event title on the activity page. |
| `admin` "reviews page snapshot" | Wait for the reviews client-fetch to settle (skeleton `role="status"` gone) before `argosScreenshot`. |
| `organiser` "step 4 snapshot" | Wait for step 4 content (`cover image`) instead of a fixed `waitForTimeout`. |
| `new-listing` "draft without cut-off time" | App-side regression already fixed (`endTime || ""`); re-enable with a longer outcome poll. |

## Testing

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 213 passed
- `pnpm test:e2e` — 164 passed, 0 failed, 0 flaky, 4 skipped