### PR TITLE
feat: use event name slug in URLs instead of ID

### DIFF
--- a/app/(user)/events/[id]/page.tsx
+++ b/app/(user)/events/[id]/page.tsx
@@ -32,7 +32,9 @@ export const revalidate = 60;
 export async function generateStaticParams() {
   try {
     const events = await getAllEvents();
-    return events.map((e: { id: string }) => ({ id: e.id }));
+    return events.flatMap((e: { id: string; slug: string | null }) =>
+      e.slug ? [{ id: e.id }, { id: e.slug }] : [{ id: e.id }],
+    );
   } catch {
     return [];
   }
@@ -52,7 +54,7 @@ export async function generateMetadata({
     found.description?.replace(/<[^>]+>/g, "").slice(0, 160) ||
     `${found.title} — ${found.city}, ${found.state.toUpperCase()}`;
   const image = found.coverImageUrl || undefined;
-  const url = `${process.env.NEXT_PUBLIC_SITE_URL ?? "https://startlineau.com"}/events/${id}`;
+  const url = `${process.env.NEXT_PUBLIC_SITE_URL ?? "https://startlineau.com"}/events/${found.slug ?? id}`;
 
   return {
     title,
@@ -262,7 +264,7 @@ export default async function EventDetailPage({ params }: { params: Promise<{ id
                 </div>
                 <div className="w-px h-5 bg-dark-lighter" />
                 <div className="flex items-center gap-2">
-                  <ShareEventButton eventId={event.id} title={event.title} />
+                  <ShareEventButton eventId={event.id} slug={event.slug} title={event.title} />
                   <span className="font-headline text-xs font-bold uppercase tracking-widest text-muted">Share</span>
                 </div>
               </div>

--- a/app/api/admin/events/route.ts
+++ b/app/api/admin/events/route.ts
@@ -4,6 +4,7 @@ import { getAdminSession } from "@/lib/amplify-server";
 import { getEventCoords } from "@/lib/australia-coords";
 import { writeAuditLog } from "@/lib/audit";
 import { adminEventPayloadSchema, eventPayloadSchema } from "@/lib/schemas";
+import { uniqueSlug } from "@/lib/slugs";
 import { z } from "zod";
 
 const VALID_STATUSES = ["DRAFT", "PENDING", "APPROVED", "REJECTED", "ARCHIVED"] as const;
@@ -125,6 +126,7 @@ export async function POST(req: NextRequest) {
       data: {
         organiserId:      organiserId,
         status:           eventStatus,
+        slug:             await uniqueSlug(body.title ?? ""),
         title:            body.title ?? "",
         discipline:       body.discipline        ?? "",
         description:      body.description       ?? null,

--- a/app/api/organiser/events/[id]/duplicate/route.ts
+++ b/app/api/organiser/events/[id]/duplicate/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { getOrganiserSession } from "@/lib/amplify-server";
 import { shiftIsoDate } from "@/lib/duplicate-event";
 import { idParams } from "@/lib/schemas";
+import { uniqueSlug } from "@/lib/slugs";
 
 /** POST /api/organiser/events/[id]/duplicate — copy listing fields into a new DRAFT (+7 days). */
 export async function POST(
@@ -30,6 +31,7 @@ export async function POST(
       data: {
         organiserId: source.organiserId,
         status: "DRAFT",
+        slug: await uniqueSlug(source.title),
         title: source.title,
         discipline: source.discipline,
         description: source.description,

--- a/app/api/organiser/events/[id]/route.ts
+++ b/app/api/organiser/events/[id]/route.ts
@@ -4,6 +4,7 @@ import { getOrganiserSession } from "@/lib/amplify-server";
 import { getEventCoords } from "@/lib/australia-coords";
 import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
 import { eventPayloadSchema, idParams } from "@/lib/schemas";
+import { uniqueSlug } from "@/lib/slugs";
 
 export async function GET(
   _req: NextRequest,
@@ -50,7 +51,7 @@ export async function PATCH(
   try {
     const existing = await prisma.event.findUnique({
       where:  { id },
-      select: { organiserId: true, status: true },
+      select: { organiserId: true, status: true, title: true },
     });
 
     if (!existing)
@@ -88,9 +89,14 @@ export async function PATCH(
       ? (session.verified ? "APPROVED" : "PENDING")
       : "DRAFT";
 
+    const slug = data.title !== undefined && data.title !== existing.title
+      ? await uniqueSlug(data.title, id)
+      : undefined;
+
     const updated = await prisma.event.update({
       where: { id },
       data: {
+        slug:              slug,
         title:             data.title             ?? undefined,
         discipline:        data.discipline        ?? undefined,
         description:       data.description       ?? undefined,

--- a/app/api/organiser/events/route.ts
+++ b/app/api/organiser/events/route.ts
@@ -6,6 +6,7 @@ import { getEventCoords } from "@/lib/australia-coords";
 import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
 import { eventPayloadSchema } from "@/lib/schemas";
 import { rateLimit } from "@/lib/rate-limit";
+import { uniqueSlug } from "@/lib/slugs";
 export async function GET() {
   await archivePastEvents();
   const session = await getOrganiserSession();
@@ -91,6 +92,7 @@ export async function POST(req: NextRequest) {
       data: {
         organiserId:      session.sub,
         status:           eventStatus,
+        slug:             await uniqueSlug(body.title ?? ""),
         title:            body.title ?? "",
         discipline:       body.discipline        ?? "",
         description:      body.description       ?? null,

--- a/components/ShareEventButton.tsx
+++ b/components/ShareEventButton.tsx
@@ -7,21 +7,23 @@ import { cn } from "@/lib/utils";
 
 interface ShareEventButtonProps {
   eventId: string;
+  slug?: string;
   title: string;
   className?: string;
 }
 
-function eventUrl(eventId: string) {
-  if (typeof window === "undefined") return `/events/${eventId}`;
-  return `${window.location.origin}/events/${eventId}`;
+function eventUrl(eventId: string, slug?: string) {
+  const path = `/events/${slug ?? eventId}`;
+  if (typeof window === "undefined") return path;
+  return `${window.location.origin}${path}`;
 }
 
-export default function ShareEventButton({ eventId, title, className = "" }: ShareEventButtonProps) {
+export default function ShareEventButton({ eventId, slug, title, className = "" }: ShareEventButtonProps) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
 
   async function copyLink() {
-    const url = eventUrl(eventId);
+    const url = eventUrl(eventId, slug);
     try {
       await navigator.clipboard.writeText(url);
       setCopied(true);
@@ -44,7 +46,7 @@ export default function ShareEventButton({ eventId, title, className = "" }: Sha
   }
 
   async function nativeShare() {
-    const url = eventUrl(eventId);
+    const url = eventUrl(eventId, slug);
     // Prefer the explicit menu in desktop browsers so Copy link is always available.
     if (navigator.share && /Android|iPhone|iPad|Mobile/i.test(navigator.userAgent)) {
       try {
@@ -58,7 +60,7 @@ export default function ShareEventButton({ eventId, title, className = "" }: Sha
     toggleMenu();
   }
 
-  const url = typeof window !== "undefined" ? eventUrl(eventId) : `/events/${eventId}`;
+  const url = typeof window !== "undefined" ? eventUrl(eventId, slug) : `/events/${slug ?? eventId}`;
   const encodedUrl = encodeURIComponent(url);
   const encodedTitle = encodeURIComponent(title);
 

--- a/e2e/events.spec.ts
+++ b/e2e/events.spec.ts
@@ -68,7 +68,7 @@ test.describe("event detail page", () => {
     await expect(page.getByRole("link", { name: /view all on organiser profile/i })).toBeVisible();
   });
 
-  test("share control copies a clean event URL", async ({ page, context }) => {
+  test("share control copies a clean slug URL", async ({ page, context }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     await page.goto("/events/seed-event-001");
@@ -78,8 +78,18 @@ test.describe("event detail page", () => {
     await page.getByRole("button", { name: /copy link/i }).click();
     await expect(page.getByRole("button", { name: /link copied/i })).toBeVisible();
     const text = await page.evaluate(() => navigator.clipboard.readText());
-    expect(text).toMatch(/\/events\/seed-event-001$/);
+    expect(text).toMatch(/\/events\/the-apex-throwdown-2026$/);
     expect(text).not.toContain("?");
+  });
+
+  test("event slug URL resolves to the event", async ({ page }) => {
+    await page.goto("/events/sydney-harbour-10k");
+    await expect(page.getByRole("heading", { level: 1, name: "Sydney Harbour 10K" })).toBeVisible({ timeout: 20000 });
+  });
+
+  test("legacy id URL still resolves to the same event", async ({ page }) => {
+    await page.goto("/events/seed-event-005");
+    await expect(page.getByRole("heading", { level: 1, name: "Sydney Harbour 10K" })).toBeVisible({ timeout: 20000 });
   });
 
   test("event card shows organiser name and rating", async ({ page }) => {

--- a/lib/event-types.ts
+++ b/lib/event-types.ts
@@ -9,6 +9,7 @@ export interface PublicWave {
 
 export interface PublicEvent {
   id: string;
+  slug: string | null;
   title: string;
   discipline: string;
   description: string | null;

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -11,6 +11,7 @@ export async function getAllEvents() {
       orderBy: { eventDate: "asc" },
       select: {
         id: true,
+        slug: true,
         title: true,
         discipline: true,
         description: true,
@@ -65,6 +66,7 @@ export async function getAllEvents() {
 
 const publicEventSelect = {
   id: true,
+  slug: true,
   title: true,
   discipline: true,
   description: true,
@@ -101,12 +103,12 @@ const publicEventSelect = {
   },
 } as const;
 
-/** Single public event by id — live or archived (past) listings. */
+/** Single public event by id or slug — live or archived (past) listings. */
 export async function getPublicEventById(id: string): Promise<PublicEvent | null> {
   try {
     const event = await prisma.event.findFirst({
       where: {
-        id,
+        OR: [{ id }, { slug: id }],
         status: { in: ["APPROVED", "ARCHIVED"] },
       },
       select: publicEventSelect,

--- a/lib/slugs.ts
+++ b/lib/slugs.ts
@@ -1,0 +1,36 @@
+import prisma from "@/lib/prisma";
+
+const MAX_SLUG_LENGTH = 80;
+
+/** Human-readable URL slug derived from an event title. Mirrors the backfill in
+ * `prisma/migrations/*_add_event_slug` — keep them in sync. */
+export function slugify(title: string): string {
+  return (
+    title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, MAX_SLUG_LENGTH)
+      .replace(/-+$/g, "") || "event"
+  );
+}
+
+/** A unique slug for `title` — appends "-2", "-3", … when the base is taken.
+ * `excludeId` skips the event being renamed so its current slug doesn't collide
+ * with the one it's being reassigned. */
+export async function uniqueSlug(title: string, excludeId?: string): Promise<string> {
+  const base = slugify(title);
+  const existing = await prisma.event.findMany({
+    where: {
+      OR: [{ slug: base }, { slug: { startsWith: `${base}-` } }],
+      ...(excludeId ? { NOT: { id: excludeId } } : {}),
+    },
+    select: { slug: true },
+  });
+  const taken = new Set(existing.map((e) => e.slug!));
+  if (!taken.has(base)) return base;
+  for (let i = 2; ; i++) {
+    const candidate = `${base}-${i}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}

--- a/lib/user-events.ts
+++ b/lib/user-events.ts
@@ -38,6 +38,7 @@ export function toUserEvent(event: PublicEvent): UserEvent {
 
   return {
     id: event.id,
+    slug: event.slug ?? undefined,
     title: event.title,
     description: event.description ?? "",
     date: event.eventDate,

--- a/prisma/migrations/20260816000000_add_event_slug/migration.sql
+++ b/prisma/migrations/20260816000000_add_event_slug/migration.sql
@@ -1,0 +1,36 @@
+-- AlterTable
+ALTER TABLE "events" ADD COLUMN     "slug" TEXT;
+
+-- Backfill: derive a slug from the title, mirroring lib/slugs.ts (lowercase,
+-- [^a-z0-9]+ -> "-", trimmed dashes, ~80 char truncation). Duplicate bases get
+-- a numeric suffix ("-2", "-3", ...) via row_number. Titles that slugify to
+-- nothing fall back to "event". Must run before the unique index below.
+WITH base_slugs AS (
+    SELECT
+        id,
+        regexp_replace(lower(title), '[^a-z0-9]+', '-', 'g') AS raw
+    FROM events
+),
+truncated AS (
+    SELECT
+        id,
+        CASE
+            WHEN rtrim(left(trim(BOTH '-' FROM raw), 80), '-') = '' THEN 'event'
+            ELSE rtrim(left(trim(BOTH '-' FROM raw), 80), '-')
+        END AS slug
+    FROM base_slugs
+),
+numbered AS (
+    SELECT
+        id,
+        slug,
+        row_number() OVER (PARTITION BY slug ORDER BY id) AS rn
+    FROM truncated
+)
+UPDATE events e
+SET slug = n.slug || CASE WHEN n.rn = 1 THEN '' ELSE '-' || n.rn::text END
+FROM numbered n
+WHERE e.id = n.id;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "events_slug_key" ON "events"("slug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,6 +125,10 @@ model Event {
   organiserId String
   status      EventStatus @default(DRAFT)
 
+  // Human-readable URL slug derived from the title (e.g. "sydney-harbour-10k").
+  // Nullable so existing rows backfill via migration; unique once populated.
+  slug String? @unique
+
   // Step 1 — basics
   title       String
   discipline  String

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -19,6 +19,7 @@ import {
   UserNotFoundException,
 } from "@aws-sdk/client-cognito-identity-provider";
 import { getEventCoords } from "../lib/australia-coords";
+import { uniqueSlug } from "../lib/slugs";
 
 function seedCoords(city: string, state: string, coords?: [number, number]) {
   const [latitude, longitude] = coords ?? getEventCoords(city, state);
@@ -523,7 +524,7 @@ async function main() {
   const event1 = await prisma.event.upsert({
     where:  { id: "seed-event-001" },
     update: apexThrowdown,
-    create: { id: "seed-event-001", organiserId: org.id, ...apexThrowdown },
+    create: { id: "seed-event-001", slug: await uniqueSlug(apexThrowdown.title), organiserId: org.id, ...apexThrowdown },
   });
 
   // Mirror the event's JSON start waves into the StartWave table — the new source
@@ -553,7 +554,7 @@ async function main() {
   const event2 = await prisma.event.upsert({
     where: { id: "seed-event-002" }, update: {},
     create: {
-      id: "seed-event-002", organiserId: org.id, status: "PENDING", photos: DISCIPLINE_PHOTOS.hybrid,
+      id: "seed-event-002", slug: await uniqueSlug("Hybrid Hustle Series — Round 3"), organiserId: org.id, status: "PENDING", photos: DISCIPLINE_PHOTOS.hybrid,
       title: "Hybrid Hustle Series — Round 3", discipline: "hybrid",
       description: "Trail running, loaded carries, obstacle crawls, and a surprise finale.",
       eventDate: "2026-09-06", startTime: "08:00", endTime: "14:00",
@@ -569,7 +570,7 @@ async function main() {
   const event3 = await prisma.event.upsert({
     where: { id: "seed-event-003" }, update: {},
     create: {
-      id: "seed-event-003", organiserId: org.id, status: "DRAFT", photos: DISCIPLINE_PHOTOS.functional_fitness,
+      id: "seed-event-003", slug: await uniqueSlug("Team Throwdown Summer Series"), organiserId: org.id, status: "DRAFT", photos: DISCIPLINE_PHOTOS.functional_fitness,
       title: "Team Throwdown Summer Series", discipline: "functional_fitness", description: "Draft — details TBC",
       eventDate: "2026-12-05", startTime: "09:00", endTime: "15:00",
       venue: "TBC", city: "Sydney", state: "nsw", ...seedCoords("Sydney", "nsw"), format: "team", level: "open",
@@ -581,7 +582,7 @@ async function main() {
   const event4 = await prisma.event.upsert({
     where: { id: "seed-event-004" }, update: {},
     create: {
-      id: "seed-event-004", organiserId: org.id, status: "REJECTED", photos: DISCIPLINE_PHOTOS.running,
+      id: "seed-event-004", slug: await uniqueSlug("Autumn Run Festival"), organiserId: org.id, status: "REJECTED", photos: DISCIPLINE_PHOTOS.running,
       title: "Autumn Run Festival", discipline: "running",
       description: "A scenic trail run through the Yarra Valley vineyards.",
       eventDate: "2026-04-11", startTime: "07:30", endTime: "13:00",
@@ -630,7 +631,7 @@ async function main() {
     const ownerId = e.org === "coastal" ? (coastalOrg?.id ?? org.id) : org.id;
     await prisma.event.upsert({
       where: { id: e.id }, update: {},
-      create: { id: e.id, organiserId: ownerId, status: e.status, title: e.title, discipline: e.discipline,
+      create: { id: e.id, slug: await uniqueSlug(e.title), organiserId: ownerId, status: e.status, title: e.title, discipline: e.discipline,
         photos: DISCIPLINE_PHOTOS[e.discipline] ?? [], description: e.description, eventDate: e.eventDate, startTime: e.startTime, endTime: e.endTime,
         venue: e.venue, city: e.city, state: e.state, ...seedCoords(e.city, e.state, "coords" in e ? e.coords : undefined), format: e.format, level: e.level, categories: e.categories,
         cap: e.cap, waves: e.waves, registrationType: "startline", feeStructure: "athlete",

--- a/src/__tests__/slugs.test.ts
+++ b/src/__tests__/slugs.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { slugify } from "@/lib/slugs";
+
+describe("slugify", () => {
+  it("lowercases, dashes separators, strips special chars", () => {
+    expect(slugify("The Apex Throwdown 2026")).toBe("the-apex-throwdown-2026");
+    expect(slugify("Sydney Harbour 10K")).toBe("sydney-harbour-10k");
+    expect(slugify("Bondi to Bronte Ocean Swim")).toBe("bondi-to-bronte-ocean-swim");
+  });
+
+  it("collapses runs of non-alphanumeric chars into a single dash", () => {
+    expect(slugify("Hybrid Hustle Series — Round 3")).toBe("hybrid-hustle-series-round-3");
+    expect(slugify("F45   Championship   World Final")).toBe("f45-championship-world-final");
+  });
+
+  it("trims leading/trailing dashes and falls back when empty", () => {
+    expect(slugify("— 2026!")).toBe("2026");
+    expect(slugify("   ")).toBe("event");
+    expect(slugify("!!!")).toBe("event");
+  });
+
+  it("truncates to ~80 chars without a trailing dash", () => {
+    const long = "A".repeat(120);
+    expect(slugify(long)).toBe("a".repeat(80));
+    expect(slugify("Supercalifragilisticexpialidocious " + "A".repeat(90))).toHaveLength(80);
+    expect(slugify("Word ".repeat(30)).endsWith("-")).toBe(false);
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -37,6 +37,7 @@ export interface TicketDrop {
 
 export interface UserEvent {
   id: string;
+  slug?: string;
   title: string;
   description: string;
   date: string;


### PR DESCRIPTION
## Description

Implements #232 — shared event links now use a human-readable slug derived from the event title instead of the raw id.

- **Data model:** `Event.slug String? @unique`. Migration `20260816000000_add_event_slug` adds the column, backfills slugs from titles (lowercase, dash-separated, ~80 chars, collision `-N` suffix via a CTE mirroring `lib/slugs.ts`), then creates the unique index.
- **Routing:** the single `[id]` route now resolves by `OR: [{ id }, { slug }]`, so old `/events/{id}` URLs keep working while `/events/{slug}` serves the same event (dual route, no redirect). `generateStaticParams` emits slug params; canonical metadata uses the slug.
- **Share control:** `ShareEventButton` copies `/events/{slug}` (falls back to id when no slug).
- **Write paths:** slugs generated on organiser create / update (title change) / duplicate and admin create, via `lib/slugs.ts` (`slugify` + `uniqueSlug`).
- **Seed:** all seed events get deterministic slugs (`sydney-harbour-10k`, `the-apex-throwdown-2026`, …).

## Test plan

- [x] Share → Copy link yields `/events/the-apex-throwdown-2026`
- [x] Visiting `/events/sydney-harbour-10k` shows Sydney Harbour 10K
- [x] Visiting legacy `/events/seed-event-005` still shows the same event
- [x] Duplicate titles get a suffix (`-2`) — backfill + `uniqueSlug` verified
- [x] All seed events have slugs (30/30 distinct)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` (217), e2e `events` (15) — full suite 154 passed / 0 failed / 2 skipped (Cognito signup only)

## Notes

- `.env.local` is gitignored and unchanged in this PR. Local dev for this worktree points at a dedicated `startline_issue232` DB because the shared docker DB has drifted ahead (migrated by the `issue-229` multi-pdf worktree).
- Backfill SQL intentionally mirrors `slugify()` in `lib/slugs.ts` — keep them in sync if the rule ever changes.

Closes #232