### PR TITLE
feat(stripe): full Stripe E2E coverage in test mode (#253)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN_READONLY }}
           environment: staging
-          bootstrap-export-keys: "STRIPE_SECRET_KEY"
+          bootstrap-export-keys: "STRIPE_SECRET_KEY,STRIPE_WEBHOOK_SECRET"
       - name: Disable Turnstile for E2E
         shell: bash
         run: |

--- a/app/api/admin/registrations/[id]/refund/route.ts
+++ b/app/api/admin/registrations/[id]/refund/route.ts
@@ -32,9 +32,9 @@ export async function POST(
       return NextResponse.json({ error: "Registration not found." }, { status: 404 });
     }
 
-    if (registration.status !== "CONFIRMED") {
+    if (registration.status !== "CONFIRMED" && registration.status !== "REFUND_REQUESTED") {
       return NextResponse.json(
-        { error: "Only confirmed registrations can be refunded." },
+        { error: "Only confirmed or refund-requested registrations can be refunded." },
         { status: 409 },
       );
     }

--- a/e2e/stripe-lifecycle.spec.ts
+++ b/e2e/stripe-lifecycle.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from "@playwright/test";
+import Stripe from "stripe";
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { resolve } from "path";
+
+// The spec process does not auto-load .env.local (only `pnpm dev` does), so
+// pull in STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET / DATABASE_URL from it
+// unless they're already in the environment (CI exports them).
+if (!process.env.STRIPE_SECRET_KEY) {
+  try {
+    process.loadEnvFile(resolve(process.cwd(), ".env.local"));
+  } catch {
+    // .env.local missing (CI) — guard below will skip the suite.
+  }
+}
+
+/**
+ * Stripe lifecycle E2E — REAL test-mode Stripe, env-guarded.
+ *
+ * Covers checkout (via the real /api/checkout route, which the validation
+ * script bypasses) → card confirm → signed webhook → CONFIRMED registration →
+ * athlete refund-request → admin refund. Skips entirely when STRIPE_SECRET_KEY
+ * or STRIPE_WEBHOOK_SECRET is absent, mirroring the hasCognito guard in
+ * auth.spec.ts so CI without Stripe stays green.
+ *
+ * Prerequisites:
+ *   - The dev server must be running with STRIPE_SECRET_KEY and
+ *     STRIPE_WEBHOOK_SECRET in .env.local (pnpm dev loads it).
+ *   - The seed organiser sarah.mitchell@startline.test must be Stripe-onboarded
+ *     (run `pnpm stripe:setup` or scripts/setup-stripe-local.mjs first).
+ *   - Turnstile must be unconfigured (fails open) or the checkout route rejects.
+ *
+ * This spec creates its own fixture event, so it does not depend on the
+ * validation script having run.
+ */
+const hasStripe = !!process.env.STRIPE_SECRET_KEY && !!process.env.STRIPE_WEBHOOK_SECRET;
+
+const PRICE_CENTS = 13500;
+const FEE_PERCENT = 0.0395;
+const FEE_FIXED_CENTS = 145;
+const platformFee = (p: number) => Math.round(p * FEE_PERCENT) + FEE_FIXED_CENTS;
+
+const FIXTURE_EVENT_ID = "test-stripe-e2e-athlete";
+
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+});
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "sk_test_unset", {
+  apiVersion: "2026-05-27.dahlia",
+});
+
+async function ensureFixture(organiserId: string) {
+  const data = {
+    status: "APPROVED" as const,
+    title: "Stripe E2E Playwright fixture",
+    discipline: "crossfit",
+    eventDate: new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10),
+    startTime: "07:30",
+    endTime: "17:00",
+    venue: "Test Venue",
+    city: "Melbourne",
+    state: "vic",
+    format: "individual",
+    level: "open",
+    categories: ["Open"],
+    cap: null,
+    minAge: 16,
+    waves: [{ label: "General", price: (PRICE_CENTS / 100).toFixed(2) }],
+    registrationType: "startline",
+    feeStructure: "athlete",
+    photos: [],
+  };
+  const event = await prisma.event.upsert({
+    where: { id: FIXTURE_EVENT_ID },
+    update: data,
+    create: { id: FIXTURE_EVENT_ID, organiserId, ...data },
+  });
+  await prisma.registration.deleteMany({ where: { eventId: FIXTURE_EVENT_ID } });
+  return event;
+}
+
+async function getOrganiser() {
+  return prisma.organiser.findUnique({
+    where: { email: "sarah.mitchell@startline.test" },
+    select: { id: true, stripeAccountId: true, stripeOnboardingComplete: true },
+  });
+}
+
+async function postSignedWebhook(paymentIntent: Stripe.PaymentIntent) {
+  const payload = JSON.stringify({
+    id: `evt_test_${Date.now()}`,
+    object: "event",
+    api_version: "2026-05-27.dahlia",
+    created: Math.floor(Date.now() / 1000),
+    livemode: false,
+    pending_webhooks: 1,
+    request: { id: null, idempotency_key: null },
+    type: "payment_intent.succeeded",
+    data: { object: paymentIntent },
+  });
+  const signature = stripe.webhooks.generateTestHeaderString({
+    payload,
+    secret: process.env.STRIPE_WEBHOOK_SECRET!,
+  });
+  const res = await fetch("http://localhost:3000/api/stripe/webhook", {
+    method: "POST",
+    headers: { "content-type": "application/json", "stripe-signature": signature },
+    body: payload,
+  });
+  return res;
+}
+
+test.describe("stripe lifecycle (real test-mode Stripe)", () => {
+  test.skip(!hasStripe, "STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET not set — skipping real Stripe lifecycle");
+
+  test("checkout API → confirm card → webhook → CONFIRMED registration → refund", async ({ request }) => {
+    const organiser = await getOrganiser();
+    if (!organiser || !organiser.stripeAccountId || !organiser.stripeOnboardingComplete) {
+      test.skip(true, "Seed organiser is not Stripe-onboarded — run `pnpm stripe:setup` first");
+      return;
+    }
+    await ensureFixture(organiser.id);
+
+    // 1. Real /api/checkout route (bypass cookie gives jade.nguyen's session,
+    //    so the guest email-verify gate is skipped for that email).
+    const checkoutRes = await request.post("/api/checkout", {
+      headers: { Cookie: "__e2e_bypass=user" },
+      data: {
+        eventId: FIXTURE_EVENT_ID,
+        waveLabel: "General",
+        participants: [
+          {
+            firstName: "Jade",
+            lastName: "Nguyen",
+            dateOfBirth: "1990-01-01",
+            gender: "Female",
+            email: "jade.nguyen@startline.test",
+            mobile: "0400000000",
+            emergencyContactName: "Sam",
+            emergencyContactPhone: "0400000001",
+            medicalNotes: "",
+            estimatedFinish: "",
+            waiverAccepted: true,
+            waveLabel: "General",
+          },
+        ],
+      },
+    });
+    if (checkoutRes.status() === 400 && (await checkoutRes.text()).includes("human")) {
+      test.skip(true, "Turnstile is configured — checkout requires a real token");
+      return;
+    }
+    expect(checkoutRes.status()).toBe(200);
+    const checkout = await checkoutRes.json();
+    expect(checkout.paymentIntentId).toBeTruthy();
+
+    // 2. Assert the real PaymentIntent's Connect fields.
+    const fee = platformFee(PRICE_CENTS);
+    const pi = await stripe.paymentIntents.retrieve(checkout.paymentIntentId);
+    expect(pi.amount).toBe(PRICE_CENTS + fee);
+    expect(pi.application_fee_amount).toBe(fee);
+    expect(pi.transfer_data?.destination).toBe(organiser.stripeAccountId);
+
+    // 3. Confirm with a Stripe test card.
+    const confirmed = await stripe.paymentIntents.confirm(pi.id, { payment_method: "pm_card_visa" });
+    expect(confirmed.status).toBe("succeeded");
+
+    // 4. Signed webhook → CONFIRMED registration.
+    const retrieved = await stripe.paymentIntents.retrieve(pi.id);
+    const webhookRes = await postSignedWebhook(retrieved);
+    expect(webhookRes.status).toBe(200);
+
+    const registration = await prisma.registration.findFirst({
+      where: { stripePaymentIntentId: pi.id },
+    });
+    expect(registration).toBeTruthy();
+    expect(registration!.status).toBe("CONFIRMED");
+    expect(registration!.amountCents).toBe(PRICE_CENTS);
+    expect(registration!.platformFeeCents).toBe(fee);
+    expect(registration!.feeStructure).toBe("athlete");
+
+    // 5. Athlete refund-request (ownership: registration.userId links to the
+    //    jade.nguyen bypass session) → admin refund → REFUNDED + Stripe refund.
+    const reqRes = await request.post(`/api/user/registrations/${registration!.id}/refund-request`, {
+      headers: { Cookie: "__e2e_bypass=user" },
+    });
+    expect(reqRes.status()).toBe(200);
+
+    const refundRes = await request.post(`/api/admin/registrations/${registration!.id}/refund`, {
+      headers: { Cookie: "__e2e_bypass=admin" },
+    });
+    expect(refundRes.status()).toBe(200);
+    const refundBody = await refundRes.json();
+    expect(refundBody.refundId).toBeTruthy();
+
+    const refund = await stripe.refunds.retrieve(refundBody.refundId);
+    expect(refund.status).toBe("succeeded");
+
+    const after = await prisma.registration.findUnique({ where: { id: registration!.id } });
+    expect(after!.status).toBe("REFUNDED");
+  });
+});

