### PR TITLE
fix(fonts): mount next/font variables on <html> so the theme tokens resolve

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -98,11 +98,15 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  // The next/font variables must sit on <html>, not <body>. Tailwind v4
+  // compiles the @theme block to :root, so --font-sans and --font-headline are
+  // declared there; a custom property substitutes its var() references where it
+  // is declared, so with the font variables on <body> those references resolve
+  // against :root, find nothing, and leave both tokens guaranteed-invalid.
+  // Every element then falls back to the system stack.
   return (
-    <html lang="en">
-      <body
-        className={`${inter.variable} ${chakraPetch.variable} bg-dark-darker text-light font-sans antialiased`}
-      >
+    <html lang="en" className={`${inter.variable} ${chakraPetch.variable}`}>
+      <body className="bg-dark-darker text-light font-sans antialiased">
         <NativeLinkHandler />
         {children}
       </body>


### PR DESCRIPTION
## Problem

Chakra Petch has not rendered anywhere on the site since the Tailwind v4 bump in 959b7bc (#270). #287 restored it as the default `--font-sans`, but that change could not take effect, which is why the site looked unchanged after it merged.

Tailwind v4 compiles the `@theme` block to `:root`, so `--font-sans` and `--font-headline` are declared on `<html>`. The next/font variables were mounted on `<body>`.

A custom property substitutes its `var()` references **where it is declared**. `--font-sans` therefore resolved `var(--font-chakra-petch)` against `:root`, found nothing, and — with no fallback — became guaranteed-invalid. `<body>` inherited an empty token and every element fell back to the system stack.

Under Tailwind v3 this worked, because the families came from `tailwind.config.ts` and were resolved per element rather than through a `:root` custom property.

## Fix

Move `inter.variable` and `chakraPetch.variable` from `<body>` to `<html>`, putting them in the same scope as the tokens that reference them.

## Verification

Measured on `/events` against the dev server.

Before:

| | |
|---|---|
| `--font-sans` (root) | *(empty)* |
| `body` font-family | `-apple-system` |
| h2 "16 events found" | `-apple-system` |

After:

| | |
|---|---|
| `--font-sans` (root) | `'Chakra Petch', 'Chakra Petch Fallback', 'Inter', …` |
| `--font-headline` (body) | `'Chakra Petch', 'Chakra Petch Fallback', sans-serif` |
| `body` font-family | `"Chakra Petch"` |
| h2 "16 events found" | `"Chakra Petch"` (italic) |

`typecheck`, `lint`, 255 unit tests and the production build all pass.
