### PR TITLE
feat: require organiser contact info at setup + surface upload errors (#274)

### DIFF
--- a/app/(user)/organiser-setup/page.tsx
+++ b/app/(user)/organiser-setup/page.tsx
@@ -14,6 +14,9 @@ export default function OrganiserSetupPage() {
   const { status } = useAuthContext();
   const [step, setStep] = useState<"info" | "form">("info");
   const [orgName, setOrgName] = useState("");
+  const [contactName, setContactName] = useState("");
+  const [contactEmail, setContactEmail] = useState("");
+  const [phone, setPhone] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -57,6 +60,14 @@ export default function OrganiserSetupPage() {
       setError("Please enter an organisation name.");
       return;
     }
+    if (!contactName.trim()) {
+      setError("Please enter a contact name.");
+      return;
+    }
+    if (!contactEmail.trim()) {
+      setError("Please enter a contact email.");
+      return;
+    }
     setLoading(true);
     setError("");
 
@@ -64,7 +75,12 @@ export default function OrganiserSetupPage() {
       const res = await fetch("/api/organiser/setup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orgName: orgName.trim() }),
+        body: JSON.stringify({
+          orgName: orgName.trim(),
+          contactName: contactName.trim(),
+          contactEmail: contactEmail.trim(),
+          phone: phone.trim(),
+        }),
       });
 
       if (!res.ok) {
@@ -164,7 +180,7 @@ export default function OrganiserSetupPage() {
                 <span className="text-primary">organisation.</span>
               </h2>
               <p className="text-light text-[14px] leading-relaxed">
-                This is the name athletes see on your listings. You can add your logo, bio and contact details straight after.
+                This is the name athletes see on your listings. Add your contact details so we can reach you about your events.
               </p>
             </div>
 
@@ -183,6 +199,42 @@ export default function OrganiserSetupPage() {
                   type="text" required value={orgName}
                   onChange={(e) => setOrgName(e.target.value)}
                   placeholder="e.g. Apex Endurance Events"
+                  className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[15px] text-light placeholder:text-light/70 focus:border-primary focus:outline-none transition-colors"
+                />
+              </div>
+
+              <div>
+                <label className="font-headline text-[11px] font-bold uppercase tracking-widest text-light block mb-2">
+                  Contact name <span className="text-primary text-[15px] leading-none">*</span>
+                </label>
+                <input
+                  type="text" required value={contactName}
+                  onChange={(e) => setContactName(e.target.value)}
+                  placeholder="Full name"
+                  className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[15px] text-light placeholder:text-light/70 focus:border-primary focus:outline-none transition-colors"
+                />
+              </div>
+
+              <div>
+                <label className="font-headline text-[11px] font-bold uppercase tracking-widest text-light block mb-2">
+                  Contact email <span className="text-primary text-[15px] leading-none">*</span>
+                </label>
+                <input
+                  type="email" required value={contactEmail}
+                  onChange={(e) => setContactEmail(e.target.value)}
+                  placeholder="events@yourorg.com.au"
+                  className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[15px] text-light placeholder:text-light/70 focus:border-primary focus:outline-none transition-colors"
+                />
+              </div>
+
+              <div>
+                <label className="font-headline text-[11px] font-bold uppercase tracking-widest text-light block mb-2">
+                  Phone
+                </label>
+                <input
+                  type="tel" value={phone}
+                  onChange={(e) => setPhone(e.target.value)}
+                  placeholder="+61 4xx xxx xxx"
                   className="w-full bg-dark border border-dark-lighter rounded-md px-4 py-3 text-[15px] text-light placeholder:text-light/70 focus:border-primary focus:outline-none transition-colors"
                 />
               </div>

--- a/app/api/organiser/setup/route.ts
+++ b/app/api/organiser/setup/route.ts
@@ -3,7 +3,12 @@ import prisma from "@/lib/prisma";
 import { getUserSession } from "@/lib/amplify-server";
 import { z } from "zod";
 
-const setupSchema = z.object({ orgName: z.string().max(200) });
+const setupSchema = z.object({
+  orgName: z.string().max(200),
+  contactName: z.string().max(200),
+  contactEmail: z.string().max(255),
+  phone: z.string().max(50),
+});
 
 export async function POST(req: Request) {
   const session = await getUserSession();
@@ -13,11 +18,17 @@ export async function POST(req: Request) {
 
   const parsed = setupSchema.safeParse(await req.json());
   if (!parsed.success) {
-    return NextResponse.json({ error: "Organisation name is required." }, { status: 400 });
+    return NextResponse.json(
+      { error: "Organisation name and contact details are required." },
+      { status: 400 },
+    );
   }
-  const { orgName } = parsed.data;
+  const { orgName, contactName, contactEmail, phone } = parsed.data;
   if (!orgName.trim()) {
     return NextResponse.json({ error: "Organisation name is required." }, { status: 400 });
+  }
+  if (!contactName.trim() || !contactEmail.trim()) {
+    return NextResponse.json({ error: "Contact name and contact email are required." }, { status: 400 });
   }
 
   const existing = await prisma.organiserMember.findFirst({
@@ -35,6 +46,9 @@ export async function POST(req: Request) {
           createdBy: session.sub,
           email: session.email,
           orgName: orgName.trim(),
+          contactName: contactName.trim(),
+          contactEmail: contactEmail.trim(),
+          phone: phone.trim(),
           verified: false,
           status: "APPROVED",
           abn: "",

--- a/components/organiser/SettingsModal.tsx
+++ b/components/organiser/SettingsModal.tsx
@@ -278,7 +278,9 @@ function PersonalInfoForm() {
     try {
       const url = await uploadImage(file, "logo");
       const updated = { ...form, logoUrl: url };
-      await fetch("/api/organiser/profile", { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(updated) });
+      const res = await fetch("/api/organiser/profile", { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(updated) });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) { setError(data.error ?? "Logo upload failed."); return; }
       patch({ logoUrl: url });
       router.refresh();
     } catch { setError("Logo upload failed."); }
@@ -290,7 +292,9 @@ function PersonalInfoForm() {
     try {
       const url = await uploadImage(file, "cover");
       const updated = { ...form, coverImageUrl: url };
-      await fetch("/api/organiser/profile", { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(updated) });
+      const res = await fetch("/api/organiser/profile", { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(updated) });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) { setError(data.error ?? "Cover upload failed."); return; }
       patch({ coverImageUrl: url });
       router.refresh();
     } catch { setError("Cover upload failed."); }

--- a/e2e/organiser.spec.ts
+++ b/e2e/organiser.spec.ts
@@ -2,6 +2,41 @@ import { test, expect } from "@playwright/test";
 import { argosScreenshot } from "@argos-ci/playwright";
 import { organiserLogin } from "./helpers";
 
+test.describe("organiser setup", () => {
+  test("requires contact details when creating a profile", async ({ page }) => {
+    // 'user' bypass maps to a seeded authenticated account.
+    await page.context().addCookies([
+      { name: "__e2e_bypass", value: "user", domain: "localhost", path: "/", sameSite: "Lax" },
+    ]);
+    await page.goto("/organiser-setup");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Org name alone is no longer enough — contact details are required.
+    await page.getByPlaceholder(/Apex Endurance/i).fill("E2E Setup Org");
+    await page.getByRole("button", { name: /create organiser profile/i }).click();
+    await expect(page.getByText(/please enter a contact name/i)).toBeVisible();
+
+    // Filling the contact fields lets the form submit.
+    await page.getByPlaceholder(/full name/i).fill("E2E Contact");
+    await page.getByPlaceholder(/events@yourorg/i).fill("e2e@example.com");
+    await page.getByPlaceholder(/\+61/i).fill("0412000000");
+    await page.getByRole("button", { name: /create organiser profile/i }).click();
+    await expect(page).toHaveURL(/\/organiser\/dashboard/, { timeout: 15000 });
+  });
+
+  test("setup API rejects missing contact details", async ({ request }) => {
+    const res = await request.post("/api/organiser/setup", {
+      headers: { Cookie: "__e2e_bypass=user" },
+      data: { orgName: "X" },
+    });
+    expect(res.status()).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/contact details are required/i);
+  });
+});
+
 
 
 test.describe("organiser login", () => {


### PR DESCRIPTION
## Description

Two linked onboarding fixes from #274:

1. **Contact info required at setup** — the organiser-setup form now collects contact name, contact email and phone, and `/api/organiser/setup` stores them. A fresh profile satisfies the edit-profile PUT's contact requirement, so uploading a cover image no longer fails with a hidden 'contact info required' 400.
2. **Surface upload errors** — the SettingsModal logo/cover upload handlers now read the profile-PUT response and show the real error instead of swallowing it as 'Cover upload failed.'

## Tests

- E2E (`e2e/organiser.spec.ts`): setup form requires contact details; setup API returns 400 when contact fields are missing; filled form submits to the dashboard.
- Verified: `pnpm lint`, `pnpm typecheck`, targeted `pnpm test` + Playwright all green.

Part of #274