### PR TITLE
fix: spam note, reset-password error, back button, price slider (#274)

### DIFF
--- a/app/(user)/auth/forgot-password/page.tsx
+++ b/app/(user)/auth/forgot-password/page.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Mail, Lock, Eye, EyeOff, ArrowRight, KeyRound } from "lucide-react";
 import { resetPassword, confirmResetPassword } from "aws-amplify/auth";
+import { mapResetPasswordError } from "@/lib/auth-errors";
 
 type Step = "request" | "confirm";
 
@@ -52,15 +53,7 @@ function ForgotPasswordForm() {
       router.push("/?reset=1");
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "";
-      if (msg.includes("CodeMismatchException")) {
-        setError("That code is incorrect. Please check and try again.");
-      } else if (msg.includes("ExpiredCodeException")) {
-        setError("That code has expired. Go back and request a new one.");
-      } else if (msg.includes("InvalidPasswordException")) {
-        setError("Password must be at least 8 characters with upper, lower and a number.");
-      } else {
-        setError("Could not reset your password. Please try again.");
-      }
+      setError(mapResetPasswordError(msg));
     } finally {
       setLoading(false);
     }
@@ -115,6 +108,9 @@ function ForgotPasswordForm() {
             </h1>
             <p className="text-muted text-[15px] leading-relaxed mb-8 text-center">
               Check <strong className="text-light">{email}</strong> for your 6-digit code, then choose a new password.
+            </p>
+            <p className="text-muted text-[13px] leading-relaxed mb-8 text-center mt-1">
+              Can&apos;t see it? Check your spam or junk folder.
             </p>
 
             {error && (

--- a/app/(user)/auth/verify-email/page.tsx
+++ b/app/(user)/auth/verify-email/page.tsx
@@ -148,6 +148,9 @@ function VerifyEmailForm() {
               {email ? <strong className="text-light">{email}</strong> : "your email"}.
               Enter it below to activate your account.
             </p>
+            <p className="text-muted text-[13px] leading-relaxed mb-6 text-center mt-1">
+              Can&apos;t see it? Check your spam or junk folder.
+            </p>
             {error && (
               <div className="mb-5 px-4 py-3 rounded-md bg-red-900/20 border border-red-500/30 text-red-400 font-headline text-[13px]">
                 {error}

--- a/app/(user)/events/[id]/page.tsx
+++ b/app/(user)/events/[id]/page.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import type { Metadata } from "next";
-import { MapPin, Calendar, ExternalLink, Trophy, Clock, Ticket, FileText } from "lucide-react";
+import { MapPin, Calendar, ExternalLink, Trophy, Clock, Ticket, FileText, ArrowLeft } from "lucide-react";
 import { getAllEvents, getPublicEventById } from "@/lib/events";
 import { todayIso } from "@/lib/event-types";
 import { parsePrizePool } from "@/lib/prize-pool";
@@ -133,9 +133,9 @@ export default async function EventDetailPage({ params }: { params: Promise<{ id
       <section className="max-w-[1440px] mx-auto px-4 sm:px-6 py-6 sm:py-8">
         <Link
           href="/events"
-          className="inline-flex items-center gap-2 font-headline text-xs font-medium uppercase tracking-widest text-muted hover:text-primary transition-colors mb-6"
+          className="inline-flex items-center gap-2 font-headline text-xs font-bold uppercase tracking-widest border border-dark-lighter text-light hover:border-primary hover:text-primary px-4 py-2 rounded-full transition-colors mb-6"
         >
-          &larr; Back to Events
+          <ArrowLeft className="w-3.5 h-3.5" /> Back to Events
         </Link>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">

--- a/app/organiser/forgot-password/page.tsx
+++ b/app/organiser/forgot-password/page.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Mail, Lock, Eye, EyeOff, ArrowRight, KeyRound } from "lucide-react";
 import { resetPassword, confirmResetPassword } from "aws-amplify/auth";
+import { mapResetPasswordError } from "@/lib/auth-errors";
 
 type Step = "request" | "confirm";
 
@@ -59,15 +60,7 @@ function ForgotPasswordForm() {
       router.push("/organiser");
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "";
-      if (msg.includes("CodeMismatchException")) {
-        setError("That code is incorrect. Please check and try again.");
-      } else if (msg.includes("ExpiredCodeException")) {
-        setError("That code has expired. Go back and request a new one.");
-      } else if (msg.includes("InvalidPasswordException")) {
-        setError("Password does not meet requirements (min 8 chars, upper, lower, number).");
-      } else {
-        setError("Could not reset your password. Please try again.");
-      }
+      setError(mapResetPasswordError(msg));
     } finally {
       setLoading(false);
     }
@@ -128,6 +121,9 @@ function ForgotPasswordForm() {
             </h1>
             <p className="text-muted text-[15px] leading-relaxed mb-8 text-center">
               Check <strong className="text-light">{email}</strong> for your 6-digit code, then choose a new password.
+            </p>
+            <p className="text-muted text-[13px] leading-relaxed mb-8 text-center mt-1">
+              Can&apos;t see it? Check your spam or junk folder.
             </p>
 
             {error && (

--- a/app/organiser/verify-email/page.tsx
+++ b/app/organiser/verify-email/page.tsx
@@ -117,6 +117,9 @@ function VerifyEmailForm() {
               {email ? <strong className="text-light">{email}</strong> : "your email"}.
               Enter it below to activate your account.
             </p>
+            <p className="text-muted text-[13px] leading-relaxed mb-8 text-center mt-1">
+              Can&apos;t see it? Check your spam or junk folder.
+            </p>
 
             {error && (
               <div className="mb-5 px-4 py-3 rounded-md bg-red-900/20 border border-red-500/30 text-red-400 font-headline text-[13px]">

--- a/components/EventsListing.tsx
+++ b/components/EventsListing.tsx
@@ -470,6 +470,20 @@ function EventsListingInner() {
   );
 
   const [priceMin, priceMax] = priceRange ?? [PRICE_RANGE_MIN, PRICE_RANGE_MAX];
+
+  // Clicking the track snaps the nearer endpoint to the clicked value.
+  const onTrackClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const frac = Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width));
+    const val = Math.round(frac * PRICE_RANGE_MAX);
+    const [lo, hi] = priceRange ?? [PRICE_RANGE_MIN, PRICE_RANGE_MAX];
+    if (Math.abs(val - lo) <= Math.abs(val - hi)) {
+      setPriceRange([Math.min(val, hi - 5), hi]);
+    } else {
+      setPriceRange([lo, Math.max(val, lo + 5)]);
+    }
+  };
+
   const priceDropdown = (
     <div>
       <div className="flex items-center justify-between mb-4">
@@ -480,7 +494,7 @@ function EventsListingInner() {
           <button onClick={() => setPriceRange(null)} className="font-headline text-[10px] font-bold uppercase tracking-widest text-primary hover:text-primary/70">Reset</button>
         )}
       </div>
-      <div className="relative h-4 mt-2 mb-1">
+      <div className="relative h-4 mt-2 mb-1 cursor-pointer" onClick={onTrackClick}>
         <div className="absolute top-1/2 -translate-y-1/2 w-full h-1 rounded-full bg-dark-lighter" />
         <div className="absolute top-1/2 -translate-y-1/2 h-1 rounded-full bg-primary"
           style={{ left: `${(priceMin / PRICE_RANGE_MAX) * 100}%`, right: `${100 - (priceMax / PRICE_RANGE_MAX) * 100}%` }}
@@ -591,7 +605,11 @@ function EventsListingInner() {
         {dateDropdown}
       </FilterTrigger>
       <FilterTrigger label="Price" active={!!priceRange} isOpen={openDropdown === "price"}
-        onToggle={() => setOpenDropdown(openDropdown === "price" ? null : "price")} panelClassName="w-64">
+        onToggle={() => {
+          if (openDropdown === "price") setOpenDropdown(null);
+          else if (priceRange) setPriceRange(null);
+          else setOpenDropdown("price");
+        }} panelClassName="w-64">
         {priceDropdown}
       </FilterTrigger>
       <FilterTrigger label="Format & Level" active={formatFilters.length > 0 || levelFilters.length > 0} isOpen={openDropdown === "format-level"}

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -144,4 +144,9 @@ test.describe("forgot-password route", () => {
     await page.waitForLoadState("networkidle");
     await argosScreenshot(page, "forgot-password");
   });
+
+  test("verify-email page shows a check-spam note", async ({ page }) => {
+    await page.goto("/auth/verify-email?email=user@example.com");
+    await expect(page.getByText(/check your spam or junk folder/i)).toBeVisible();
+  });
 });

--- a/e2e/events.spec.ts
+++ b/e2e/events.spec.ts
@@ -108,6 +108,50 @@ test.describe("event detail page", () => {
     // Star rating chip is only rendered when the organiser has published reviews
     await expect(page.getByLabel(/Rated .+ out of 5 from \d+ reviews/i).first()).toBeVisible();
   });
+
+  test("back to events button is visible and navigates to the listing", async ({ page }) => {
+    await page.goto("/events/seed-event-001");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible({ timeout: 20000 });
+    const back = page.getByRole("link", { name: /back to events/i });
+    await expect(back).toBeVisible();
+    await back.click();
+    await expect(page).toHaveURL(/\/events$/);
+  });
+});
+
+test.describe("events price filter", () => {
+  test("clicking the track moves the nearer endpoint", async ({ page }) => {
+    await page.goto("/events?view=list");
+    await page.waitForLoadState("networkidle");
+    await page.getByRole("button", { name: /^Price$/ }).click();
+    const panel = page.locator("[data-filter-panel]");
+    const track = panel.locator(".relative.h-4");
+    const box = await track.boundingBox();
+    expect(box).not.toBeNull();
+    // Click at 60% of the track — the max thumb snaps there.
+    await page.mouse.click(box!.x + box!.width * 0.6, box!.y + box!.height / 2);
+    await expect(panel.getByText(/^\$0 – \$\d+/)).toHaveText(/\$0 – \$1\d{2}/);
+  });
+
+  test("re-clicking the active Price pill clears the filter", async ({ page }) => {
+    await page.goto("/events?view=list");
+    await page.waitForLoadState("networkidle");
+    const pricePill = page.getByRole("button", { name: /^Price$/ });
+    await pricePill.click();
+    // Set a range by moving the max thumb (drag from its default position)
+    const maxThumb = page.locator('input[type="range"]').nth(1);
+    await maxThumb.focus();
+    await maxThumb.press("ArrowLeft");
+    const priceChip = page.getByRole("button", { name: /^\$\d+ – \$\d+/ });
+    await expect(priceChip).toBeVisible();
+    // Dismiss the dropdown; the filter stays active.
+    await page.keyboard.press("Escape");
+    await expect(priceChip).toBeVisible();
+    // Re-clicking the active pill removes the filter.
+    await pricePill.click();
+    await expect(priceChip).not.toBeVisible();
+    await expect(page.getByRole("button", { name: /clear all/i })).not.toBeVisible();
+  });
 });
 
 test.describe("static pages", () => {

--- a/emails/components/email-footer.tsx
+++ b/emails/components/email-footer.tsx
@@ -34,6 +34,10 @@ export function EmailFooter() {
       </Text>
 
       <Text style={{ margin: '0 0 6px', fontFamily: fonts.body, fontSize: '12px', color: colors.muted }}>
+        Didn&apos;t get this email? Check your spam or junk folder.
+      </Text>
+
+      <Text style={{ margin: '0 0 6px', fontFamily: fonts.body, fontSize: '12px', color: colors.muted }}>
         Need help?{' '}
         <Link href="mailto:support@startline.com.au" style={{ color: colors.muted }}>
           support@startline.com.au

--- a/lib/auth-errors.ts
+++ b/lib/auth-errors.ts
@@ -1,0 +1,28 @@
+// Shared user-facing error mapping for the forgot-password flow. Cognito
+// rejects a reset password that matches the current/previous one with
+// InvalidPasswordException — that case must be shown as a reuse error, not the
+// generic complexity message. Used by all three reset handlers.
+export function mapResetPasswordError(msg: string): string {
+  const m = msg.toLowerCase();
+  if (m.includes("codemismatch")) {
+    return "That code is incorrect. Please check and try again.";
+  }
+  if (m.includes("expiredcode")) {
+    return "That code has expired. Go back and request a new one.";
+  }
+  if (
+    m.includes("invalidpassword") &&
+    (m.includes("current") ||
+      m.includes("previous") ||
+      m.includes("same as") ||
+      m.includes("history") ||
+      m.includes("reuse") ||
+      m.includes("used before"))
+  ) {
+    return "Your new password must be different from your current password.";
+  }
+  if (m.includes("invalidpassword")) {
+    return "Password must be at least 8 characters with upper, lower and a number.";
+  }
+  return "Could not reset your password. Please try again.";
+}

--- a/src/__tests__/auth-errors.test.ts
+++ b/src/__tests__/auth-errors.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { mapResetPasswordError } from "@/lib/auth-errors";
+
+describe("mapResetPasswordError", () => {
+  it("maps a code mismatch", () => {
+    expect(mapResetPasswordError("CodeMismatchException: Invalid code")).toContain("code is incorrect");
+  });
+
+  it("maps an expired code", () => {
+    expect(mapResetPasswordError("ExpiredCodeException: Code expired")).toContain("expired");
+  });
+
+  it("distinguishes password reuse from complexity", () => {
+    const reuse = "InvalidPasswordException: Password cannot be the same as a previous password";
+    expect(mapResetPasswordError(reuse)).toContain("different from your current password");
+  });
+
+  it("maps a generic InvalidPasswordException to complexity", () => {
+    const complexity = "InvalidPasswordException: Password does not meet requirements";
+    expect(mapResetPasswordError(complexity)).toContain("at least 8 characters");
+  });
+
+  it("falls back to a generic message", () => {
+    expect(mapResetPasswordError("Some other error")).toContain("Could not reset");
+  });
+});

--- a/terraform/modules/environment/lambda/email-sender/index.mjs
+++ b/terraform/modules/environment/lambda/email-sender/index.mjs
@@ -132,6 +132,9 @@ function footer() {
           <a href="https://www.strava.com/clubs/startlineau" style="color:#6E737B;text-decoration:none;">Strava</a>
         </p>
         <p style="margin:0 0 6px;font-family:'Inter',Arial,sans-serif;font-size:12px;color:#8A8F98;">
+          Didn't get this email? Check your spam or junk folder.
+        </p>
+        <p style="margin:0 0 6px;font-family:'Inter',Arial,sans-serif;font-size:12px;color:#8A8F98;">
           Need help? <a href="mailto:support@startline.com.au" style="color:#8A8F98;">support@startline.com.au</a>
         </p>
         <p style="margin:0 0 16px;font-family:'Inter',Arial,sans-serif;font-size:11px;color:#6E737B;">


### PR DESCRIPTION
## Description

Four quick fixes from #274:

1. **Check-spam note** — 'check your spam or junk folder' copy added to the verify-email and forgot-password pages, the React-email footer, and the Cognito custom-message lambda footer. (Root cause — Cognito's default sender lacking SPF/DKIM — noted as a follow-up.)
2. **Old-password reset error** — new shared `mapResetPasswordError` helper (`lib/auth-errors.ts`) distinguishes the 'new password matches current/previous' case from the generic complexity message. Used by both forgot-password pages and the in-modal reset handler.
3. **Back-to-Events button** — restyled as a visible pill button on the event detail page.
4. **Price slider** — clicking the track snaps the nearer endpoint; re-clicking the active Price pill clears the filter (consistent with other filters).

## Tests

- Unit: `src/__tests__/auth-errors.test.ts` (5 cases).
- E2E: verify-email spam note, back button navigation, price slider track-click + toggle-off.
- Verified: `pnpm lint`, `pnpm typecheck`, targeted `pnpm test` + Playwright all green.

Part of #274