### PR TITLE
feat: validate event end time/date and ticket close dates (#274)

### DIFF
--- a/components/event/EventFormWizard.tsx
+++ b/components/event/EventFormWizard.tsx
@@ -445,6 +445,8 @@ function StateSelect({ value, onChange }: { value: AusState; onChange: (v: AusSt
 }
 
 function WhenStep({ form, update }: { form: FormState; update: (p: Partial<FormState>) => void }) {
+  const timeInvalid = !!(form.startTime && form.endTime && form.endTime <= form.startTime);
+
   return (
     <div>
       <Field label="Event date(s)" required hint="Tap start then end for multi-day">
@@ -470,6 +472,11 @@ function WhenStep({ form, update }: { form: FormState; update: (p: Partial<FormS
         </Field>
         <Field label="Cut-off time" hint="Last finisher">
           <TimePicker value={form.endTime} onChange={v => update({ endTime: v })} placeholder="Select end time" />
+          {timeInvalid && (
+            <p className="font-headline text-[10px] uppercase tracking-widest text-red-400 mt-1.5">
+              End time must be after start time.
+            </p>
+          )}
         </Field>
       </div>
 
@@ -696,7 +703,7 @@ function TicketsStep({ form, update }: { form: FormState; update: (p: Partial<Fo
                 </div>
                 <div>
                   <div className="font-headline text-[10px] uppercase tracking-widest text-muted-dark mb-1.5">Category closes</div>
-                  <DatePicker value={w.closes} onChange={v => updateWave(i, { closes: v })} placeholder="Optional close date" disablePast={false} />
+                  <DatePicker value={w.closes} onChange={v => updateWave(i, { closes: v })} placeholder="Optional close date" disablePast={false} maxDate={form.endDate || form.date} />
                 </div>
               </div>
 
@@ -1548,7 +1555,8 @@ export default function EventFormWizard({
         (!hasCatRequirement || form.categories.length > 0)
       );
     }
-    if (s === 1) return !(form.date && form.startTime && form.address.trim() && form.city.trim() && form.state);
+    if (s === 1) return !(form.date && form.startTime && form.address.trim() && form.city.trim() && form.state) ||
+      !!(form.startTime && form.endTime && form.endTime <= form.startTime);
     if (s === 2) return !(
       form.waves.length > 0 &&
       (form.waves[0]?.price === "0" || !!form.waves[0]?.price) &&

--- a/e2e/new-listing.spec.ts
+++ b/e2e/new-listing.spec.ts
@@ -62,6 +62,22 @@ test.describe("new listing wizard", () => {
     // ponytail: skips if AWS GeoPlaces API unavailable in test env
   });
 
+  test("blocks an end time at or before the start time", async ({ page }) => {
+    await organiserLogin(page);
+    await page.goto("/organiser/new-listing");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByPlaceholder(/Apex Throwdown/i).fill("Time Test Event");
+    await page.getByRole("button", { name: /continue/i }).click();
+    await expect(page.getByText(/when and where/i).first()).toBeVisible();
+
+    const timeInputs = page.locator('input[type="time"]');
+    await timeInputs.nth(0).fill("10:00");
+    await timeInputs.nth(1).fill("09:00");
+
+    await expect(page.getByText(/end time must be after start time/i)).toBeVisible();
+  });
+
   test("fills all 5 steps and saves as draft", async ({ page }) => {
     await organiserLogin(page);
     await page.goto("/organiser/new-listing");

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -17,48 +17,84 @@ export const idAnnouncementIdParams = z.object({
 // All fields optional (PATCH semantics); the routes apply their own defaults and
 // submit-time required-field checks so existing error messages stay unchanged.
 // JSON columns (categories, waves) are kept opaque — Prisma serialises them.
-export const eventPayloadSchema = z.object({
-  submit: z.boolean().optional(),
-  title: z.string().max(200).optional(),
-  discipline: z.string().max(80).optional(),
-  description: z.string().max(10000).nullable().optional(),
-  eventDate: z.string().max(20).optional(),
-  endDate: z.string().max(20).nullable().optional(),
-  startTime: z.string().max(10).optional(),
-  endTime: z.string().max(10).optional(),
-  venue: z.string().max(200).optional(),
-  address: z.string().max(300).nullable().optional(),
-  city: z.string().max(100).optional(),
-  state: z.string().max(50).optional(),
-  latitude: z.number().min(-90).max(90).nullable().optional(),
-  longitude: z.number().min(-180).max(180).nullable().optional(),
-  format: z.string().max(100).optional(),
-  level: z.string().max(100).optional(),
-  categories: z.unknown().optional(),
-  cap: z.number().int().min(1).max(1000000).nullable().optional(),
-  minAge: z.number().int().min(0).max(150).nullable().optional(),
-  waves: z.unknown().optional(),
-  inclusions: z.string().max(10000).nullable().optional(),
-  extras: z.string().max(10000).nullable().optional(),
-  activations: z.string().max(10000).nullable().optional(),
-  refundPolicy: z.string().max(10000).nullable().optional(),
-  registrationType: z.enum(["startline", "external"]).optional(),
-  feeStructure: z.enum(["athlete", "organiser"]).optional(),
-  registrationUrl: z.string().max(2000).nullable().optional(),
-  accessibilityInfo: z.string().max(10000).nullable().optional(),
-  coverImageUrl: z.string().max(2000).nullable().optional(),
-  informationPdfs: z
-    .array(
-      z.object({
-        url: z.string().max(2000),
-        label: z.string().max(120).nullable().optional(),
-        name: z.string().max(255).nullable().optional(),
-      }),
-    )
-    .max(20)
-    .optional(),
-  photos: z.array(z.string().max(3000)).optional(),
-});
+export const eventPayloadSchema = z
+  .object({
+    submit: z.boolean().optional(),
+    title: z.string().max(200).optional(),
+    discipline: z.string().max(80).optional(),
+    description: z.string().max(10000).nullable().optional(),
+    eventDate: z.string().max(20).optional(),
+    endDate: z.string().max(20).nullable().optional(),
+    startTime: z.string().max(10).optional(),
+    endTime: z.string().max(10).optional(),
+    venue: z.string().max(200).optional(),
+    address: z.string().max(300).nullable().optional(),
+    city: z.string().max(100).optional(),
+    state: z.string().max(50).optional(),
+    latitude: z.number().min(-90).max(90).nullable().optional(),
+    longitude: z.number().min(-180).max(180).nullable().optional(),
+    format: z.string().max(100).optional(),
+    level: z.string().max(100).optional(),
+    categories: z.unknown().optional(),
+    cap: z.number().int().min(1).max(1000000).nullable().optional(),
+    minAge: z.number().int().min(0).max(150).nullable().optional(),
+    waves: z.unknown().optional(),
+    inclusions: z.string().max(10000).nullable().optional(),
+    extras: z.string().max(10000).nullable().optional(),
+    activations: z.string().max(10000).nullable().optional(),
+    refundPolicy: z.string().max(10000).nullable().optional(),
+    registrationType: z.enum(["startline", "external"]).optional(),
+    feeStructure: z.enum(["athlete", "organiser"]).optional(),
+    registrationUrl: z.string().max(2000).nullable().optional(),
+    accessibilityInfo: z.string().max(10000).nullable().optional(),
+    coverImageUrl: z.string().max(2000).nullable().optional(),
+    informationPdfs: z
+      .array(
+        z.object({
+          url: z.string().max(2000),
+          label: z.string().max(120).nullable().optional(),
+          name: z.string().max(255).nullable().optional(),
+        }),
+      )
+      .max(20)
+      .optional(),
+    photos: z.array(z.string().max(3000)).optional(),
+  })
+  .superRefine((data, ctx) => {
+    // Cross-field ordering checks (only when both values are present, so
+    // partially-filled drafts keep saving). HH:MM and YYYY-MM-DD strings
+    // compare correctly in lexicographic order.
+    if (data.startTime && data.endTime && data.endTime <= data.startTime) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["endTime"],
+        message: "End time must be after start time.",
+      });
+    }
+    if (data.eventDate && data.endDate && data.endDate < data.eventDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["endDate"],
+        message: "End date must be on or after the start date.",
+      });
+    }
+    // Ticket categories cannot close after the event ends.
+    const maxClose = data.endDate || data.eventDate;
+    if (maxClose && Array.isArray(data.waves)) {
+      data.waves.forEach((w: unknown, i: number) => {
+        if (w && typeof w === "object" && "closes" in w && typeof (w as { closes: unknown }).closes === "string") {
+          const closes = (w as { closes: string }).closes;
+          if (closes && closes > maxClose) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["waves", i, "closes"],
+              message: "A ticket category cannot close after the event ends.",
+            });
+          }
+        }
+      });
+    }
+  });
 
 export const adminEventPayloadSchema = eventPayloadSchema.extend({
   organiserId: z.string().min(1).max(255),

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { eventPayloadSchema } from "@/lib/schemas";
+
+describe("eventPayloadSchema time/date ordering", () => {
+  it("rejects an end time at or before the start time", () => {
+    const res = eventPayloadSchema.safeParse({ startTime: "09:00", endTime: "09:00" });
+    expect(res.success).toBe(false);
+    expect(res.success ? "" : res.error.issues[0].message).toBe("End time must be after start time.");
+  });
+
+  it("accepts an end time after the start time", () => {
+    const res = eventPayloadSchema.safeParse({ startTime: "09:00", endTime: "12:00" });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects an end date before the start date", () => {
+    const res = eventPayloadSchema.safeParse({ eventDate: "2026-10-02", endDate: "2026-10-01" });
+    expect(res.success).toBe(false);
+    expect(res.success ? "" : res.error.issues[0].message).toBe("End date must be on or after the start date.");
+  });
+
+  it("rejects a ticket category closing after the event ends", () => {
+    const res = eventPayloadSchema.safeParse({
+      eventDate: "2026-10-02",
+      waves: [{ label: "General", price: "50", closes: "2026-10-03" }],
+    });
+    expect(res.success).toBe(false);
+    expect(res.success ? "" : res.error.issues[0].message).toBe("A ticket category cannot close after the event ends.");
+  });
+
+  it("allows a ticket category closing on or before the event end", () => {
+    const res = eventPayloadSchema.safeParse({
+      eventDate: "2026-10-02",
+      waves: [{ label: "General", price: "50", closes: "2026-10-02" }],
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("does not block partial drafts missing one side of a comparison", () => {
+    const res = eventPayloadSchema.safeParse({ startTime: "09:00" });
+    expect(res.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Validation for event scheduling, from #274:

- **Server** — a `superRefine` on the shared `eventPayloadSchema` rejects:
  - end time at or before the start time,
  - end date before the start date,
  - a ticket category closing after the event ends.
  Checks only fire when both sides are present so partially-filled drafts keep saving. Enforced in both the event POST and PATCH routes via the existing 400 path.
- **Wizard** — inline 'End time must be after start time' error on the When step and in step validation; the ticket 'closes' DatePicker is capped at the event end date.

## Tests

- Unit: `src/__tests__/schemas.test.ts` (6 cases).
- E2E: wizard blocks an end time at/before the start time; draft-without-cut-off still saves.
- Verified: `pnpm lint`, `pnpm typecheck`, targeted `pnpm test` + Playwright all green.

Part of #274