### PR TITLE
feat: closest-event search fallback + place suggestions (#274)

### DIFF
--- a/components/EventsListing.tsx
+++ b/components/EventsListing.tsx
@@ -19,6 +19,7 @@ import { useAuthContext } from "@/context/AuthContext";
 import EventMap from "@/components/EventMap";
 import type { EventMapHandle } from "@/components/EventMap";
 import EventCard from "@/components/EventCard";
+import SuburbAutocomplete from "@/components/ui/SuburbAutocomplete";
 
 const DISCIPLINE_OPTIONS = EVENT_TYPE_OPTIONS.map((o) => ({ value: o.value, label: o.label }));
 const STATE_CHIP_OPTIONS  = STATE_OPTIONS.map((o) => ({ value: o.value, label: o.shortLabel }));
@@ -254,7 +255,11 @@ function EventsListingInner() {
   }), [typeFilters, stateFilters, formatFilters, levelFilters, priceRange, dateFilter, whatQuery, searchOrigin]);
 
   const displayEvents = useMemo(() => {
-    let results = filterEvents(allEvents, filterState);
+    // Geocoded search drops the hard radius cap — results are still sorted
+    // closest-first below, so a suburb with no nearby event surfaces the
+    // closest matches instead of an empty list.
+    const effectiveFilter = searchOrigin ? { ...filterState, maxDistance: undefined } : filterState;
+    let results = filterEvents(allEvents, effectiveFilter);
     if (searchOrigin) {
       // Geocoded search — sort closest-first and stamp distance onto each event.
       results = results
@@ -375,13 +380,17 @@ function EventsListingInner() {
             {whatQuery && <button type="button" onClick={() => setWhatQuery("")} aria-label="Clear event search" className="text-muted hover:text-light flex-shrink-0"><X className="w-3.5 h-3.5" /></button>}
           </div>
           <div className="flex-1 px-3.5 py-2.5 min-w-0 flex items-center gap-1.5">
-            <label className="flex-1 min-w-0 cursor-text">
+            <div className="flex-1 min-w-0">
               <span className="font-headline text-[10px] font-black uppercase tracking-widest text-primary block mb-0.5">Where</span>
-              <input type="text" placeholder="State, city, or suburb" value={whereQuery}
-                onChange={(e) => setWhereQuery(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && handleWhereSearch()}
-                className="w-full bg-transparent text-light font-headline text-sm placeholder:text-muted/40 border-0 focus:ring-0 focus:outline-none" />
-            </label>
+              <SuburbAutocomplete
+                value={whereQuery}
+                onChange={setWhereQuery}
+                onSelect={(label) => handleWhereSearch(label)}
+                onEnter={() => handleWhereSearch()}
+                placeholder="State, city, or suburb"
+                className="w-full bg-transparent text-light font-headline text-sm placeholder:text-muted/40 border-0 focus:ring-0 focus:outline-none"
+              />
+            </div>
             {isGeocoding
               ? <Loader2 data-testid="geocoding-spinner" className="w-3.5 h-3.5 text-muted animate-spin flex-shrink-0" />
               : <button type="button" onClick={locateMe} aria-label="Use my location" title="Use my location" className="text-muted hover:text-primary flex-shrink-0"><Locate className="w-3.5 h-3.5" /></button>}
@@ -406,10 +415,16 @@ function EventsListingInner() {
           </div>
           <div className="flex items-center gap-2 bg-dark rounded-xl px-4 py-2.5">
             <MapPin className="w-4 h-4 text-muted flex-shrink-0" />
-            <input type="text" placeholder="City or state" value={whereQuery}
-              onChange={(e) => setWhereQuery(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleWhereSearch()}
-              className="flex-1 bg-transparent text-light font-headline text-sm placeholder:text-muted/40 border-0 focus:outline-none" />
+            <div className="flex-1 min-w-0">
+              <SuburbAutocomplete
+                value={whereQuery}
+                onChange={setWhereQuery}
+                onSelect={(label) => handleWhereSearch(label)}
+                onEnter={() => handleWhereSearch()}
+                placeholder="City or state"
+                className="w-full bg-transparent text-light font-headline text-sm placeholder:text-muted/40 border-0 focus:outline-none"
+              />
+            </div>
             {isGeocoding
               ? <Loader2 data-testid="geocoding-spinner" className="w-4 h-4 text-muted animate-spin flex-shrink-0" />
               : <button onClick={locateMe} aria-label="Use my location" title="Use my location" className="text-muted hover:text-primary flex-shrink-0"><Locate className="w-4 h-4" /></button>}
@@ -640,7 +655,16 @@ function EventsListingInner() {
   const resultsHeader = (
     <div className="px-3 lg:px-6 pt-4 pb-1 flex items-center justify-between gap-3 flex-wrap flex-shrink-0">
       <h2 className="font-headline text-base lg:text-xl font-black italic tracking-tighter text-light">
-        <span className="text-primary">{displayEvents.length}</span> event{displayEvents.length !== 1 ? "s" : ""} found
+        {searchOrigin ? (
+          <>
+            <span className="text-primary">{displayEvents.length}</span> closest event{displayEvents.length !== 1 ? "s" : ""} to{" "}
+            <span className="text-light">{whereQuery || "your location"}</span>
+          </>
+        ) : (
+          <>
+            <span className="text-primary">{displayEvents.length}</span> event{displayEvents.length !== 1 ? "s" : ""} found
+          </>
+        )}
       </h2>
     </div>
   );

--- a/components/ui/SuburbAutocomplete.tsx
+++ b/components/ui/SuburbAutocomplete.tsx
@@ -13,6 +13,8 @@ interface Props {
   value: string;
   onChange: (city: string) => void;
   onStateChange?: (state: string) => void;
+  onSelect?: (label: string) => void;
+  onEnter?: () => void;
   placeholder?: string;
   className?: string;
 }
@@ -21,6 +23,8 @@ export default function SuburbAutocomplete({
   value,
   onChange,
   onStateChange,
+  onSelect,
+  onEnter,
   placeholder = "e.g. Melbourne",
   className = "",
 }: Props) {
@@ -68,8 +72,10 @@ export default function SuburbAutocomplete({
   };
 
   const select = (item: PlaceResult) => {
-    onChange(item.label.split(",")[0].trim());
+    const label = item.label.split(",")[0].trim();
+    onChange(label);
     setOpen(false);
+    onSelect?.(label);
     fetch(`/api/places/geocode?q=${encodeURIComponent(item.title)}`)
       .then(r => r.json())
       .then(data => {
@@ -79,6 +85,16 @@ export default function SuburbAutocomplete({
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") { setOpen(false); return; }
+    if (e.key === "Enter") {
+      if (open && activeIdx >= 0) {
+        e.preventDefault();
+        select(suggestions[activeIdx]);
+      } else {
+        onEnter?.();
+      }
+      return;
+    }
     if (!open) return;
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -86,11 +102,6 @@ export default function SuburbAutocomplete({
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setActiveIdx(i => Math.max(i - 1, 0));
-    } else if (e.key === "Enter" && activeIdx >= 0) {
-      e.preventDefault();
-      select(suggestions[activeIdx]);
-    } else if (e.key === "Escape") {
-      setOpen(false);
     }
   };
 

--- a/e2e/distance-search.spec.ts
+++ b/e2e/distance-search.spec.ts
@@ -68,6 +68,38 @@ test.describe("distance-based search", () => {
     await expect(page.getByText("No events found.").first()).toBeVisible({ timeout: 10000 });
   });
 
+  test("a suburb far from all events still shows the closest events", async ({ page }) => {
+    const PERTH = { latitude: -31.9522, longitude: 115.8589 };
+    await stubGeocode(page, PERTH);
+    await page.goto("/events?view=list");
+    await page.waitForLoadState("networkidle");
+
+    await searchWhere(page, "Perth");
+
+    // The radius cap is dropped for geocoded search — events still appear,
+    // sorted closest-first, with a "closest events" heading.
+    await expect(page.locator('[data-testid="event-distance"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/closest event/i).first()).toBeVisible();
+  });
+
+  test("typing in the where field shows place suggestions", async ({ page }) => {
+    await page.route("**/api/places/autocomplete**", (route) =>
+      route.fulfill({
+        json: {
+          results: [
+            { placeId: "p1", label: "Perth WA, Australia", title: "Perth", placeType: "Locality" },
+          ],
+        },
+      }),
+    );
+    await page.goto("/events?view=list");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByPlaceholder("State, city, or suburb").fill("Per");
+
+    await expect(page.getByRole("button", { name: /Perth WA/ })).toBeVisible({ timeout: 10000 });
+  });
+
   test("clearing the where input resets to normal listing", async ({ page }) => {
     await stubGeocode(page, SYDNEY);
     await page.goto("/events?view=list");


### PR DESCRIPTION
## Description

Two search improvements from #274:

1. **Closest-event fallback** — geocoded search no longer hard-caps results at 100 km. Events are sorted distance-first with a 'closest events to X' heading, so a suburb with no nearby event surfaces the nearest matches instead of an empty list.
2. **Place suggestions** — the events 'where' fields (desktop + mobile) now reuse `SuburbAutocomplete` against the existing `/api/places/autocomplete` endpoint. Selecting a suggestion geocodes and searches immediately. Added `onSelect`/`onEnter` callbacks to `SuburbAutocomplete`.

## Tests

- E2E (`e2e/distance-search.spec.ts`): far-suburb fallback shows closest events; suggestion dropdown appears on typing. Existing distance-search tests still pass.
- Verified: `pnpm lint`, `pnpm typecheck`, targeted Playwright all green.

Part of #274