### PR TITLE
fix(upload): enforce per-type MIME allowlist server-side

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -29,23 +29,16 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid upload type." }, { status: 400 });
   }
 
-  const allowed = [
-    "image/jpeg",
-    "image/png",
-    "image/webp",
-    "image/gif",
-    "video/mp4",
-    "video/webm",
-    "video/quicktime",
-    "video/avi",
-    "video/ogg",
-    "application/pdf",
-  ];
-  if (!allowed.includes(file.type)) {
-    return NextResponse.json({ error: "File type not allowed." }, { status: 400 });
-  }
-  if (type === "document" && file.type !== "application/pdf") {
-    return NextResponse.json({ error: "Documents must be PDF." }, { status: 400 });
+  const TYPE_MIMES: Record<string, string[]> = {
+    logo: ["image/jpeg", "image/png", "image/webp", "image/gif"],
+    cover: ["image/jpeg", "image/png", "image/webp", "image/gif"],
+    photo: ["image/jpeg", "image/png", "image/webp", "image/gif"],
+    avatar: ["image/jpeg", "image/png", "image/webp", "image/gif"],
+    video: ["video/mp4", "video/webm", "video/quicktime", "video/avi", "video/ogg"],
+    document: ["application/pdf"],
+  };
+  if (!TYPE_MIMES[type]?.includes(file.type)) {
+    return NextResponse.json({ error: "File type not allowed for this upload." }, { status: 400 });
   }
   if (type === "document" && file.size > 15 * 1024 * 1024) {
     return NextResponse.json({ error: "PDF must be 15 MB or smaller." }, { status: 400 });


### PR DESCRIPTION
## Summary

Server-side upload route previously used a single flat MIME allowlist shared across all upload `type` values. A client could send `type=photo` (or `cover`/`logo`/`avatar`) with a video file — or `type=document` logic was the only special case — and pass the type gate.

Now each upload type maps to its own allowlist:

- `logo`/`cover`/`photo`/`avatar` → images only (JPEG/PNG/WEBP/GIF)
- `video` → video only (mp4/webm/mov/avi/ogg)
- `document` → PDF only (`application/pdf`) + existing 15 MB cap

## Motivation

Client-side `accept="image/*"`/`accept="application/pdf"` was already restricting the pickers, but the API accepted any allowlisted MIME for any type. This closes the gap so a video can't be stored under a `photo` type.

Magic-byte content verification (`lib/upload-magic-bytes.ts`) was already in place and unchanged — it still backstops every upload by sniffing actual bytes against the declared MIME.

## Changes

- `app/api/upload/route.ts`: replace flat `allowed` array + `document`→PDF special case with a per-type `TYPE_MIMES` map.

## Verification

- `pnpm lint` passes.
- Typecheck is currently blocked repo-wide in this worktree by missing `DATABASE_URL` (Prisma client not generated) — pre-existing, unrelated to this change. The modified file introduces no new type errors.

## Notes

- Kept GIF in the image set (unchanged behaviour). Say the word if photos should drop GIF.