### PR TITLE
fix(organiser): managing regos — tier fill bars, rich-text bold, payout label, profile photo persistence

### DIFF
--- a/app/api/organiser/events/[id]/dashboard/route.ts
+++ b/app/api/organiser/events/[id]/dashboard/route.ts
@@ -45,6 +45,12 @@ export async function GET(
       prisma.registration.count({ where: { eventId: id, status: "CONFIRMED" } }),
     ]);
 
+    const soldByWave: Record<string, number> = {};
+    for (const r of registrations) {
+      if (r.waveLabel) soldByWave[r.waveLabel] = (soldByWave[r.waveLabel] ?? 0) + 1;
+    }
+    const wavesWithSold = waves.map(w => ({ ...w, sold: soldByWave[w.label] ?? 0 }));
+
     const count = registrationCount;
     const hasRealData = count > 0;
 
@@ -92,7 +98,7 @@ export async function GET(
         cap:               event.cap,
         registrationCount: count,
         coverImageUrl:     event.coverImageUrl,
-        waves,
+        waves: wavesWithSold,
         feeStructure:      event.feeStructure,
         categories:        event.categories,
       },

--- a/app/organiser/dashboard/page.tsx
+++ b/app/organiser/dashboard/page.tsx
@@ -12,6 +12,7 @@ import { TableSkeleton } from "@/components/ui/skeleton";
 import DashboardTrendChart, {
   type TrendDay,
 } from "@/components/organiser/DashboardTrendChart";
+import CapacityBar from "@/components/ui/CapacityBar";
 import { formatAudFromCents } from "@/lib/organiser-dashboard";
 
 export const dynamic = "force-dynamic";
