### PR TITLE
chore: keep staging DB running 24/7

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -146,7 +146,7 @@ locals {
       cognito_deletion_protection      = false
       bucket_cors_allowed_origins      = ["*"]
       site_url                         = "https://staging.startlineau.com"
-      enable_daily_stop                = true
+      enable_daily_stop                = false
     }
   }
 


### PR DESCRIPTION
Removes the daily RDS stop scheduler for staging by flipping `enable_daily_stop` to `false`.

The staging DB stays available around the clock; the scheduler role and schedule are destroyed on apply (count = 0).