### PR TITLE
feat(profile): surface organiser-entered race results on public profiles

### DIFF
--- a/app/(user)/profile/[username]/page.tsx
+++ b/app/(user)/profile/[username]/page.tsx
@@ -59,8 +59,8 @@ export default async function PublicProfilePage({ params }: PublicProfilePagePro
     orderBy: { event: { eventDate: "asc" } },
     select: {
       id: true,
-      finishTime: true,
-      result: true,
+      resultTime: true,
+      resultPlacement: true,
       event: {
         select: {
           id: true,

--- a/app/api/user/profile/[username]/route.ts
+++ b/app/api/user/profile/[username]/route.ts
@@ -43,8 +43,8 @@ export async function GET(
     orderBy: { event: { eventDate: "asc" } },
     select: {
       id: true,
-      finishTime: true,
-      result: true,
+      resultTime: true,
+      resultPlacement: true,
       event: {
         select: {
           id: true,

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -83,8 +83,6 @@ export async function GET() {
     orderBy: { event: { eventDate: "asc" } },
     select: {
       id: true,
-      finishTime: true,
-      result: true,
       resultDistance: true,
       resultTime: true,
       resultPlacement: true,

--- a/components/profile/UserProfileView.tsx
+++ b/components/profile/UserProfileView.tsx
@@ -13,8 +13,8 @@ export type ProfileRaceHistory = {
   completed: number;
   registrations: {
     id: string;
-    finishTime: string | null;
-    result: string | null;
+    resultTime: string | null;
+    resultPlacement: string | null;
     event: {
       id: string;
       title: string;
@@ -65,7 +65,7 @@ function groupHistoryByYear(registrations: HistoryRegistration[]) {
 function RaceHistoryCard({ reg }: { reg: HistoryRegistration }) {
   const [day, month] = formatShortDate(reg.event.eventDate).split(" ");
   const location = `${reg.event.city}, ${STATE_LABELS[reg.event.state as AustralianState]}`;
-  const hasResult = Boolean(reg.result || reg.finishTime);
+  const hasResult = Boolean(reg.resultPlacement || reg.resultTime);
 
   return (
     <Link
@@ -130,24 +130,24 @@ function RaceHistoryCard({ reg }: { reg: HistoryRegistration }) {
 
         {hasResult && (
           <div className="xl:hidden flex items-center gap-8 pt-1 border-t border-dark-lighter">
-            {reg.finishTime && (
+            {reg.resultTime && (
               <div>
                 <p className="font-headline text-[11px] font-bold uppercase tracking-widest text-light">
                   Finish
                 </p>
                 <p className="flex items-center gap-1.5 font-headline text-xl font-black tracking-tighter text-light leading-none mt-0.5">
                   <Timer className="w-3.5 h-3.5 text-muted" />
-                  {reg.finishTime}
+                  {reg.resultTime}
                 </p>
               </div>
             )}
-            {reg.result && (
+            {reg.resultPlacement && (
               <div>
                 <p className="font-headline text-[11px] font-bold uppercase tracking-widest text-light">
                   Result
                 </p>
                 <p className="font-headline text-xl font-black tracking-tighter text-light leading-none mt-0.5">
-                  {reg.result}
+                  {reg.resultPlacement}
                 </p>
               </div>
             )}
@@ -164,24 +164,24 @@ function RaceHistoryCard({ reg }: { reg: HistoryRegistration }) {
       >
         {hasResult ? (
           <div className="grid grid-cols-2 gap-x-10 gap-y-2 w-full pr-5">
-            {reg.finishTime && (
+            {reg.resultTime && (
               <div>
                 <p className="font-headline text-[11px] font-bold uppercase tracking-[0.18em] text-light">
                   Finish time
                 </p>
                 <p className="flex items-center gap-1.5 font-headline text-2xl font-black tracking-tighter text-light leading-none mt-1">
                   <Timer className="w-4 h-4 text-muted shrink-0" />
-                  {reg.finishTime}
+                  {reg.resultTime}
                 </p>
               </div>
             )}
-            {reg.result && (
+            {reg.resultPlacement && (
               <div>
                 <p className="font-headline text-[11px] font-bold uppercase tracking-[0.18em] text-light">
                   Result
                 </p>
                 <p className="font-headline text-2xl font-black tracking-tighter text-light leading-none mt-1">
-                  {reg.result}
+                  {reg.resultPlacement}
                 </p>
               </div>
             )}

--- a/e2e/race-management.spec.ts
+++ b/e2e/race-management.spec.ts
@@ -482,4 +482,39 @@ test.describe("athlete public profile race history", () => {
     await page.waitForLoadState("networkidle");
     await expect(page.getByText(/profile not found/i)).toBeVisible();
   });
+
+  test("an organiser-entered result renders on the athlete public profile", async ({ page }) => {
+    await organiserLogin(page);
+    // Idempotent across retries: clear any result left by a previous run. The
+    // first request may race the dev server on a cold route, so retry once.
+    const clear = async () =>
+      page.request.patch(`/api/organiser/events/${EVENT_ID}/results`, {
+        data: { results: [{ athleteEmail: "jade.nguyen@startline.test", resultTime: null, resultPlacement: null }] },
+      });
+    const clearRes = await clear().catch(() => null) ?? await clear();
+    expect(clearRes.ok()).toBeTruthy();
+
+    await page.goto(MANAGE);
+    await page.waitForLoadState("networkidle");
+    await page.getByRole("button", { name: /after race/i }).click();
+    // The results tab's own CTA proves the tab actually switched.
+    await expect(page.getByRole("button", { name: /upload results csv/i })).toBeVisible();
+
+    // Jade is seeded onto this event's results board (profile-linked athlete).
+    await page.getByPlaceholder(/search any wave by name, email, or bib/i).fill("jade.nguyen");
+    await page.getByRole("button", { name: /add result|edit result/i }).first().click();
+
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel(/^time$/i).fill("57:30");
+    await dialog.getByLabel(/placement/i).fill("22nd / 100");
+    await dialog.getByRole("button", { name: /save result/i }).click();
+    await expect(dialog).toHaveCount(0);
+
+    await page.goto("/profile/jade-nguyen");
+    await page.waitForLoadState("networkidle");
+    // The card renders the time in both the mobile and desktop result blocks;
+    // filter to the visible one rather than assuming a breakpoint.
+    await expect(page.getByText("57:30").locator("visible=true")).toBeVisible();
+    await expect(page.getByText("22nd / 100").locator("visible=true")).toBeVisible();
+  });
 });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -831,22 +831,25 @@ async function main() {
     id: string;
     userId: string | undefined;
     eventId: string;
-    finishTime?: string | null;
-    result?: string | null;
+    resultTime?: string | null;
+    resultPlacement?: string | null;
   }[] = [
-    { id: "seed-history-user-001", userId: userSeedId, eventId: "seed-event-040", result: "12th", finishTime: "02:14:37" },
-    { id: "seed-history-user-002", userId: userSeedId, eventId: "seed-event-042", result: "8th",  finishTime: "01:47:22" },
-    { id: "seed-history-user-003", userId: userSeedId, eventId: "seed-event-044", result: "1st",  finishTime: "00:42:10" },
-    { id: "seed-history-user-004", userId: userSeedId, eventId: "seed-event-022", result: "24th", finishTime: null },
-    { id: "seed-history-user-005", userId: userSeedId, eventId: "seed-event-006", result: "157th", finishTime: "04:28:51" },
-    { id: "seed-history-user-006", userId: userSeedId, eventId: "seed-event-024", result: "19th", finishTime: null },
-    { id: "seed-history-admin-001", userId: adminSeedId, eventId: "seed-event-041", result: "3rd", finishTime: "01:23:40" },
-    { id: "seed-history-admin-002", userId: adminSeedId, eventId: "seed-event-043", result: "DNF", finishTime: null },
-    { id: "seed-history-organiser-001", userId: organiserSeedId, eventId: "seed-event-040", result: "5th", finishTime: "02:01:12" },
-    { id: "seed-history-organiser-002", userId: organiserSeedId, eventId: "seed-event-044", result: "2nd", finishTime: "00:39:58" },
+    { id: "seed-history-user-001", userId: userSeedId, eventId: "seed-event-040", resultPlacement: "12th", resultTime: "02:14:37" },
+    { id: "seed-history-user-002", userId: userSeedId, eventId: "seed-event-042", resultPlacement: "8th",  resultTime: "01:47:22" },
+    { id: "seed-history-user-003", userId: userSeedId, eventId: "seed-event-044", resultPlacement: "1st",  resultTime: "00:42:10" },
+    { id: "seed-history-user-004", userId: userSeedId, eventId: "seed-event-022", resultPlacement: "24th", resultTime: null },
+    { id: "seed-history-user-005", userId: userSeedId, eventId: "seed-event-006", resultPlacement: "157th", resultTime: "04:28:51" },
+    { id: "seed-history-user-006", userId: userSeedId, eventId: "seed-event-024", resultPlacement: "19th", resultTime: null },
+    // On the Apex Throwdown board so the race-management e2e can enter a result
+    // for a profile-linked athlete and assert it renders on her public profile.
+    { id: "seed-history-user-007", userId: userSeedId, eventId: "seed-event-001", resultPlacement: null, resultTime: null },
+    { id: "seed-history-admin-001", userId: adminSeedId, eventId: "seed-event-041", resultPlacement: "3rd", resultTime: "01:23:40" },
+    { id: "seed-history-admin-002", userId: adminSeedId, eventId: "seed-event-043", resultPlacement: "DNF", resultTime: null },
+    { id: "seed-history-organiser-001", userId: organiserSeedId, eventId: "seed-event-040", resultPlacement: "5th", resultTime: "02:01:12" },
+    { id: "seed-history-organiser-002", userId: organiserSeedId, eventId: "seed-event-044", resultPlacement: "2nd", resultTime: "00:39:58" },
     // Upcoming and unraced, so the athlete-side refund-request flow has something
     // it is actually allowed to act on (past events can no longer be refunded).
-    { id: "seed-history-organiser-003", userId: organiserSeedId, eventId: "seed-event-005", result: null, finishTime: null },
+    { id: "seed-history-organiser-003", userId: organiserSeedId, eventId: "seed-event-005", resultPlacement: null, resultTime: null },
   ];
 
   let historyCount = 0;
@@ -873,11 +876,9 @@ async function main() {
         platformFeeCents: 0,
         feeStructure: "athlete",
         status: "CONFIRMED",
-        finishTime: h.finishTime ?? null,
-        result: h.result ?? null,
-        // New-style result fields (race management / public profile table)
-        resultTime: h.finishTime ?? null,
-        resultPlacement: h.result ?? null,
+        // Race-management result fields (public profile table)
+        resultTime: h.resultTime ?? null,
+        resultPlacement: h.resultPlacement ?? null,
         resultDistance: "5K",
       },
     });
@@ -888,18 +889,18 @@ async function main() {
   // ── Athlete race history (new regular users) ─────────────────────────────
   // Give the extra athletes a couple of completed races each so their
   // profile KStats / timeline aren't empty.
-  const athleteHistory: { email: string; eventId: string; result: string; finishTime: string | null }[] = [
-    { email: "harper.jones@startline.test",  eventId: "seed-event-005", result: "43rd",  finishTime: "00:48:22" },
-    { email: "harper.jones@startline.test",  eventId: "seed-event-010", result: "DNF",   finishTime: null },
-    { email: "mateo.silva@startline.test",   eventId: "seed-event-014", result: "27th",  finishTime: "00:51:09" },
-    { email: "mateo.silva@startline.test",   eventId: "seed-event-017", result: "DNF",   finishTime: null },
-    { email: "aria.kapoor@startline.test",   eventId: "seed-event-006", result: "88th",  finishTime: "04:01:44" },
-    { email: "aria.kapoor@startline.test",   eventId: "seed-event-022", result: "12th",  finishTime: null },
-    { email: "oscar.ngata@startline.test",   eventId: "seed-event-015", result: "5th",  finishTime: "06:12:03" },
-    { email: "oscar.ngata@startline.test",   eventId: "seed-event-044", result: "9th",  finishTime: "00:44:30" },
-    { email: "sophie.moreau@startline.test", eventId: "seed-event-008", result: "31st",  finishTime: "03:52:18" },
-    { email: "lucas.tan@startline.test",     eventId: "seed-event-026", result: "DNF",   finishTime: null },
-    { email: "lucas.tan@startline.test",     eventId: "seed-event-017", result: "66th",  finishTime: "02:41:55" },
+  const athleteHistory: { email: string; eventId: string; resultPlacement: string; resultTime: string | null }[] = [
+    { email: "harper.jones@startline.test",  eventId: "seed-event-005", resultPlacement: "43rd",  resultTime: "00:48:22" },
+    { email: "harper.jones@startline.test",  eventId: "seed-event-010", resultPlacement: "DNF",   resultTime: null },
+    { email: "mateo.silva@startline.test",   eventId: "seed-event-014", resultPlacement: "27th",  resultTime: "00:51:09" },
+    { email: "mateo.silva@startline.test",   eventId: "seed-event-017", resultPlacement: "DNF",   resultTime: null },
+    { email: "aria.kapoor@startline.test",   eventId: "seed-event-006", resultPlacement: "88th",  resultTime: "04:01:44" },
+    { email: "aria.kapoor@startline.test",   eventId: "seed-event-022", resultPlacement: "12th",  resultTime: null },
+    { email: "oscar.ngata@startline.test",   eventId: "seed-event-015", resultPlacement: "5th",  resultTime: "06:12:03" },
+    { email: "oscar.ngata@startline.test",   eventId: "seed-event-044", resultPlacement: "9th",  resultTime: "00:44:30" },
+    { email: "sophie.moreau@startline.test", eventId: "seed-event-008", resultPlacement: "31st",  resultTime: "03:52:18" },
+    { email: "lucas.tan@startline.test",     eventId: "seed-event-026", resultPlacement: "DNF",   resultTime: null },
+    { email: "lucas.tan@startline.test",     eventId: "seed-event-017", resultPlacement: "66th",  resultTime: "02:41:55" },
   ];
   let athleteHistoryCount = 0;
   for (let i = 0; i < athleteHistory.length; i++) {
@@ -923,8 +924,8 @@ async function main() {
         platformFeeCents: 0,
         feeStructure: "athlete",
         status: "CONFIRMED",
-        finishTime: ah.finishTime ?? null,
-        result: ah.result ?? null,
+        resultTime: ah.resultTime ?? null,
+        resultPlacement: ah.resultPlacement ?? null,
       },
     });
     athleteHistoryCount++;
@@ -1008,8 +1009,6 @@ async function main() {
           isTopResult: r.top,
           bibNumber: r.bib,
           userId: athleteUserId,
-          finishTime: r.time,
-          result: r.placement,
         },
         create: {
           id: r.id,
@@ -1029,8 +1028,6 @@ async function main() {
           resultPlacement: r.placement,
           isPersonalBest: r.pb,
           isTopResult: r.top,
-          finishTime: r.time,
-          result: r.placement,
         },
       });
     }


### PR DESCRIPTION
## Description

Fixes the gap in #201: the organiser race-day console (built under #45/#217) writes `resultTime`/`resultPlacement` on registrations, but the public profile race history read the legacy `finishTime`/`result` fields — so results an organiser entered never appeared on the athlete's `/profile`.

The organiser entry UI (dialog + CSV upload + validation) already existed; this PR wires the result to the display by unifying the profile read path onto the new fields.

## Changes

- **Profile read path** — `components/profile/UserProfileView.tsx`, `app/(user)/profile/[username]/page.tsx`, `app/api/user/profile/[username]/route.ts`, `app/api/user/profile/route.ts`: read `resultTime` / `resultPlacement` instead of legacy `finishTime` / `result`.
- **Seed** — `prisma/seed.ts`: write only the new result fields (no more double-write to legacy columns); add jade to the Apex Throwdown board as a profile-linked athlete for the e2e.
- **E2E** — new closed-loop test: organiser enters a result via the "After race" dialog, then it renders on the athlete's public profile.

## Out of scope (deliberately deferred)

- Athlete self-service result entry
- Placement format validation (free text)
- Edit-timing gate
- Dropping the legacy `finishTime`/`result`/`resultDistance` schema columns

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — 0 errors
- `pnpm test` — 229 passed
- `npx playwright test e2e/race-management.spec.ts` — 24 passed

Closes #201