--- a/openwiki/payments/index.md
+++ b/openwiki/payments/index.md
@@ -7,3 +7,4 @@ description: "Files and subdirectories in Payments."
 # Files
 
 - [Payments — Stripe Connect & Platform Fees](overview.md) - Stripe Connect Express integration for the Startline platform — organiser payouts, platform fee calculation, checkout flow, and capacity management.
+- [Stripe E2E & Lifecycle Validation](testing.md) - How to validate the full Stripe payment lifecycle in test mode — the validate-stripe-lifecycle script and the env-guarded Playwright spec.

--- a/openwiki/payments/testing.md
+++ b/openwiki/payments/testing.md
@@ -1,0 +1,92 @@
+---
+type: Reference
+title: Stripe E2E & Lifecycle Validation
+description: How to validate the full Stripe payment lifecycle in test mode — the validate-stripe-lifecycle script and the env-guarded Playwright spec.
+tags: [startline, payments, stripe, e2e, playwright, test-mode]
+---
+
+# Stripe E2E & Lifecycle Validation
+
+Issue #253 — prove the whole Stripe flow works end-to-end in **test mode**:
+checkout → card confirm → webhook → CONFIRMED registration → refund → payout.
+
+Two layers:
+
+1. `scripts/validate-stripe-lifecycle.mjs` — a runnable Node script that drives
+   every flow against real test-mode Stripe.
+2. `e2e/stripe-lifecycle.spec.ts` — a Playwright spec, env-guarded so CI without
+   Stripe keys stays green (mirrors the `hasCognito` guard in `auth.spec.ts`).
+
+## Env guard
+
+Every Stripe entry point refuses to run against a live key or with a missing
+key. Shared guards live in `scripts/lib/stripe-test.mjs`:
+
+| Guard | Behaviour |
+|---|---|
+| `assertTestKey()` | exits on missing / `sk_test_xxxxxxxx` / `sk_live_` key |
+| `assertWebhookSecret()` | exits when `STRIPE_WEBHOOK_SECRET` is absent |
+| `getStripe()` | `Stripe` client pinned to the repo API version |
+
+`scripts/setup-stripe-local.mjs` and `scripts/validate-stripe-connect.mjs` use
+the same guards.
+
+## Lifecycle script
+
+```bash
+pnpm stripe:setup     # onboard the seed organiser's Express account (once)
+pnpm dev              # webhook/refund/payout steps hit real HTTP routes
+pnpm stripe:lifecycle # charge → webhook → refund → payout, both fee structures
+```
+
+For each `feeStructure` ("athlete" and "organiser") it:
+
+1. Creates a PaymentIntent mirroring the checkout route and asserts
+   `amount` / `application_fee_amount` / `transfer_data.destination`
+2. Confirms with a Stripe test card and asserts `succeeded`
+3. Forges a **real signed** `payment_intent.succeeded` payload
+   (`stripe.webhooks.generateTestHeaderString`) and POSTs it to the running
+   `/api/stripe/webhook` — signature verification is exercised for real, no
+   Stripe CLI needed
+4. Asserts the CONFIRMED Registration rows: `amountCents`, `platformFeeCents`,
+   `feeStructure`
+5. Refund: athlete `refund-request` → admin `refund` → Stripe refund created +
+   registration `REFUNDED`
+6. Payout: admin-triggered payout against the connected Express account, asserts
+   `payoutTriggered` / `payoutAmountCents` / `payoutAt`, then asserts a retry
+   returns 409 with **no double-pay**
+
+Gated assertions (flip on once the fix lands):
+
+- `EXPECT_ORGANISER_NET=1` — hard-assert the organiser payout net equals
+  `Σ(amountCents − platformFeeCents)` instead of the current over-pay (issue
+  #251). Until then the organiser payout trigger is skipped because the current
+  `runPayoutForEvent` pays `Σ amountCents`, which exceeds the connected
+  account's balance after the platform fee was withheld — Stripe rejects it.
+
+## Playwright spec
+
+`e2e/stripe-lifecycle.spec.ts` skips entirely when `STRIPE_SECRET_KEY` or
+`STRIPE_WEBHOOK_SECRET` is absent. When present it drives the **real
+`/api/checkout` route** (which the script bypasses) through confirm → signed
+webhook → CONFIRMED → refund, using the `__e2e_bypass` cookies for the refund
+endpoints.
+
+Prerequisites to run it locally:
+
+- `.env.local` with `STRIPE_SECRET_KEY` + `STRIPE_WEBHOOK_SECRET` (test mode)
+- Seed organiser `sarah.mitchell@startline.test` Stripe-onboarded
+  (`pnpm stripe:setup`)
+- Turnstile unconfigured (fails open) or the checkout route rejects
+
+## CI
+
+The e2e workflow (`ci.yml`) exports `STRIPE_SECRET_KEY` + `STRIPE_WEBHOOK_SECRET`
+from the bootstrap secret. When they are absent the spec skips; when present the
+seed organiser is not onboarded in CI, so it also skips there — real-Stripe runs
+are a local/dev activity. The skip path keeps CI green either way.
+
+## Related
+
+- [Payments — Stripe Connect & Platform Fees](overview.md)
+- [Payments overview](index.md)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "prisma:seed": "npx tsx prisma/seed.ts",
     "stripe:listen": "stripe listen --forward-to localhost:3000/api/stripe/webhook",
     "stripe:setup": "node scripts/setup-stripe-local.mjs",
+    "stripe:validate": "node scripts/validate-stripe-connect.mjs",
+    "stripe:lifecycle": "node scripts/validate-stripe-lifecycle.mjs",
     "test:registration": "node scripts/test-registration-payment.mjs",
     "staging:db:start": "aws rds start-db-instance --db-instance-identifier startline-staging-postgres"
   },

