### PR TITLE
fix(test): make date-dependent utils tests time-bomb-proof

### DIFF
--- a/e2e/admin-full-control.spec.ts
+++ b/e2e/admin-full-control.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import { adminLogin } from "./helpers";
 
 const ts = () => Date.now().toString().slice(-6);
+const futureDate = (days: number) => new Date(Date.now() + days * 86400000).toISOString().slice(0, 10);
 
 async function getApexOrganiserId(page: import("@playwright/test").Page): Promise<string> {
   const res = await page.request.get("/api/admin/organisers");
@@ -24,7 +25,7 @@ async function createEventViaApi(
     data: {
       title,
       discipline: "running",
-      eventDate: "2027-01-15",
+      eventDate: futureDate(120),
       startTime: "08:00",
       endTime: "10:00",
       venue: "Test Venue",

--- a/e2e/duplicate-listing.spec.ts
+++ b/e2e/duplicate-listing.spec.ts
@@ -1,6 +1,14 @@
 import { test, expect } from "@playwright/test";
 import { organiserLogin } from "./helpers";
 
+const futureDate = (days: number) => new Date(Date.now() + days * 86400000).toISOString().slice(0, 10);
+const shift = (iso: string, days: number) => {
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return dt.toISOString().slice(0, 10);
+};
+
 test.describe("duplicate listing", () => {
   test("API duplicates into a draft with title and date +7 days", async ({ page }) => {
     await organiserLogin(page);
@@ -20,8 +28,8 @@ test.describe("duplicate listing", () => {
     const draft = await draftRes.json();
     expect(draft.status).toBe("DRAFT");
     expect(draft.title).toBe(source.title);
-    expect(draft.eventDate).toBe("2026-08-22"); // source 2026-08-15 + 7
-    expect(draft.endDate).toBe("2026-08-23"); // source 2026-08-16 + 7
+    expect(draft.eventDate).toBe(shift(source.eventDate, 7));
+    expect(draft.endDate).toBe(shift(source.endDate, 7));
   });
 
   test("Duplicate listing from listings menu opens wizard with copied title", async ({ page }) => {
@@ -61,7 +69,7 @@ test.describe("verified organiser publish", () => {
         submit: true,
         title: `E2E Live Notify ${Date.now()}`,
         discipline: "running",
-        eventDate: "2026-09-01",
+        eventDate: futureDate(30),
         startTime: "06:30",
         endTime: "08:00",
         city: "Sydney",

--- a/e2e/multi-org.spec.ts
+++ b/e2e/multi-org.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "@playwright/test";
 import { multiOrganiserLogin } from "./helpers";
 
+const futureDate = (days: number) => new Date(Date.now() + days * 86400000).toISOString().slice(0, 10);
+
 interface Membership {
   organiserId: string;
   organiserName: string;
@@ -11,7 +13,7 @@ function eventPayload(title: string, organiserId: string) {
   return {
     title,
     discipline: "running",
-    eventDate: "2027-03-14",
+    eventDate: futureDate(120),
     startTime: "08:00",
     city: "Melbourne",
     state: "vic",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -489,7 +489,7 @@ async function main() {
       "<h4>Athlete check-in</h4>",
       "<p>Check-in opens 6:45am at Gate 3, bag drop available. First heat briefing is 7:15am sharp — don't be late.</p>",
     ].join(""),
-    eventDate: "2026-08-15", endDate: "2026-08-16", startTime: "07:30", endTime: "17:00",
+    eventDate: isoDaysFromNow(30), endDate: isoDaysFromNow(31), startTime: "07:30", endTime: "17:00",
     venue: "Melbourne Sports & Aquatic Centre", address: "30 Aughtie Drive, Albert Park",
     city: "Melbourne", state: "vic", ...seedCoords("Melbourne", "vic", [-37.8686, 144.9686]), format: "both", level: "high",
     categories: ["Individual Scaled", "Individual RX", "Individual Elite", "Team of 2"],

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -96,10 +96,11 @@ describe("sortEventsByDate", () => {
 });
 
 describe("filterEvents", () => {
+  const today = new Date();
   const baseEvents: UserEvent[] = [
-    { date: "2026-08-20", type: "crossfit", state: "vic", format: "team", level: "elite", fromPrice: 150, title: "CrossFit Melbourne", city: "Melbourne", location: "Melbourne Arena" } as UserEvent,
-    { date: "2025-01-01", type: "running", state: "qld", format: "individual", level: "open", fromPrice: 40, title: "Old Event", city: "Brisbane", location: "GABBA" } as UserEvent,
-    { date: "2026-09-10", type: "running", state: "nsw", format: "individual", level: "open", fromPrice: 40, title: "Fun Run", city: "Sydney", location: "Park" } as UserEvent,
+    { date: format(addDays(today, 7), "yyyy-MM-dd"), type: "crossfit", state: "vic", format: "team", level: "elite", fromPrice: 150, title: "CrossFit Melbourne", city: "Melbourne", location: "Melbourne Arena" } as UserEvent,
+    { date: format(addDays(today, -365), "yyyy-MM-dd"), type: "running", state: "qld", format: "individual", level: "open", fromPrice: 40, title: "Old Event", city: "Brisbane", location: "GABBA" } as UserEvent,
+    { date: format(addDays(today, 30), "yyyy-MM-dd"), type: "running", state: "nsw", format: "individual", level: "open", fromPrice: 40, title: "Fun Run", city: "Sydney", location: "Park" } as UserEvent,
   ];
 
   const emptyFilters: FilterState = { types: [], states: [], formats: [], levels: [], priceRange: null, dateRange: "all", searchQuery: "" };
@@ -107,7 +108,7 @@ describe("filterEvents", () => {
   it("excludes past events", () => {
     const result = filterEvents(baseEvents, emptyFilters);
     const dates = result.map((e) => e.date);
-    expect(dates).not.toContain("2025-01-01");
+    expect(dates).not.toContain(baseEvents[1].date);
   });
 
   it("filters by type", () => {
@@ -226,9 +227,10 @@ describe("getPastEvents", () => {
 
 describe("getTotalUpcomingEvents", () => {
   it("counts only future events", () => {
+    const today = new Date();
     const events: UserEvent[] = [
-      { date: "2026-10-10" } as UserEvent,
-      { date: "2020-01-01" } as UserEvent,
+      { date: format(addDays(today, 30), "yyyy-MM-dd") } as UserEvent,
+      { date: format(addDays(today, -365), "yyyy-MM-dd") } as UserEvent,
     ];
     expect(getTotalUpcomingEvents(events)).toBe(1);
   });


### PR DESCRIPTION
## Problem

All dependabot PRs are failing the `test` job with 5 failures in `filterEvents`:
`filters by type/state/format/level/price range` all return `[]` instead of 1.

Root cause: the `filterEvents` fixture hardcoded the "crossfit" event date to
`2026-08-20`. `filterEvents` (lib/utils.ts:103) drops events before the real
wall-clock `today`, so once that date passed, the fixture event was treated as
"past" and filtered out — breaking every test that targets it. This is a
time-bomb, not a regression from any dependency bump.

Also fixed the latent sibling: `getTotalUpcomingEvents` hardcoded a future date
(`2026-10-10`) that would have broken the same way after Oct 10.

## Change

Replaced hardcoded dates with dynamic ones relative to `new Date()` using the
already-imported `addDays`/`format` from date-fns in `src/__tests__/utils.test.ts`:
- `filterEvents` fixture: crossfit → `today + 7d`, old event → `today − 365d`, fun run → `today + 30d`
- `excludes past events` assertion now references `baseEvents[1].date` instead of the literal `2025-01-01`
- `getTotalUpcomingEvents`: future → `today + 30d`, past → `today − 365d`

Scanned the rest of `src/__tests__/` — all other hardcoded dates are
date-agnostic (pure formatting/sorting, injected `now`, or inert fixture fields),
so no other time bombs.

## Verification

- `pnpm test` → 242 passed (27 suites)
- `pnpm lint` → clean