@@ -126,39 +127,6 @@ function MetricStrip({
 
 function formatCount(n: number): string {
   return n.toLocaleString("en-AU");
-}
-
-/** Design.md capacity gauge: &lt;70% green · 70–89% amber · ≥90% red. */
-function capacityBarColor(pct: number): string {
-  if (pct >= 90) return "bg-red-400";
-  if (pct >= 70) return "bg-amber-400";
-  return "bg-primary";
-}
-
-function CapacityBar({
-  count,
-  cap,
-}: {
-  count: number;
-  cap: number | null | undefined;
-}) {
-  if (cap == null || cap <= 0) return null;
-  const pct = Math.min(100, Math.round((count / cap) * 100));
-  return (
-    <div
-      className="mt-1.5 h-1.5 w-full min-w-[96px] max-w-[112px] ml-auto sm:min-w-0 sm:max-w-[88px] sm:ml-0 rounded-full bg-dark-lighter overflow-hidden"
-      role="progressbar"
-      aria-valuenow={pct}
-      aria-valuemin={0}
-      aria-valuemax={100}
-      aria-label={`${pct}% full`}
-    >
-      <div
-        className={`h-full rounded-full transition-[width] duration-300 ${capacityBarColor(pct)}`}
-        style={{ width: `${pct}%` }}
-      />
-    </div>
-  );
 }
 
 export default function DashboardPage() {
@@ -378,6 +346,7 @@ export default function DashboardPage() {
                               <CapacityBar
                                 count={e.registrationCount ?? 0}
                                 cap={e.cap}
+                                className="mt-1.5 w-full min-w-[96px] max-w-[112px] ml-auto sm:min-w-0 sm:max-w-[88px] sm:ml-0"
                               />
                             </div>
                           </div>
@@ -444,6 +413,7 @@ export default function DashboardPage() {
                           <CapacityBar
                             count={e.registrationCount ?? 0}
                             cap={e.cap}
+                            className="mt-1.5 w-full min-w-[96px] max-w-[112px] ml-auto sm:min-w-0 sm:max-w-[88px] sm:ml-0"
                           />
                           {price && (
                             <div className="font-headline text-[10px] uppercase tracking-widest text-light mt-0.5">

--- a/app/organiser/events/[id]/dashboard/page.tsx
+++ b/app/organiser/events/[id]/dashboard/page.tsx
@@ -17,10 +17,11 @@ import {
 } from "@/components/ui/skeleton";
 import RaceManagementPanel from "@/components/organiser/RaceManagementPanel";
 import RichTextEditor from "@/components/ui/RichTextEditor";
+import CapacityBar from "@/components/ui/CapacityBar";
 import { sanitizeHtml } from "@/lib/sanitize-html";
 import { stripHtml } from "@/lib/utils";
 
-interface Wave { label: string; price: string; qty?: number }
+interface Wave { label: string; price: string; qty?: number; sold?: number }
 
 interface DashboardData {
   event: {
@@ -36,6 +37,7 @@ interface DashboardData {
     registrationCount: number; lowestTicketPrice: number;
     grossRevenue: number; platformFees: number;
     estimatedPayout: number; feeStructure: string; note: string;
+    isEstimate: boolean;
   };
   recentRegistrations: Registration[];
   announcements: Announcement[];
@@ -296,8 +298,11 @@ function EventDashboardInner({
                 <div className="font-headline text-xl sm:text-2xl font-black tracking-tighter text-light leading-none">
                   {fmt(payout.estimatedPayout)}
                 </div>
-                <div className="font-headline text-[9px] sm:text-[10px] font-bold uppercase tracking-widest text-muted mt-1">
-                  Estimated payout
+                <div
+                  className="font-headline text-[9px] sm:text-[10px] font-bold uppercase tracking-widest text-muted mt-1"
+                  title={payout.note}
+                >
+                  {payout.isEstimate ? "Est. payout (after fees)" : "Payout (after fees)"}
                 </div>
               </div>
             </div>
@@ -507,23 +512,40 @@ function EventDashboardInner({
                 {tiersOpen && (
                   <>
                     <div className="divide-y divide-white/5 mt-5">
-                      {event.waves.map((w, i) => (
-                        <div key={i} className="flex items-center justify-between py-3 gap-4">
-                          <div className="font-headline text-[14px] font-bold text-white/90 min-w-0 truncate">{w.label}</div>
-                          <div className="flex items-center gap-4 sm:gap-6 shrink-0">
-                            <div className="font-headline text-[14px] font-black italic text-white">A${w.price}</div>
-                            <div className="text-right">
-                              <div className="font-headline text-[10px] uppercase tracking-widest text-muted-dark">Cap</div>
-                              <div className="font-headline text-[13px] text-muted-light">{w.qty ? w.qty.toLocaleString() : "—"}</div>
+                      {event.waves.map((w, i) => {
+                        const sold = w.sold ?? 0;
+                        const capped = w.qty != null;
+                        return (
+                          <div key={i} className="py-3 gap-4">
+                            <div className="flex items-center justify-between gap-4">
+                              <div className="font-headline text-[14px] font-bold text-white/90 min-w-0 truncate">{w.label}</div>
+                              <div className="flex items-center gap-4 sm:gap-6 shrink-0">
+                                <div className="font-headline text-[14px] font-black italic text-white">A${w.price}</div>
+                                <div className="text-right">
+                                  <div className="font-headline text-[10px] uppercase tracking-widest text-muted-dark">Sold / Cap</div>
+                                  <div className="font-headline text-[13px] text-muted-light">
+                                    {sold.toLocaleString()}
+                                    {capped ? ` / ${w.qty!.toLocaleString()}` : ""}
+                                  </div>
+                                </div>
+                              </div>
                             </div>
+                            {capped && (
+                              <CapacityBar
+                                count={sold}
+                                cap={w.qty}
+                                className="mt-2.5 w-full max-w-[360px]"
+                                label={`${w.label}: ${sold} of ${w.qty} sold`}
+                              />
+                            )}
                           </div>
-                        </div>
-                      ))}
+                        );
+                      })}
                     </div>
 
                     <div className="mt-4 pt-3 border-t border-white/5">
                       <p className="text-[11px] text-muted-dark">
-                        A per-tier breakdown of sales is coming soon. See the Registrations list below for each athlete&apos;s wave.
+                        Tiers without a cap show sold count only. Athletes register per tier; see the Registrations list below for each athlete&apos;s wave.
                       </p>
                     </div>
                   </>

--- a/components/organiser/SettingsModal.tsx
+++ b/components/organiser/SettingsModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import {
   X, ChevronRight, Upload, Move, Mail, Phone,
   CheckCircle, User, Lock, Bell, CreditCard, Cookie,
@@ -28,12 +29,13 @@ function FieldLabel({ label, hint, required }: { label: string; hint?: string; r
 // ── CoverEditor ─────────────────────────────────────────────────────────────
 
 function CoverEditor({
-  imageUrl, position, uploading, onUpload, onPositionChange, onRemove, fileRef,
+  imageUrl, position, uploading, onUpload, onPositionChange, onRemove, fileRef, onDone,
 }: {
   imageUrl: string; position: string; uploading: boolean;
   onUpload: (f: File) => void; onPositionChange: (p: string) => void;
   onRemove: () => void;
   fileRef: React.RefObject<HTMLInputElement | null>;
+  onDone?: () => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [dragging,   setDragging]   = useState(false);
@@ -99,7 +101,7 @@ function CoverEditor({
       </div>
       <div className="flex items-center gap-2 mt-2">
         {reposition ? (
-          <button onClick={() => setReposition(false)}
+          <button onClick={() => { setReposition(false); onDone?.(); }}
             className="font-headline text-[11px] font-bold uppercase tracking-widest bg-primary text-dark px-3 py-1.5 rounded-md hover:opacity-90 transition-opacity">
             Done
           </button>
@@ -122,11 +124,12 @@ function CoverEditor({
 // ── LogoEditor ──────────────────────────────────────────────────────────────
 
 function LogoEditor({
-  imageUrl, position, initial, uploading, onUpload, onPositionChange, fileRef,
+  imageUrl, position, initial, uploading, onUpload, onPositionChange, fileRef, onDone,
 }: {
   imageUrl: string; position: string; initial: string; uploading: boolean;
   onUpload: (f: File) => void; onPositionChange: (p: string) => void;
   fileRef: React.RefObject<HTMLInputElement | null>;
+  onDone?: () => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [reposition, setReposition] = useState(false);
@@ -192,7 +195,7 @@ function LogoEditor({
             <>
               <span className="text-white/20 text-xs">·</span>
               {reposition ? (
-                <button onClick={() => setReposition(false)}
+                <button onClick={() => { setReposition(false); onDone?.(); }}
                   className="font-headline text-[12px] font-bold uppercase tracking-widest bg-primary text-dark px-2.5 py-1 rounded-md hover:opacity-90 transition-opacity">
                   Done
                 </button>
@@ -226,6 +229,7 @@ const EMPTY_FORM: ProfileForm = {
 
 function PersonalInfoForm() {
   const { notifyProfileSaved } = useSettings();
+  const router = useRouter();
   const [form,           setForm]           = useState<ProfileForm>(EMPTY_FORM);
   const [loadingForm,    setLoadingForm]     = useState(true);
   const [saving,         setSaving]         = useState(false);
@@ -276,6 +280,7 @@ function PersonalInfoForm() {
       const updated = { ...form, logoUrl: url };
       await fetch("/api/organiser/profile", { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(updated) });
       patch({ logoUrl: url });
+      router.refresh();
     } catch { setError("Logo upload failed."); }
     finally { setLogoUploading(false); }
   };
@@ -284,7 +289,10 @@ function PersonalInfoForm() {
     setCoverUploading(true);
     try {
       const url = await uploadImage(file, "cover");
+      const updated = { ...form, coverImageUrl: url };
+      await fetch("/api/organiser/profile", { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(updated) });
       patch({ coverImageUrl: url });
+      router.refresh();
     } catch { setError("Cover upload failed."); }
     finally { setCoverUploading(false); }
   };
@@ -300,6 +308,7 @@ function PersonalInfoForm() {
       if (!res.ok) { setError(data.error ?? "Save failed."); return; }
       setSaved(true);
       notifyProfileSaved();
+      router.refresh();
       setTimeout(() => setSaved(false), 2500);
     } catch { setError("Something went wrong."); }
     finally { setSaving(false); }
@@ -338,6 +347,7 @@ function PersonalInfoForm() {
             uploading={coverUploading} onUpload={handleCoverUpload}
             onPositionChange={pos => patch({ coverPosition: pos })}
             onRemove={() => patch({ coverImageUrl: "" })}
+            onDone={handleSave}
             fileRef={coverRef}
           />
           <input ref={coverRef} type="file" accept="image/*" className="sr-only"
@@ -348,7 +358,7 @@ function PersonalInfoForm() {
           <LogoEditor
             imageUrl={form.logoUrl} position={form.logoPosition} initial={initial}
             uploading={logoUploading} onUpload={handleLogoUpload}
-            onPositionChange={pos => patch({ logoPosition: pos })} fileRef={logoRef}
+            onPositionChange={pos => patch({ logoPosition: pos })} onDone={handleSave} fileRef={logoRef}
           />
           <input ref={logoRef} type="file" accept="image/*" className="sr-only"
             onChange={e => { const f = e.target.files?.[0]; if (f) handleLogoUpload(f); }} />

--- a/components/ui/CapacityBar.tsx
+++ b/components/ui/CapacityBar.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/lib/utils";
+
+/** Design.md capacity gauge: &lt;70% green · 70–89% amber · ≥90% red. */
+export function capacityBarColor(pct: number): string {
+  if (pct >= 90) return "bg-red-400";
+  if (pct >= 70) return "bg-amber-400";
+  return "bg-primary";
+}
+
+export default function CapacityBar({
+  count,
+  cap,
+  className,
+  label,
+}: {
+  count: number;
+  cap: number | null | undefined;
+  className?: string;
+  label?: string;
+}) {
+  if (cap == null || cap <= 0) return null;
+  const pct = Math.min(100, Math.round((count / cap) * 100));
+  return (
+    <div
+      className={cn(
+        "h-1.5 rounded-full bg-dark-lighter overflow-hidden",
+        className,
+      )}
+      role="progressbar"
+      aria-valuenow={pct}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={label ?? `${pct}% full`}
+    >
+      <div
+        className={`h-full rounded-full transition-[width] duration-300 ${capacityBarColor(pct)}`}
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}

--- a/components/ui/RichTextEditor.tsx
+++ b/components/ui/RichTextEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Bold, Italic, Underline, AlignLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -21,6 +21,8 @@ export default function RichTextEditor({
 }: Props) {
   const editorRef = useRef<HTMLDivElement>(null);
   const userHasTyped = useRef(false);
+  // Mirrors the caret's current formatting so the toolbar shows what is active.
+  const [states, setStates] = useState({ bold: false, italic: false, underline: false });
 
   useEffect(() => {
     if (!editorRef.current) return;
@@ -30,18 +32,44 @@ export default function RichTextEditor({
     }
   }, [value]);
 
+  const refreshStates = () => {
+    try {
+      setStates({
+        bold:      document.queryCommandState("bold"),
+        italic:    document.queryCommandState("italic"),
+        underline: document.queryCommandState("underline"),
+      });
+    } catch {
+      // queryCommandState can throw in some embedders; the toolbar just stays idle.
+    }
+  };
+
+  useEffect(() => {
+    // Keep the toolbar in sync as the caret moves through styled text.
+    document.addEventListener("selectionchange", refreshStates);
+    return () => document.removeEventListener("selectionchange", refreshStates);
+  }, []);
+
   const exec = (cmd: string, val?: string) => {
+    // Toolbar buttons preventDefault on mousedown so focus stays in the editor;
+    // execCommand therefore still sees the live selection instead of an empty one.
     document.execCommand(cmd, false, val ?? undefined);
     editorRef.current?.focus();
+    refreshStates();
   };
 
   const setBlock = (tag: string) => {
     document.execCommand("formatBlock", false, tag);
     editorRef.current?.focus();
+    refreshStates();
   };
+
+  const keepSelection = (e: React.MouseEvent) => e.preventDefault();
 
   const toolbarBtn =
     "w-8 h-8 rounded flex items-center justify-center text-muted hover:bg-white/5 hover:text-light transition-colors font-headline font-bold text-[13px]";
+
+  const toolbarBtnActive = "bg-primary/15 text-primary";
 
   return (
     <div
@@ -51,19 +79,23 @@ export default function RichTextEditor({
       )}
     >
       <div className="flex items-center gap-1 px-3 py-2 border-b border-dark-lighter bg-white/[0.02] flex-wrap">
-        <button type="button" title="Bold (Ctrl+B)" onClick={() => exec("bold")} className={toolbarBtn}>
+        <button type="button" title="Bold (Ctrl+B)" onMouseDown={keepSelection} onClick={() => exec("bold")}
+          className={cn(toolbarBtn, states.bold && toolbarBtnActive)} aria-pressed={states.bold}>
           <Bold className="w-3.5 h-3.5" />
         </button>
-        <button type="button" title="Italic (Ctrl+I)" onClick={() => exec("italic")} className={toolbarBtn}>
+        <button type="button" title="Italic (Ctrl+I)" onMouseDown={keepSelection} onClick={() => exec("italic")}
+          className={cn(toolbarBtn, states.italic && toolbarBtnActive)} aria-pressed={states.italic}>
           <Italic className="w-3.5 h-3.5" />
         </button>
-        <button type="button" title="Underline (Ctrl+U)" onClick={() => exec("underline")} className={toolbarBtn}>
+        <button type="button" title="Underline (Ctrl+U)" onMouseDown={keepSelection} onClick={() => exec("underline")}
+          className={cn(toolbarBtn, states.underline && toolbarBtnActive)} aria-pressed={states.underline}>
           <Underline className="w-3.5 h-3.5" />
         </button>
         <div className="w-px h-5 bg-dark-lighter mx-1" />
         <button
           type="button"
           title="Heading"
+          onMouseDown={keepSelection}
           onClick={() => setBlock("h3")}
           className={`${toolbarBtn} text-[11px] font-black uppercase tracking-widest`}
         >
@@ -72,18 +104,20 @@ export default function RichTextEditor({
         <button
           type="button"
           title="Subheading"
+          onMouseDown={keepSelection}
           onClick={() => setBlock("h4")}
           className={`${toolbarBtn} text-[10px] font-black uppercase tracking-widest`}
         >
           H2
         </button>
-        <button type="button" title="Normal text" onClick={() => setBlock("p")} className={toolbarBtn}>
+        <button type="button" title="Normal text" onMouseDown={keepSelection} onClick={() => setBlock("p")} className={toolbarBtn}>
           <AlignLeft className="w-3.5 h-3.5" />
         </button>
         <div className="w-px h-5 bg-dark-lighter mx-1" />
         <button
           type="button"
           title="Bullet list"
+          onMouseDown={keepSelection}
           onClick={() => exec("insertUnorderedList")}
           className={`${toolbarBtn} text-[11px]`}
         >
@@ -114,6 +148,7 @@ export default function RichTextEditor({
             }
           }
         }}
+        onKeyUp={refreshStates}
         data-placeholder={placeholder}
         className={cn(
           "min-h-[220px] px-4 py-3 font-headline text-[14px] text-light focus:outline-none prose prose-sm max-w-none",

--- a/e2e/organiser.spec.ts
+++ b/e2e/organiser.spec.ts
@@ -197,6 +197,50 @@ test.describe("organiser pages", () => {
     await argosScreenshot(page, "organiser-event-dashboard");
   });
 
+  test("ticket tiers show fill progress per tier", async ({ page }) => {
+    await organiserLogin(page);
+    await page.goto("/organiser/events/seed-event-001/dashboard");
+
+    await expect(page.getByText("Ticket tiers")).toBeVisible();
+    await expect(page.getByText("Sold / Cap").first()).toBeVisible();
+
+    // All three seeded tiers have caps, so each renders a fill gauge.
+    const bars = page.getByRole("progressbar");
+    await expect(bars).toHaveCount(3);
+    // Sold count is bound to the right tier cap, without pinning the exact count.
+    await expect(page.getByRole("progressbar", { name: /^Early Bird: \d+ of 80 sold$/ })).toBeVisible();
+    await expect(page.getByRole("progressbar", { name: /^General: \d+ of 150 sold$/ })).toBeVisible();
+    await expect(page.getByRole("progressbar", { name: /^Late Entry: \d+ of 90 sold$/ })).toBeVisible();
+  });
+
+  test("announcement editor applies bold formatting to new text", async ({ page }) => {
+    await organiserLogin(page);
+    await page.goto("/organiser/events/seed-event-001/dashboard?panel=announce");
+
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible();
+    await editor.click();
+    await page.getByRole("button", { name: /bold/i }).click();
+    await editor.pressSequentially("Hello bold");
+
+    expect(await editor.innerHTML()).toMatch(/<(b|strong)[\s>]/i);
+  });
+
+  test("profile settings reposition Done saves and confirms", async ({ page }) => {
+    await organiserLogin(page);
+    await page.goto("/organiser/profile");
+
+    await page.getByRole("button", { name: "Edit Profile" }).click();
+    await expect(page.getByText("Cover photo")).toBeVisible();
+
+    // The cover has an image in seed data, so Reposition is available.
+    await page.getByRole("button", { name: "Reposition" }).first().click();
+    await page.getByRole("button", { name: "Done" }).first().click();
+
+    // Done now commits the change rather than silently dropping it.
+    await expect(page.getByText("Saved")).toBeVisible();
+  });
+
   test("organiser payments page visual snapshot", async ({ page }) => {
 
     await organiserLogin(page);


### PR DESCRIPTION
## Description

Fixes the four items in #221 for the organiser event dashboard / settings.

**1. Ticket tier fill** — the event dashboard now shows each tier's sold count against its cap with a capacity progress bar (design.md thresholds: <70% green, 70–89% amber, ≥90% red). The dashboard API groups CONFIRMED registrations by `waveLabel` and attaches `sold` to each wave. Extracted the existing capacity gauge from the organiser dashboard into a shared `components/ui/CapacityBar.tsx`.

**2. Announcement rich text** — toolbar buttons now keep focus/selection in the editor (preventDefault on `mousedown`), so `execCommand("bold")` applies to the live selection instead of a cleared one. Added an active-state indicator (`aria-pressed` + highlight) via `queryCommandState` on `selectionchange`, so bold visibly toggles.

**3. Payout metric** — header now reads `Est. payout (after fees)` only when real registration data is absent, otherwise `Payout (after fees)`, with a tooltip explaining the basis.

**4. Profile/cover photo** — settings modal: cover upload now persists (was local-state only), reposition **Done** commits via the save handler (was a no-op), and `router.refresh()` after save/upload makes the server-rendered profile reflect changes (the `profileSavedAt` bump was previously unconsumed).

**Tests** — 3 new E2E tests in `e2e/organiser.spec.ts`: tier fill bars render per-tier sold/cap, bold wraps typed text in `<b>/<strong>`, and reposition-Done shows the saved confirmation.

Closes #221