--- a/scripts/lib/stripe-test.mjs
+++ b/scripts/lib/stripe-test.mjs
@@ -1,0 +1,50 @@
+/**
+ * Shared Stripe TEST-mode guards for the validation scripts.
+ *
+ * Every script that touches Stripe must refuse to run against a live key and
+ * fail fast when the key or webhook secret is missing, so nothing ever hits
+ * production with test tooling (or vice versa).
+ */
+import Stripe from "stripe";
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { loadEnv } from "./env.mjs";
+
+export const STRIPE_API_VERSION = "2026-05-27.dahlia";
+
+export function loadStripeEnv() {
+  loadEnv();
+  assertTestKey();
+}
+
+export function assertTestKey() {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key || key.includes("xxxxxxxx")) {
+    console.error("Set STRIPE_SECRET_KEY in .env.local to a Stripe TEST key (sk_test_...).");
+    process.exit(1);
+  }
+  if (key.startsWith("sk_live_")) {
+    console.error("Refusing to run against a LIVE Stripe key. Use a test key (sk_test_...).");
+    process.exit(1);
+  }
+  return key;
+}
+
+export function assertWebhookSecret() {
+  const secret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!secret) {
+    console.error(
+      "Set STRIPE_WEBHOOK_SECRET in .env.local (run `pnpm stripe:listen` once and copy the printed whsec_... value)."
+    );
+    process.exit(1);
+  }
+  return secret;
+}
+
+export function getStripe() {
+  return new Stripe(assertTestKey(), { apiVersion: STRIPE_API_VERSION });
+}
+
+export function getPrisma() {
+  return new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }) });
+}

