### PR TITLE
fix: resolve general website issues (#282)

### DIFF
--- a/app/(user)/events/[id]/register/page.tsx
+++ b/app/(user)/events/[id]/register/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, startTransition } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, ArrowRight, Plus, Minus, LogIn, Check, ChevronDown } from "lucide-react";
@@ -16,6 +16,7 @@ import { useAuthContext } from "@/context/AuthContext";
 import { cn } from "@/lib/utils";
 
 const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "";
+const BOT_CHECK_HOSTS = ["startlineau.com", "www.startlineau.com", "staging.startlineau.com"];
 import {
   Skeleton, PageHeaderSkeleton, PageShellSkeleton,
 } from "@/components/ui/skeleton";
@@ -162,6 +163,16 @@ function RegisterContent() {
   const [error, setError] = useState("");
   const [isSignInOpen, setIsSignInOpen] = useState(false);
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  // Turnstile only works on hostnames whitelisted on the widget; Amplify
+  // preview URLs are dynamic and can't be enumerated, so hide it there (the
+  // server fails open for those hosts). Start hidden to keep SSR/hydration in
+  // sync, then reveal once we know the real hostname.
+  const [showTurnstile, setShowTurnstile] = useState(false);
+  useEffect(() => {
+    startTransition(() => {
+      setShowTurnstile(Boolean(TURNSTILE_SITE_KEY) && BOT_CHECK_HOSTS.includes(window.location.hostname));
+    });
+  }, []);
 
   // Tickets chosen on step 1: wave label → quantity. Locked once the buyer
   // moves on; changing it means going Back to this step.
@@ -631,7 +642,7 @@ function RegisterContent() {
 
             <StepRail current={step} />
 
-            {TURNSTILE_SITE_KEY && (
+            {showTurnstile && (
               <div className="mb-4">
                 <TurnstileWidget siteKey={TURNSTILE_SITE_KEY} onTokenChange={setTurnstileToken} />
               </div>

--- a/app/(user)/profile/[username]/page.tsx
+++ b/app/(user)/profile/[username]/page.tsx
@@ -2,8 +2,10 @@ import Link from "next/link";
 import { User } from "lucide-react";
 import prisma from "@/lib/prisma";
 import { getServerSession } from "@/lib/amplify-server";
-import { getOrganiserRatings } from "@/lib/reviews";
-import ProfilePageClient from "@/components/profile/ProfilePageClient";
+import ProfileServerView, {
+  PROFILE_USER_SELECT,
+  type ProfileUser,
+} from "@/components/profile/ProfileServerView";
 
 interface PublicProfilePageProps {
   params: Promise<{ username: string }>;
@@ -14,32 +16,7 @@ export default async function PublicProfilePage({ params }: PublicProfilePagePro
 
   const user = await prisma.user.findUnique({
     where: { username },
-    select: {
-      id: true,
-      username: true,
-      email: true,
-      name: true,
-      bio: true,
-      profilePicUrl: true,
-      isPublic: true,
-      city: true,
-      state: true,
-      mobile: true,
-      dateOfBirth: true,
-      gender: true,
-      emergencyContactName: true,
-      emergencyContactPhone: true,
-      createdAt: true,
-      memberships: {
-        select: {
-          organiser: {
-            select: { id: true, orgName: true, logoUrl: true, verified: true },
-          },
-        },
-        take: 1,
-        orderBy: { createdAt: "asc" },
-      },
-    },
+    select: PROFILE_USER_SELECT,
   });
 
   if (!user) {
@@ -54,79 +31,7 @@ export default async function PublicProfilePage({ params }: PublicProfilePagePro
     return <ProfileNotFound />;
   }
 
-  const registrations = await prisma.registration.findMany({
-    where: { userId: user.id, status: "CONFIRMED" },
-    orderBy: { event: { eventDate: "asc" } },
-    select: {
-      id: true,
-      resultTime: true,
-      resultPlacement: true,
-      event: {
-        select: {
-          id: true,
-          title: true,
-          discipline: true,
-          eventDate: true,
-          city: true,
-          state: true,
-          coverImageUrl: true,
-          organiser: { select: { id: true, orgName: true, logoUrl: true } },
-        },
-      },
-    },
-  });
-
-  const ratings = await getOrganiserRatings(
-    registrations.map((r) => r.event.organiser.id),
-  );
-
-  const profile = {
-    username: user.username!,
-    bio: user.bio,
-    profilePicUrl: user.profilePicUrl,
-    history: {
-      completed: registrations.length,
-      registrations: registrations.map((r) => ({
-        ...r,
-        event: {
-          ...r.event,
-          organiser: {
-            ...r.event.organiser,
-            rating: ratings.get(r.event.organiser.id) ?? null,
-          },
-        },
-      })),
-    },
-  };
-
-  const ownerData = isOwner
-    ? {
-        id: user.id,
-        email: user.email,
-        name: user.name,
-        username: user.username,
-        bio: user.bio,
-        isPublic: user.isPublic,
-        city: user.city,
-        state: user.state,
-        profilePicUrl: user.profilePicUrl,
-        mobile: user.mobile,
-        dateOfBirth: user.dateOfBirth,
-        gender: user.gender,
-        emergencyContactName: user.emergencyContactName,
-        emergencyContactPhone: user.emergencyContactPhone,
-        createdAt: user.createdAt,
-        organiser: user.memberships[0]?.organiser ?? null,
-      }
-    : null;
-
-  return (
-    <ProfilePageClient
-      profile={profile}
-      isOwner={isOwner}
-      ownerData={ownerData}
-    />
-  );
+  return <ProfileServerView user={user as ProfileUser} isOwner={isOwner} />;
 }
 
 function ProfileNotFound() {

--- a/app/(user)/profile/page.tsx
+++ b/app/(user)/profile/page.tsx
@@ -1,6 +1,10 @@
 import { redirect } from "next/navigation";
 import { getServerSession } from "@/lib/amplify-server";
 import prisma from "@/lib/prisma";
+import ProfileServerView, {
+  PROFILE_USER_SELECT,
+  type ProfileUser,
+} from "@/components/profile/ProfileServerView";
 
 export default async function ProfilePage() {
   const session = await getServerSession();
@@ -22,7 +26,7 @@ export default async function ProfilePage() {
 
   const user = await prisma.user.findUnique({
     where: { id: session.sub },
-    select: { username: true },
+    select: PROFILE_USER_SELECT,
   });
 
   // Fallback: resolve by email (covers dev bypass + accounts without a
@@ -30,10 +34,18 @@ export default async function ProfilePage() {
   const userByEmail = !user && session.email
     ? await prisma.user.findUnique({
         where: { email: session.email },
-        select: { username: true },
+        select: PROFILE_USER_SELECT,
       })
     : null;
 
-  const handle = user?.username ?? userByEmail?.username ?? session.email?.split("@")[0] ?? "athlete";
-  redirect(`/profile/${handle}`);
+  const resolved = (user ?? userByEmail) as ProfileUser | null;
+  if (!resolved) return null;
+
+  // Users without a handle can't reach /profile/{username}, so render their
+  // own profile directly by id.
+  if (!resolved.username) {
+    return <ProfileServerView user={resolved} isOwner />;
+  }
+
+  redirect(`/profile/${resolved.username}`);
 }

--- a/app/organiser-landing/page.tsx
+++ b/app/organiser-landing/page.tsx
@@ -1,9 +1,17 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { Building2, ArrowRight } from "lucide-react";
+import { getOrganiserSession } from "@/lib/amplify-server";
 
-const CUSTOMER_URL = process.env.NODE_ENV === "development" ? "/" : "https://startlineau.com";
+const CUSTOMER_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  (process.env.NODE_ENV === "development" ? "" : "https://startlineau.com")
+).replace(/\/$/, "");
 
-export default function OrganiserLandingPage() {
+export default async function OrganiserLandingPage() {
+  const session = await getOrganiserSession();
+  if (session) redirect("/organiser/dashboard");
+
   return (
     <main className="min-h-screen bg-dark-darker flex items-center justify-center px-6">
       <div className="text-center max-w-md">
@@ -17,7 +25,7 @@ export default function OrganiserLandingPage() {
           Sign up for a free user account, then set up your organiser profile to start publishing events on Australia&apos;s fitness calendar.
         </p>
         <Link
-          href={`${CUSTOMER_URL}organiser-setup`}
+          href={`${CUSTOMER_URL}/organiser-setup`}
           className="bg-machined shadow-machined inline-flex items-center gap-2 text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 px-8 rounded-md hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform"
         >
           Get started <ArrowRight className="w-4 h-4" />

--- a/components/organiser/OrganiserNavBar.tsx
+++ b/components/organiser/OrganiserNavBar.tsx
@@ -171,7 +171,7 @@ export default function OrganiserNavBar() {
 
           {/* ── Logo ── */}
           <div className="shrink-0 flex items-center gap-3 min-w-0">
-            <Link href="/" className="py-1 flex items-center gap-2">
+            <Link href="/organiser/dashboard" className="py-1 flex items-center gap-2">
               <Image src="/images/logo-title.svg" alt="Startline" width={110} height={28} className="h-6 w-auto" />
             </Link>
           </div>

--- a/components/profile/ProfileServerView.tsx
+++ b/components/profile/ProfileServerView.tsx
@@ -1,0 +1,135 @@
+import prisma from "@/lib/prisma";
+import { getOrganiserRatings } from "@/lib/reviews";
+import ProfilePageClient from "@/components/profile/ProfilePageClient";
+
+export const PROFILE_USER_SELECT = {
+  id: true,
+  username: true,
+  email: true,
+  name: true,
+  bio: true,
+  profilePicUrl: true,
+  isPublic: true,
+  city: true,
+  state: true,
+  mobile: true,
+  dateOfBirth: true,
+  gender: true,
+  emergencyContactName: true,
+  emergencyContactPhone: true,
+  createdAt: true,
+  memberships: {
+    select: {
+      organiser: { select: { id: true, orgName: true, logoUrl: true, verified: true } },
+    },
+    take: 1,
+    orderBy: { createdAt: "asc" },
+  },
+} as const;
+
+export type ProfileUser = {
+  id: string;
+  username: string | null;
+  email: string;
+  name: string | null;
+  bio: string | null;
+  profilePicUrl: string | null;
+  isPublic: boolean;
+  city: string | null;
+  state: string | null;
+  mobile: string | null;
+  dateOfBirth: string | null;
+  gender: string | null;
+  emergencyContactName: string | null;
+  emergencyContactPhone: string | null;
+  createdAt: Date;
+  memberships: { organiser: { id: string; orgName: string | null; logoUrl: string | null; verified: boolean } }[];
+};
+
+/**
+ * Renders a user's profile (history + optional owner edit affordances).
+ * Shared by /profile (owner by id, no username required) and
+ * /profile/[username] (public profile). The caller resolves the user and any
+ * privacy gating; this component only fetches race history + ratings.
+ */
+export default async function ProfileServerView({
+  user,
+  isOwner,
+}: {
+  user: ProfileUser;
+  isOwner: boolean;
+}) {
+  const registrations = await prisma.registration.findMany({
+    where: { userId: user.id, status: "CONFIRMED" },
+    orderBy: { event: { eventDate: "asc" } },
+    select: {
+      id: true,
+      resultTime: true,
+      resultPlacement: true,
+      event: {
+        select: {
+          id: true,
+          title: true,
+          discipline: true,
+          eventDate: true,
+          city: true,
+          state: true,
+          coverImageUrl: true,
+          organiser: { select: { id: true, orgName: true, logoUrl: true } },
+        },
+      },
+    },
+  });
+
+  const ratings = await getOrganiserRatings(
+    registrations.map((r) => r.event.organiser.id),
+  );
+
+  const profile = {
+    username: user.username ?? "",
+    bio: user.bio,
+    profilePicUrl: user.profilePicUrl,
+    history: {
+      completed: registrations.length,
+      registrations: registrations.map((r) => ({
+        ...r,
+        event: {
+          ...r.event,
+          organiser: {
+            ...r.event.organiser,
+            rating: ratings.get(r.event.organiser.id) ?? null,
+          },
+        },
+      })),
+    },
+  };
+
+  const ownerData = isOwner
+    ? {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        username: user.username,
+        bio: user.bio,
+        isPublic: user.isPublic,
+        city: user.city,
+        state: user.state,
+        profilePicUrl: user.profilePicUrl,
+        mobile: user.mobile,
+        dateOfBirth: user.dateOfBirth,
+        gender: user.gender,
+        emergencyContactName: user.emergencyContactName,
+        emergencyContactPhone: user.emergencyContactPhone,
+        createdAt: user.createdAt,
+        organiser: user.memberships[0]?.organiser ?? null,
+      }
+    : null;
+
+  return (
+    <ProfilePageClient
+      profile={profile}
+      isOwner={isOwner}
+      ownerData={ownerData}
+    />
+  );
+}

--- a/lib/registration-form.ts
+++ b/lib/registration-form.ts
@@ -177,6 +177,14 @@ export function getRegistrationFormErrors(
     if (!data.emergencyContactPhone.trim()) {
       errors.emergencyContactPhone = "Emergency contact number is required.";
     }
+    // Emergency contact must be someone other than the participant themselves
+    // (mirrors the group/shared-contact check in getEmergencyContactErrors).
+    const selfErrors = getEmergencyContactErrors(
+      { name: data.emergencyContactName, phone: data.emergencyContactPhone },
+      [data]
+    );
+    if (selfErrors.emergencyContactName) errors.emergencyContactName = selfErrors.emergencyContactName;
+    if (selfErrors.emergencyContactPhone) errors.emergencyContactPhone = selfErrors.emergencyContactPhone;
   }
 
   if (includeWaiver && !data.waiverAccepted) {

--- a/lib/turnstile.ts
+++ b/lib/turnstile.ts
@@ -18,6 +18,23 @@ export function turnstileConfigured(): boolean {
   return Boolean(process.env.TURNSTILE_SECRET_KEY);
 }
 
+// Hostnames where bot checks are enforced. Everywhere else (Amplify preview
+// URLs, localhost, staging aliases) we fail open — those hostnames aren't
+// whitelisted on the Cloudflare Turnstile widget, so the widget errors out and
+// no token is ever produced. ponytail: preview hostnames are dynamic and can't
+// be enumerated; gate on the known production set instead.
+const BOT_CHECK_HOSTS = new Set([
+  "startlineau.com",
+  "www.startlineau.com",
+  "staging.startlineau.com",
+]);
+
+function botCheckApplicable(req?: NextRequest): boolean {
+  if (!req) return true;
+  const host = (req.headers.get("host") ?? "").replace(/:\d+$/, "");
+  return BOT_CHECK_HOSTS.has(host);
+}
+
 type VerifyResult = { success: boolean };
 
 export async function verifyTurnstileToken(
@@ -59,6 +76,7 @@ export async function assertTurnstile(
   body: { turnstileToken?: string | null } | null | undefined,
   action: string,
 ): Promise<NextResponse | null> {
+  if (!botCheckApplicable(req)) return null;
   if (await verifyTurnstileToken(body?.turnstileToken, req)) return null;
   await recordSecurityEvent({
     type: "bot_check_failed",

--- a/src/__tests__/registration-form.test.ts
+++ b/src/__tests__/registration-form.test.ts
@@ -37,6 +37,16 @@ describe("registration form validation", () => {
     expect(validateRegistrationForm({ ...valid, emergencyContactPhone: "" })).toMatch(/emergency/i);
   });
 
+  it("rejects an emergency contact matching the single registrant", () => {
+    const errors = getRegistrationFormErrors({
+      ...valid,
+      emergencyContactName: "Alex Rossi",
+      emergencyContactPhone: "0400000000",
+    });
+    expect(errors.emergencyContactName).toMatch(/other than a participant/i);
+    expect(errors.emergencyContactPhone).toMatch(/differ from participant/i);
+  });
+
   it("requires participants to be at least 18", () => {
     const latestAllowed = maxDateOfBirthForMinAge();
     const d = new Date(latestAllowed + "T00:00:00");

--- a/src/__tests__/turnstile.test.ts
+++ b/src/__tests__/turnstile.test.ts
@@ -13,9 +13,9 @@ import { recordSecurityEvent } from "@/lib/security-event";
 
 const recordMock = recordSecurityEvent as ReturnType<typeof vi.fn>;
 
-function makeRequest() {
-  return new NextRequest("http://localhost:3000/api/contact", {
-    headers: { "x-forwarded-for": "203.0.113.9" },
+function makeRequest(host = "startlineau.com") {
+  return new NextRequest(`http://${host}/api/contact`, {
+    headers: { "x-forwarded-for": "203.0.113.9", host },
   });
 }
 
@@ -107,6 +107,17 @@ describe("assertTurnstile", () => {
   it("passes through when Turnstile is unconfigured", async () => {
     delete process.env.TURNSTILE_SECRET_KEY;
     const res = await assertTurnstile(makeRequest(), { turnstileToken: undefined }, "contact");
+    expect(res).toBeNull();
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+
+  it("fails open on non-production hostnames (Amplify preview URLs)", async () => {
+    process.env.TURNSTILE_SECRET_KEY = "secret";
+    const res = await assertTurnstile(
+      makeRequest("main.d1xamplifyapp.com.amplifyapp.com"),
+      { turnstileToken: undefined },
+      "contact",
+    );
     expect(res).toBeNull();
     expect(recordMock).not.toHaveBeenCalled();
   });

--- a/terraform/cloudflare-turnstile.tf
+++ b/terraform/cloudflare-turnstile.tf
@@ -5,7 +5,7 @@ resource "cloudflare_turnstile_widget" "spam_bot_protection" {
   account_id = var.cloudflare_account_id
   name       = "startline-web-app"
 
-  domains = ["startlineau.com", "staging.startlineau.com", "localhost"]
+  domains = ["startlineau.com", "www.startlineau.com", "staging.startlineau.com", "localhost"]
 
   mode = "invisible"
 }


### PR DESCRIPTION
## Description

Fixes the five issues reported in #282.

1. **Turnstile blocked checkout on preview URLs** — the Cloudflare widget only works on whitelisted hostnames, and Amplify preview hostnames are dynamic. `assertTurnstile` now fails open on non-production hosts (startlineau.com / www / staging), so registration, contact, feedback, etc. work on `*.amplifyapp.com` URLs. Also added the missing `www.startlineau.com` to the widget's `domains` (it's the canonical site URL and was silently un-whitelisted). The register wizard hides the non-functional widget off-prod.

2. **Emergency contact could be yourself** — the self-match rejection (`getEmergencyContactErrors`) only ran for group/shared-contact registrations. It now also applies to a single registrant.

3. **Organiser nav looped to "Become an Organiser"** — the organiser landing page now redirects signed-in users who already have an organiser profile to `/organiser/dashboard`; the portal logo links there too.

4. **Profile broken for new users** — users without a `username` were redirected to a phantom `/profile/{email-local}` → "Profile not found". `/profile` now renders the owner's profile by id when no username is set (shared fetch/render extracted into `ProfileServerView`).

5. **"Get Started" linked to `startlineau.comorganiser-setup`** — missing `/` in the URL join; also switched the base to per-env `NEXT_PUBLIC_SITE_URL` so staging doesn't hop to prod.

## Notes

- Emergency-contact visibility question from the issue: organisers *can* see it (registration CSV export + Stripe metadata). Flagging for a product decision on whether that's desired.
- Unit tests added for both Turnstile host-gating and single-registrant emergency-contact self-match.
- Verified: `pnpm lint`, `pnpm typecheck`, `pnpm test` (255 passing), plus targeted E2E (checkout, user-profile, organiser, spam-protection).

Closes #282