### PR TITLE
fix(fonts): restore Chakra Petch as default sans and load real italics

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17,7 +17,7 @@
   --color-muted-light: #a0a5ae;
   --color-muted-dark: #6e737b;
 
-  --font-sans: var(--font-inter), system-ui, sans-serif;
+  --font-sans: var(--font-chakra-petch), var(--font-inter), system-ui, sans-serif;
   --font-headline: var(--font-chakra-petch), sans-serif;
 
   --shadow-machined: 2px 2px 0 #b3e153;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,10 @@ const inter = Inter({
 const chakraPetch = Chakra_Petch({
   subsets:  ["latin"],
   weight:   ["400", "500", "600", "700"],
+  // Headings use `italic` (hero h1, card/dialog titles). Without this the
+  // browser synthesises the slant and Chakra Petch loses its squared-off
+  // letterforms.
+  style:    ["normal", "italic"],
   variable: "--font-chakra-petch",
 });
 


### PR DESCRIPTION
## What

Two changes, both in their Tailwind v4 locations (this branch is cut from current `main`, after #270 migrated off `tailwind.config.ts`).

**1. Chakra Petch restored as the default sans** — `app/globals.css`

```diff
- --font-sans: var(--font-inter), system-ui, sans-serif;
+ --font-sans: var(--font-chakra-petch), var(--font-inter), system-ui, sans-serif;
```

**2. Real italics loaded** — `app/layout.tsx`

`next/font` only requested the normal style, so browsers synthesised the slant on every `italic` heading and Chakra Petch lost its squared-off letterforms. Now requests `style: ["normal", "italic"]`.

## Why

Chakra Petch was the site-wide default until `62039c4`, which demoted it to a heading-only token and made Inter the default `font-sans`. That commit landed on main via #13. Since then, anything not explicitly opting into `font-headline` has rendered in Inter.

In practice `font-headline` is used 1243 times, so most visible text was already Chakra Petch — this closes the remaining gap: text with no font class, and all native form controls (Tailwind preflight sets `font-family: inherit` on `input`/`select`/`textarea`).

## Verified

Confirmed in the build output rather than inferred:

```
--font-sans: var(--font-chakra-petch), var(--font-inter), system-ui, sans-serif
--font-chakra-petch: "Chakra Petch", "Chakra Petch Fallback"
18 font-style:italic faces emitted
```

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test` — 255 passed / 29 files
- `pnpm build` — succeeds

## Known gaps, deliberately not fixed here

- **Stripe payment fields** — `ReviewPayStep.tsx:53` sets `appearance.variables.fontFamily: "Chakra Petch, ..."`, but Elements renders in a cross-origin iframe and no `fonts: [...]` array is passed, so card/expiry/CVC silently fall back to `system-ui`. The appearance variable reads as though it works, which is why it wasn't caught. Worth a follow-up.
- **Waitlist email input** — `globals.css:522` hardcodes `var(--font-inter)`; now the only explicit Inter override left, and inconsistent with its own sibling button.
- **Cloudflare Turnstile** — cross-origin iframe on six surfaces; Cloudflare owns its typography.
- **Hero h1 uses `font-black`** — Chakra Petch tops out at 700, so 900 is still synthesised. `font-bold` would render true.