--- a/scripts/setup-stripe-local.mjs
+++ b/scripts/setup-stripe-local.mjs
@@ -4,24 +4,16 @@
  *
  * Usage: node scripts/setup-stripe-local.mjs
  */
-import Stripe from "stripe";
-import { PrismaClient } from "@prisma/client";
-import { loadEnv } from "./lib/env.mjs";
+import { loadStripeEnv, assertTestKey, getStripe, getPrisma } from "./lib/stripe-test.mjs";
 
-loadEnv();
+loadStripeEnv();
 
 const ORGANISER_EMAIL = "organiser@startline.test";
 
 async function main() {
-  const secretKey = process.env.STRIPE_SECRET_KEY;
-  if (!secretKey || secretKey.includes("xxxxxxxx")) {
-    console.error("Set STRIPE_SECRET_KEY in .env.local to your Stripe test secret key (sk_test_...).");
-    console.error("Get keys from https://dashboard.stripe.com/test/apikeys");
-    process.exit(1);
-  }
-
-  const stripe = new Stripe(secretKey, { apiVersion: "2026-05-27.dahlia" });
-  const prisma = new PrismaClient();
+  assertTestKey();
+  const stripe = getStripe();
+  const prisma = getPrisma();
 
   try {
     const organiser = await prisma.organiser.findUnique({
@@ -68,7 +60,7 @@ async function main() {
     }
 
     await prisma.organiser.update({
-      where: { id: ORGANISER_ID },
+      where: { id: organiser.id },
       data: {
         stripeAccountId: accountId,
         stripeOnboardingComplete: chargesEnabled && payoutsEnabled,

--- a/scripts/validate-stripe-connect.mjs
+++ b/scripts/validate-stripe-connect.mjs
@@ -12,11 +12,9 @@
  * Usage: node scripts/validate-stripe-connect.mjs
  * Requires STRIPE_SECRET_KEY (sk_test_...) in .env.local
  */
-import Stripe from "stripe";
-import { PrismaClient } from "@prisma/client";
-import { loadEnv } from "./lib/env.mjs";
+import { loadStripeEnv, getStripe, getPrisma } from "./lib/stripe-test.mjs";
 
-loadEnv();
+loadStripeEnv();
 
 const ORGANISER_EMAIL = "organiser@startline.test";
 const TEST_PRICE_CENTS = 13500; // seed-event-001 Late Entry
@@ -30,18 +28,8 @@ function expectFee(expected, actual, label) {
 }
 
 async function main() {
-  const key = process.env.STRIPE_SECRET_KEY;
-  if (!key) {
-    console.error("Set STRIPE_SECRET_KEY in .env.local to a Stripe test key (sk_test_...).");
-    process.exit(1);
-  }
-  if (key.startsWith("sk_live_")) {
-    console.error("Refusing to run against a LIVE Stripe key. Use a test key (sk_test_...).");
-    process.exit(1);
-  }
-
-  const stripe = new Stripe(key, { apiVersion: "2026-05-27.dahlia" });
-  const prisma = new PrismaClient();
+  const stripe = getStripe();
+  const prisma = getPrisma();
 
   try {
     const organiser = await prisma.organiser.findUnique({

--- a/scripts/validate-stripe-lifecycle.mjs
+++ b/scripts/validate-stripe-lifecycle.mjs
@@ -1,0 +1,435 @@
+/**
+ * End-to-end validation of the full Stripe payment lifecycle (issue #253).
+ *
+ * Runs against Stripe TEST mode only — refuses to run with a live key. For
+ * each feeStructure variant ("athlete" and "organiser") it:
+ *   1. Creates a PaymentIntent mirroring the checkout route (Connect:
+ *      application_fee_amount + transfer_data.destination) and asserts the
+ *      amount / fee / destination fields
+ *   2. Confirms the payment with a Stripe test card and asserts status
+ *      "succeeded"
+ *   3. Forges a real signed payment_intent.succeeded webhook payload and POSTs
+ *      it to the running /api/stripe/webhook route, then asserts the CONFIRMED
+ *      Registration rows carry the correct amountCents / platformFeeCents /
+ *      feeStructure
+ *   4. Exercises the refund path: athlete refund-request → admin refund →
+ *      Stripe refund created + registration REFUNDED
+ *   5. Exercises the payout path: admin-triggered payout against the connected
+ *      Express account, asserts payoutTriggered / payoutAmountCents /
+ *      payoutAt, and asserts a retry returns 409 with no double-pay
+ *
+ * Prerequisites:
+ *   - STRIPE_SECRET_KEY + STRIPE_WEBHOOK_SECRET in .env.local (test mode)
+ *   - A running dev server (`pnpm dev`) — the webhook / refund / payout steps
+ *     hit real HTTP routes with the __e2e_bypass cookies
+ *
+ * Usage: node scripts/validate-stripe-lifecycle.mjs
+ *
+ * Gated assertions (flip on once the fixes land):
+ *   - EXPECT_ORGANISER_NET=1 → hard-assert the organiser payout net equals
+ *     Σ(amountCents − platformFeeCents) instead of the current over-pay (issue
+ *     #251)
+ */
+import {
+  loadStripeEnv,
+  assertTestKey,
+  assertWebhookSecret,
+  getStripe,
+  getPrisma,
+  STRIPE_API_VERSION,
+} from "./lib/stripe-test.mjs";
+
+loadStripeEnv();
+
+const ORGANISER_EMAIL = "sarah.mitchell@startline.test";
+const BASE = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+const PRICE_CENTS = 13500; // $135.00 General ticket on the fixture events
+const FEE_PERCENT = 0.0395;
+const FEE_FIXED_CENTS = 145;
+
+const expectOrganiserNet = process.env.EXPECT_ORGANISER_NET === "1";
+
+const ATHLETE_REFUND_EVENT = "test-stripe-athlete-refund";
+const ORGANISER_REFUND_EVENT = "test-stripe-organiser-refund";
+const ATHLETE_PAYOUT_EVENT = "test-stripe-athlete-payout";
+const ORGANISER_PAYOUT_EVENT = "test-stripe-organiser-payout";
+
+const platformFee = (priceCents) => Math.round(priceCents * FEE_PERCENT) + FEE_FIXED_CENTS;
+
+let failures = 0;
+const check = (label, ok, extra = "") => {
+  console.log(`  ${ok ? "PASS" : "FAIL"} ${label}${extra ? ` — ${extra}` : ""}`);
+  if (!ok) failures += 1;
+};
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function fixtureEvent(feeStructure, date, payout) {
+  const wave = { label: "General", price: (PRICE_CENTS / 100).toFixed(2) };
+  return {
+    status: "APPROVED",
+    title: `Stripe E2E ${feeStructure} ${payout ? "payout" : "refund"} fixture`,
+    discipline: "crossfit",
+    eventDate: date,
+    startTime: "07:30",
+    endTime: "17:00",
+    venue: "Test Venue",
+    city: "Melbourne",
+    state: "vic",
+    format: "individual",
+    level: "open",
+    categories: ["Open"],
+    cap: null,
+    minAge: 16,
+    waves: [wave],
+    registrationType: "startline",
+    feeStructure,
+    photos: [],
+  };
+}
+
+function tomorrow() {
+  return new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10);
+}
+
+function daysAgo(n) {
+  return new Date(Date.now() - n * 86400000).toISOString().slice(0, 10);
+}
+
+async function ensureFixtureEvents(prisma, organiserId) {
+  const upsert = (id, data) =>
+    prisma.event.upsert({ where: { id }, update: data, create: { id, organiserId, ...data } });
+  const refundAthlete = await upsert(ATHLETE_REFUND_EVENT, fixtureEvent("athlete", tomorrow(), false));
+  const refundOrganiser = await upsert(ORGANISER_REFUND_EVENT, fixtureEvent("organiser", tomorrow(), false));
+  const payoutAthlete = await upsert(ATHLETE_PAYOUT_EVENT, fixtureEvent("athlete", daysAgo(30), true));
+  const payoutOrganiser = await upsert(ORGANISER_PAYOUT_EVENT, fixtureEvent("organiser", daysAgo(30), true));
+  return { refundAthlete, refundOrganiser, payoutAthlete, payoutOrganiser };
+}
+
+async function resetFixtures(prisma) {
+  const ids = [ATHLETE_REFUND_EVENT, ORGANISER_REFUND_EVENT, ATHLETE_PAYOUT_EVENT, ORGANISER_PAYOUT_EVENT];
+  await prisma.registration.deleteMany({ where: { eventId: { in: ids } } });
+  await prisma.event.updateMany({
+    where: { id: { in: [ATHLETE_PAYOUT_EVENT, ORGANISER_PAYOUT_EVENT] } },
+    data: { payoutTriggered: false, payoutAmountCents: null, payoutAt: null },
+  });
+}
+
+async function ensureConnectAccount(stripe, prisma) {
+  const organiser = await prisma.organiser.findUnique({
+    where: { email: ORGANISER_EMAIL },
+    select: { id: true, stripeAccountId: true, stripeOnboardingComplete: true },
+  });
+  if (!organiser) {
+    console.error(`Organiser ${ORGANISER_EMAIL} not found. Run the seed first.`);
+    process.exit(1);
+  }
+
+  let accountId = organiser.stripeAccountId;
+  if (!accountId) {
+    console.log("  No account linked — creating a test Express account…");
+    const account = await stripe.accounts.create({
+      type: "express",
+      country: "AU",
+      email: ORGANISER_EMAIL,
+      capabilities: { card_payments: { requested: true }, transfers: { requested: true } },
+      business_type: "individual",
+      settings: { payouts: { schedule: { interval: "manual" } } },
+    });
+    accountId = account.id;
+    await stripe.accounts.update(accountId, {
+      tos_acceptance: { date: Math.floor(Date.now() / 1000), ip: "127.0.0.1" },
+    });
+    await prisma.organiser.update({
+      where: { id: organiser.id },
+      data: { stripeAccountId: accountId, stripeOnboardingComplete: true },
+    });
+    console.log(`  Created ${accountId}`);
+  }
+
+  const connected = await stripe.accounts.retrieve(accountId);
+  const chargesEnabled = connected.charges_enabled ?? false;
+  const payoutsEnabled = connected.payouts_enabled ?? false;
+  console.log(`  charges_enabled: ${chargesEnabled}, payouts_enabled: ${payoutsEnabled}`);
+  if (!chargesEnabled || !payoutsEnabled) {
+    console.error("  Connect account is not fully onboarded — run scripts/setup-stripe-local.mjs or finish onboarding.");
+    process.exit(1);
+  }
+  return { accountId, organiserId: organiser.id };
+}
+
+function buildPaymentIntentArgs({ feeStructure, accountId, organiserId, eventId, priceCents, athleteEmail, athleteName }) {
+  const fee = platformFee(priceCents);
+  const amount = feeStructure === "athlete" ? priceCents + fee : priceCents;
+  return {
+    amount,
+    currency: "aud",
+    payment_method_types: ["card"],
+    application_fee_amount: fee,
+    transfer_data: { destination: accountId },
+    metadata: {
+      eventId,
+      waveLabel: "General",
+      wavePricing: JSON.stringify({ General: { p: priceCents, f: fee } }),
+      userName: athleteName,
+      userEmail: athleteEmail,
+      organiserId,
+      userId: "",
+      ticketPriceCents: String(priceCents),
+      platformFeeCents: String(fee),
+      platformFeeCentsPerTicket: String(fee),
+      feeStructure,
+      groupRegistration: "false",
+      participantCount: "1",
+      participant0: JSON.stringify({
+        fn: athleteName.split(" ")[0] ?? "Stripe",
+        ln: athleteName.split(" ").slice(1).join(" ") || "E2E",
+        dob: "1990-01-01",
+        gen: "Female",
+        em: athleteEmail,
+        mob: "0400000000",
+        ecn: "Sam",
+        ecp: "0400000001",
+        wav: "General",
+      }),
+    },
+  };
+}
+
+/** POST /api/stripe/webhook with a real signed payload (no Stripe CLI needed). */
+async function deliverSignedWebhook(stripe, webhookSecret, paymentIntent) {
+  const payload = JSON.stringify({
+    id: `evt_test_${Date.now()}`,
+    object: "event",
+    api_version: STRIPE_API_VERSION,
+    created: Math.floor(Date.now() / 1000),
+    livemode: false,
+    pending_webhooks: 1,
+    request: { id: null, idempotency_key: null },
+    type: "payment_intent.succeeded",
+    data: { object: paymentIntent },
+  });
+  const signature = stripe.webhooks.generateTestHeaderString({ payload, secret: webhookSecret });
+  const res = await fetch(`${BASE}/api/stripe/webhook`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "stripe-signature": signature },
+    body: payload,
+  });
+  return res;
+}
+
+async function waitForRegistration(prisma, paymentIntentId, timeoutMs = 15000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const reg = await prisma.registration.findFirst({
+      where: { stripePaymentIntentId: paymentIntentId },
+    });
+    if (reg) return reg;
+    await sleep(500);
+  }
+  return null;
+}
+
+async function postWithBypass(path, cookie, body) {
+  return fetch(`${BASE}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: `__e2e_bypass=${cookie}`,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function waitForConnectedBalance(stripe, accountId, minCents, timeoutMs = 25000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const balance = await stripe.balance.retrieve({ stripeAccount: accountId });
+    const available = balance.available.reduce((sum, b) => sum + b.amount, 0);
+    if (available >= minCents) return available;
+    await sleep(2000);
+  }
+  throw new Error(`Connected account balance never reached ${minCents} cents in ${timeoutMs}ms`);
+}
+
+/**
+ * Checkout → confirm → webhook → CONFIRMED registration. Returns the
+ * registration, paymentIntent, and the expected cents.
+ */
+async function runChargeFlow({ stripe, prisma, webhookSecret, feeStructure, eventId, accountId, organiserId, athleteEmail, athleteName }) {
+  const fee = platformFee(PRICE_CENTS);
+  const expectedTotal = feeStructure === "athlete" ? PRICE_CENTS + fee : PRICE_CENTS;
+
+  console.log(`\n  Create PaymentIntent (feeStructure=${feeStructure})`);
+  const pi = await stripe.paymentIntents.create(
+    buildPaymentIntentArgs({ feeStructure, accountId, organiserId, eventId, priceCents: PRICE_CENTS, athleteEmail, athleteName })
+  );
+  check(`amount = ${expectedTotal}`, pi.amount === expectedTotal, `got ${pi.amount}`);
+  check(`application_fee_amount = ${fee}`, pi.application_fee_amount === fee, `got ${pi.application_fee_amount}`);
+  check(
+    `transfer_data.destination = connected account`,
+    pi.transfer_data?.destination === accountId,
+    `got ${pi.transfer_data?.destination}`
+  );
+
+  const confirmed = await stripe.paymentIntents.confirm(pi.id, { payment_method: "pm_card_visa" });
+  check("card confirmation status = succeeded", confirmed.status === "succeeded", `got ${confirmed.status}`);
+  if (confirmed.status !== "succeeded") return null;
+
+  const retrieved = await stripe.paymentIntents.retrieve(pi.id);
+  const res = await deliverSignedWebhook(stripe, webhookSecret, retrieved);
+  check("webhook POST accepted", res.status === 200, `got ${res.status}`);
+
+  const registration = await waitForRegistration(prisma, pi.id);
+  if (!registration) {
+    check("registration created via webhook", false, "not found within timeout");
+    return null;
+  }
+  check("registration status = CONFIRMED", registration.status === "CONFIRMED", `got ${registration.status}`);
+  check("registration amountCents", registration.amountCents === PRICE_CENTS, `got ${registration.amountCents}`);
+  check("registration platformFeeCents", registration.platformFeeCents === fee, `got ${registration.platformFeeCents}`);
+  check("registration feeStructure", registration.feeStructure === feeStructure, `got ${registration.feeStructure}`);
+
+  return { registration, paymentIntent: retrieved, expectedTotal };
+}
+
+async function runRefundFlow({ stripe, registration }) {
+  console.log("\n  Refund (athlete refund-request → admin refund)");
+  const reqRes = await postWithBypass(`/api/user/registrations/${registration.id}/refund-request`, "user");
+  const reqBody = await reqRes.json().catch(() => ({}));
+  check(
+    "athlete refund-request accepted",
+    reqRes.status === 200 && reqBody.status === "REFUND_REQUESTED",
+    `got ${reqRes.status} ${JSON.stringify(reqBody)}`
+  );
+
+  const refundRes = await postWithBypass(`/api/admin/registrations/${registration.id}/refund`, "admin");
+  const refundBody = await refundRes.json().catch(() => ({}));
+  check(
+    "admin refund accepted",
+    refundRes.status === 200 && refundBody.refundId,
+    `got ${refundRes.status} ${JSON.stringify(refundBody)}`
+  );
+  if (!refundBody.refundId) return;
+
+  const refund = await stripe.refunds.retrieve(refundBody.refundId);
+  check("Stripe refund created", Boolean(refund.id), refund.id);
+  check("Stripe refund status = succeeded", refund.status === "succeeded", `got ${refund.status}`);
+
+  const after = await prisma.registration.findUnique({ where: { id: registration.id } });
+  check("registration status = REFUNDED", after?.status === "REFUNDED", `got ${after?.status}`);
+}
+
+async function runPayoutFlow({ stripe, prisma, eventId, feeStructure, accountId, organiserId, webhookSecret, runPayout }) {
+  console.log("\n  Payout (admin-triggered, post-event)");
+
+  const flow = await runChargeFlow({
+    stripe,
+    prisma,
+    webhookSecret,
+    feeStructure,
+    eventId,
+    accountId,
+    organiserId,
+    athleteEmail: "stripe-e2e@startline.test",
+    athleteName: "Stripe E2E Athlete",
+  });
+  if (!flow) return;
+
+  const fee = platformFee(PRICE_CENTS);
+  const expectedNet = feeStructure === "athlete" ? PRICE_CENTS : PRICE_CENTS - fee; // #251-correct net
+
+  if (!runPayout) {
+    console.log(
+      `  WARN #251: skipping the admin payout trigger for feeStructure "organiser" — ` +
+        `runPayoutForEvent pays Σ amountCents (${PRICE_CENTS}) but the connected account only holds ` +
+        `${expectedNet} after the platform fee, so Stripe rejects the payout. Once #251 lands, set ` +
+        `EXPECT_ORGANISER_NET=1 to run it and assert the corrected net.`
+    );
+    return;
+  }
+
+  await waitForConnectedBalance(stripe, accountId, expectedNet);
+
+  const res = await postWithBypass("/api/admin/payouts", "admin", { eventId });
+  const body = await res.json().catch(() => ({}));
+  check("admin payout triggered", res.status === 200 && body.ok === true, `got ${res.status} ${JSON.stringify(body)}`);
+
+  const event = await prisma.event.findUnique({ where: { id: eventId } });
+  check("payoutTriggered = true", event?.payoutTriggered === true, `got ${event?.payoutTriggered}`);
+  check("payoutAt set", Boolean(event?.payoutAt));
+  check(
+    "payoutAmountCents = Σ(amountCents − platformFeeCents)",
+    event?.payoutAmountCents === expectedNet,
+    `got ${event?.payoutAmountCents}, expected ${expectedNet}`
+  );
+
+  // No double-pay: the second POST must be rejected (409) and no new Stripe
+  // payout object may appear after the first succeeded.
+  const payoutsAfterFirst = await stripe.payouts.list({ limit: 100 }, { stripeAccount: accountId });
+  const retry = await postWithBypass("/api/admin/payouts", "admin", { eventId });
+  check("retry payout rejected (no double-pay)", retry.status === 409, `got ${retry.status}`);
+  const payoutsAfterRetry = await stripe.payouts.list({ limit: 100 }, { stripeAccount: accountId });
+  check(
+    "no new Stripe payout on retry",
+    payoutsAfterRetry.data.length === payoutsAfterFirst.data.length,
+    `${payoutsAfterFirst.data.length} → ${payoutsAfterRetry.data.length}`
+  );
+}
+
+async function main() {
+  assertTestKey();
+  const webhookSecret = assertWebhookSecret();
+  const stripe = getStripe();
+  const prisma = getPrisma();
+
+  try {
+    console.log("0. Connected Express account");
+    const { accountId, organiserId } = await ensureConnectAccount(stripe, prisma);
+
+    console.log("\n1. Fixture events");
+    await resetFixtures(prisma);
+    const fixtures = await ensureFixtureEvents(prisma, organiserId);
+    console.log(
+      `  ${fixtures.refundAthlete.id}, ${fixtures.refundOrganiser.id}, ` +
+      `${fixtures.payoutAthlete.id}, ${fixtures.payoutOrganiser.id}`
+    );
+
+    for (const feeStructure of ["athlete", "organiser"]) {
+      console.log(`\n=== feeStructure: "${feeStructure}" ===`);
+
+      console.log("\n-- Refund lifecycle --");
+      const refundEventId = feeStructure === "athlete" ? ATHLETE_REFUND_EVENT : ORGANISER_REFUND_EVENT;
+      const refundFlow = await runChargeFlow({
+        stripe, prisma, webhookSecret, feeStructure,
+        eventId: refundEventId, accountId, organiserId,
+        athleteEmail: "jade.nguyen@startline.test",
+        athleteName: "Jade Nguyen",
+      });
+      if (refundFlow) {
+        await runRefundFlow({ stripe, registration: refundFlow.registration });
+        // Reset so the payout loop's charge flow starts clean.
+        await resetFixtures(prisma);
+      }
+
+      console.log("\n-- Payout lifecycle --");
+      const payoutEventId = feeStructure === "athlete" ? ATHLETE_PAYOUT_EVENT : ORGANISER_PAYOUT_EVENT;
+      await runPayoutFlow({
+        stripe, prisma, webhookSecret, feeStructure,
+        eventId: payoutEventId, accountId, organiserId,
+        runPayout: feeStructure === "athlete" || expectOrganiserNet,
+      });
+      await resetFixtures(prisma);
+    }
+
+    console.log(failures === 0 ? "\n✓ Stripe lifecycle validation complete." : `\n✗ ${failures} assertion(s) failed.`);
+    if (failures > 0) process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #253

## Description

Full Stripe payment-path E2E coverage in **test mode only**, as the MVP tracking issue for the Stripe flow.

### What changed

**New lifecycle validation script — `scripts/validate-stripe-lifecycle.mjs`**
Runs the whole flow for both `feeStructure` variants (`athlete`, `organiser`):
1. Checkout — PaymentIntent with correct `amount`, `application_fee_amount`, `transfer_data.destination` (Connect)
2. Card payment — confirm with a Stripe test card, assert `succeeded`
3. Webhook — **real signed** `payment_intent.succeeded` payload via `generateTestHeaderString` posted to the running `/api/stripe/webhook`, then asserts `CONFIRMED` registrations carry the correct `amountCents` / `platformFeeCents` / `feeStructure`
4. Refund — athlete `refund-request` → admin refund → Stripe refund created + registration `REFUNDED`
5. Payout — admin-triggered against the connected Express account; asserts `payoutTriggered` / `payoutAmountCents` / `payoutAt` and that a retry returns 409 with **no double-pay**

**Env-guarded Playwright spec — `e2e/stripe-lifecycle.spec.ts`**
Skips entirely when `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` are absent (mirrors the `hasCognito` guard in `auth.spec.ts`), so CI stays green without keys. Drives the **real `/api/checkout` route** (which the script bypasses) through confirm → signed webhook → CONFIRMED → refund, using the `__e2e_bypass` cookies.

**Shared test-mode guards — `scripts/lib/stripe-test.mjs`**
`assertTestKey()` refuses `sk_live_` / missing keys, `assertWebhookSecret()`, `getStripe()`, `getPrisma()` (Prisma 7 adapter). Refactored `validate-stripe-connect.mjs` + `setup-stripe-local.mjs` to use them (and fixed a latent `ORGANISER_ID` bug in the latter).

**Bug fix — admin refund route**
`app/api/admin/registrations/[id]/refund` now accepts `REFUND_REQUESTED` status (previously only `CONFIRMED`), so the athlete refund-request → admin refund path actually completes.

**CI + docs**
- `ci.yml` exports `STRIPE_WEBHOOK_SECRET` alongside `STRIPE_SECRET_KEY`
- `openwiki/payments/testing.md` documents how to run locally + the CI env guard

### Gated on #251 / #252 (harness-first sequencing)
- Organiser payout net is asserted as `Σ(amountCents − platformFeeCents)` once `EXPECT_ORGANISER_NET=1` is set — until #251 lands the organiser payout trigger is skipped with a WARN (the current `runPayoutForEvent` pays `Σ amountCents`, which exceeds the connected account's balance after the platform fee is withheld)
- Retry/no-double-pay is asserted against current behaviour and stays valid after #252

### Verification
- `pnpm lint` — 0 errors / 0 warnings
- `pnpm typecheck` — 0 errors
- `pnpm test` — 242 passed
- Playwright discovers 185 tests; the new spec is discovered and skips cleanly without Stripe keys
- All scripts pass `node --check`

Related: #116, #209, #210, #251, #252
