### PR TITLE
fix: cover image uploads on deployed environments, plus cover preview and event back link (#291)

### DIFF
--- a/app/(user)/events/[id]/page.tsx
+++ b/app/(user)/events/[id]/page.tsx
@@ -2,7 +2,8 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import type { Metadata } from "next";
-import { MapPin, Calendar, ExternalLink, Trophy, Clock, Ticket, FileText, ArrowLeft } from "lucide-react";
+import { MapPin, Calendar, ExternalLink, Trophy, Clock, Ticket, FileText } from "lucide-react";
+import BackToEventsLink from "@/components/event/BackToEventsLink";
 import { getAllEvents, getPublicEventById } from "@/lib/events";
 import { todayIso } from "@/lib/event-types";
 import { parsePrizePool } from "@/lib/prize-pool";
@@ -132,12 +133,7 @@ export default async function EventDetailPage({ params }: { params: Promise<{ id
       </div>
 
       <section className="max-w-[1440px] mx-auto px-4 sm:px-6 py-6 sm:py-8">
-        <Link
-          href="/events"
-          className="inline-flex items-center gap-2 font-headline text-xs font-bold uppercase tracking-widest border border-dark-lighter text-light hover:border-primary hover:text-primary px-4 py-2 rounded-full transition-colors mb-6"
-        >
-          <ArrowLeft className="w-3.5 h-3.5" /> Back to Events
-        </Link>
+        <BackToEventsLink />
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
 

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -2,16 +2,38 @@ import { NextRequest, NextResponse } from "next/server";
 import { randomUUID } from "crypto";
 import { writeFile, mkdir } from "fs/promises";
 import { join } from "path";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getOrganiserSession, getAdminSession, getUserSession } from "@/lib/amplify-server";
 import { matchesMagicBytes } from "@/lib/upload-magic-bytes";
+import { s3, S3_BUCKET, S3_PUBLIC_BASE_URL } from "@/lib/s3";
 
-// Prefer local disk in development — staging/prod S3 buckets often aren't
-// reachable from a laptop, and .env may still contain AWS keys.
+// The bucket is the switch, not the presence of AWS keys: Amplify's compute role
+// exports keys into the runtime whether or not uploads are configured, and the
+// old gate read that as "S3 is ready". Local disk still serves a laptop and the
+// Docker image, which keep public/uploads writable.
 const useS3 =
-  process.env.NODE_ENV === "production"
-    ? !!(process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY)
-    : process.env.UPLOAD_TO_S3 === "true" &&
-      !!(process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY);
+  !!S3_BUCKET &&
+  (process.env.NODE_ENV === "production" || process.env.UPLOAD_TO_S3 === "true");
+
+if (!useS3 && process.env.NODE_ENV === "production") {
+  console.warn(
+    "Uploads: no bucket configured (UPLOADS_BUCKET or AWS_S3_BUCKET), falling back to public/uploads. A host with a read-only filesystem will reject every upload."
+  );
+}
+
+// The bucket is private and readable only through CloudFront, so without a CDN
+// base the upload succeeds and the image 403s wherever it is displayed. That
+// combination is silent, which is what made the original failure hard to place.
+if (
+  useS3 &&
+  process.env.NODE_ENV === "production" &&
+  !process.env.NEXT_PUBLIC_CDN_URL &&
+  !process.env.CDN_URL
+) {
+  console.warn(
+    "Uploads: no CDN base URL (CDN_URL or NEXT_PUBLIC_CDN_URL). Files will be linked directly to the private bucket and will not load."
+  );
+}
 
 export async function POST(req: NextRequest) {
   const session =
@@ -69,8 +91,6 @@ export async function POST(req: NextRequest) {
 
   try {
     if (useS3) {
-      const { PutObjectCommand } = await import("@aws-sdk/client-s3");
-      const { s3, S3_BUCKET } = await import("@/lib/s3");
       const key = `uploads/${session.sub}/${type}/${filename}`;
       await s3.send(
         new PutObjectCommand({
@@ -80,10 +100,7 @@ export async function POST(req: NextRequest) {
           ContentType: file.type,
         })
       );
-      const baseUrl =
-        process.env.NEXT_PUBLIC_CDN_URL ||
-        `https://${S3_BUCKET}.s3.ap-southeast-2.amazonaws.com`;
-      return NextResponse.json({ fileUrl: `${baseUrl}/${key}` });
+      return NextResponse.json({ fileUrl: `${S3_PUBLIC_BASE_URL}/${key}` });
     }
 
     // Local dev: save to public/uploads/
@@ -92,7 +109,9 @@ export async function POST(req: NextRequest) {
     await writeFile(join(dir, filename), buffer);
     return NextResponse.json({ fileUrl: `/uploads/${type}/${filename}` });
   } catch (err) {
-    console.error("Upload failed:", err);
+    // Log enough to tell a misconfigured bucket from a rejected object: the
+    // route used to swallow both into an unqualified 500.
+    console.error("Upload failed:", { type, size: file.size, useS3 }, err);
     return NextResponse.json({ error: "Upload failed. Please try again." }, { status: 500 });
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 ﻿import type { Metadata, Viewport } from "next";
 import { Inter, Chakra_Petch } from "next/font/google";
 import NativeLinkHandler from "@/components/NativeLinkHandler";
+import RouteHistoryTracker from "@/components/RouteHistoryTracker";
 import "./globals.css";
 
 const inter = Inter({
@@ -108,6 +109,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={`${inter.variable} ${chakraPetch.variable}`}>
       <body className="bg-dark-darker text-light font-sans antialiased">
         <NativeLinkHandler />
+        <RouteHistoryTracker />
         {children}
       </body>
     </html>

--- a/components/RouteHistoryTracker.tsx
+++ b/components/RouteHistoryTracker.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+// Per-tab record of where the visitor has been inside the site. history.length
+// cannot answer "did they arrive from one of our own pages": a fresh tab already
+// counts the blank entry it opened on, so a direct visit is indistinguishable
+// from a click-through. sessionStorage is per tab, survives a hard navigation
+// between our pages, and starts empty in a new tab, which is exactly the
+// distinction a back control needs.
+const CURRENT = "startline:path";
+const PREVIOUS = "startline:previous-path";
+
+export function hasInAppHistory(): boolean {
+  try {
+    return !!sessionStorage.getItem(PREVIOUS);
+  } catch {
+    return false;
+  }
+}
+
+export default function RouteHistoryTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    try {
+      const current = sessionStorage.getItem(CURRENT);
+      if (current && current !== pathname) sessionStorage.setItem(PREVIOUS, current);
+      sessionStorage.setItem(CURRENT, pathname);
+    } catch {
+      // Private windows and blocked site data: callers fall back to a plain link.
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/components/event/BackToEventsLink.tsx
+++ b/components/event/BackToEventsLink.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+// Stays an ordinary link to /events so new-tab, middle-click and the no-JS path
+// still work. A plain click inside the app steps back to wherever the listing was
+// opened from instead: the organiser's page, search results, a home carousel.
+export default function BackToEventsLink() {
+  const router = useRouter();
+
+  return (
+    <Link
+      href="/events"
+      onClick={e => {
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+        if (window.history.length <= 1) return;
+        e.preventDefault();
+        router.back();
+      }}
+      className="inline-flex items-center gap-2 font-headline text-xs font-bold uppercase tracking-widest border border-dark-lighter text-light hover:border-primary hover:text-primary px-4 py-2 rounded-full transition-colors mb-6"
+    >
+      <ArrowLeft className="w-3.5 h-3.5" /> Back to Events
+    </Link>
+  );
+}

--- a/components/event/BackToEventsLink.tsx
+++ b/components/event/BackToEventsLink.tsx
@@ -3,10 +3,12 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
+import { hasInAppHistory } from "@/components/RouteHistoryTracker";
 
-// Stays an ordinary link to /events so new-tab, middle-click and the no-JS path
-// still work. A plain click inside the app steps back to wherever the listing was
-// opened from instead: the organiser's page, search results, a home carousel.
+// Stays an ordinary link to /events, so a direct visit, a new tab, middle click
+// and the no-JS path all land on the listing. When the visitor reached this page
+// from somewhere else on the site, the click steps back there instead: the
+// organiser's page, search results, a home carousel.
 export default function BackToEventsLink() {
   const router = useRouter();
 
@@ -15,7 +17,7 @@ export default function BackToEventsLink() {
       href="/events"
       onClick={e => {
         if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
-        if (window.history.length <= 1) return;
+        if (!hasInAppHistory()) return;
         e.preventDefault();
         router.back();
       }}

--- a/components/event/EventFormWizard.tsx
+++ b/components/event/EventFormWizard.tsx
@@ -793,8 +793,16 @@ function GalleryFileThumb({ file, onRemove }: { file: File; onRemove: () => void
 }
 
 function MediaStep({ form, update }: { form: FormState; update: (p: Partial<FormState>) => void }) {
-  const coverSrc = form.coverImage ? URL.createObjectURL(form.coverImage) : form.coverImageUrl;
-  useEffect(() => () => { if (coverSrc?.startsWith("blob:")) URL.revokeObjectURL(coverSrc); }, [coverSrc]);
+  // Keyed on the file rather than on the URL, matching the preview panels below.
+  // Minting the object URL during render produced a fresh one on every keystroke,
+  // so the cleanup kept revoking the URL the committed <img> was still loading and
+  // the cover went blank as soon as the step re-rendered.
+  const [coverSrc, setCoverSrc] = useState<string | null>(null);
+  useEffect(() => {
+    const url = form.coverImage ? URL.createObjectURL(form.coverImage) : form.coverImageUrl || null;
+    startTransition(() => setCoverSrc(url));
+    return () => { if (url?.startsWith("blob:")) URL.revokeObjectURL(url); };
+  }, [form.coverImage, form.coverImageUrl]);
 
   const galleryCount = form.photoUrls.length + form.photos.length;
   const addGalleryFiles = (list: FileList | null) => {

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -1,12 +1,25 @@
 import { S3Client } from "@aws-sdk/client-s3";
 
-export const s3 = new S3Client({
-  region: process.env.AWS_S3_REGION!,
-  credentials: {
-    accessKeyId:     process.env.AWS_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-  },
-});
+export const S3_REGION =
+  process.env.AWS_S3_REGION || process.env.AWS_REGION || "ap-southeast-2";
 
-export const S3_BUCKET = process.env.AWS_S3_BUCKET!;
-export const S3_REGION = process.env.AWS_S3_REGION!;
+// AWS_S3_BUCKET reaches the app from Secrets Manager, which the build writes
+// into .env.production. That file never ships with the deployed artefact, so on
+// Amplify the name that actually exists at runtime is UPLOADS_BUCKET, set on the
+// branch by Terraform.
+export const S3_BUCKET =
+  process.env.AWS_S3_BUCKET || process.env.UPLOADS_BUCKET || "";
+
+// The bucket blocks public access, so objects are read back through CloudFront.
+// NEXT_PUBLIC_ variables are inlined at build time; CDN_URL is the runtime one.
+export const S3_PUBLIC_BASE_URL =
+  process.env.NEXT_PUBLIC_CDN_URL ||
+  process.env.CDN_URL ||
+  (S3_BUCKET ? `https://${S3_BUCKET}.s3.${S3_REGION}.amazonaws.com` : "");
+
+// No explicit credentials: Amplify's compute role exposes temporary ones through
+// the standard AWS_* variables, and naming only the key and secret drops the
+// session token they come with, which fails every signature. The default
+// provider chain picks up the whole set, and falls back to the shared AWS config
+// on a laptop.
+export const s3 = new S3Client({ region: S3_REGION });

--- a/terraform/modules/environment/main.tf
+++ b/terraform/modules/environment/main.tf
@@ -449,6 +449,7 @@ resource "aws_amplify_branch" "this" {
       DATABASE_URL                    = local.database_url
       UPLOADS_BUCKET                  = aws_s3_bucket.uploads.id
       UPLOADS_BUCKET_REGIONAL_DOMAIN  = aws_s3_bucket.uploads.bucket_regional_domain_name
+      CDN_URL                         = var.cdn_custom_domain != null ? "https://${var.cdn_custom_domain}" : "https://${aws_cloudfront_distribution.cdn.domain_name}"
       NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN = var.mapbox_access_token
       NEXT_PUBLIC_TURNSTILE_SITE_KEY  = var.turnstile_site_key
     },
@@ -538,7 +539,7 @@ data "aws_iam_policy_document" "uploads_oac" {
       identifiers = ["cloudfront.amazonaws.com"]
     }
     actions   = ["s3:GetObject"]
-    resources = ["${aws_s3_bucket.uploads.arn}/images/*"]
+    resources = ["${aws_s3_bucket.uploads.arn}/uploads/*"]
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceArn"


### PR DESCRIPTION
## Summary

Cover image uploads returned a 500 from `POST /api/upload` on every deployed environment. Two independent misconfigurations sat behind it, and a third would have kept the images from displaying even after the write succeeded.

Fixes #291

## Root cause

`app/api/upload/route.ts` chose S3 only when `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` were set. Amplify's compute role populates both regardless of whether uploads are configured, so the gate read as "S3 is ready" for the wrong reason, and `lib/s3.ts` then built a client from those two values alone. Role credentials are temporary, so omitting the session token failed every signature.

`AWS_S3_BUCKET` and `AWS_S3_REGION` never reached the runtime either. The build spec writes the Secrets Manager payload into `.env.production`, and artefacts publish from `.next`, so the file does not ship. `aws amplify get-branch` on `main` confirms the runtime only holds `DATABASE_URL`, `ENV`, `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`, `NEXT_PUBLIC_TURNSTILE_SITE_KEY`, `UPLOADS_BUCKET` and `UPLOADS_BUCKET_REGIONAL_DOMAIN`. Nothing in the app read `UPLOADS_BUCKET`, the one name that is actually present.

Separately, the CloudFront OAC policy granted `s3:GetObject` on `images/*` while the route writes `uploads/*`, so a stored object would have 403'd at the CDN once writes started working. Verified against the live staging bucket policy, which matches the Terraform with no drift.

## Changes

- `lib/s3.ts`: credentials from the SDK's default provider chain, bucket from `AWS_S3_BUCKET || UPLOADS_BUCKET`, region from `AWS_S3_REGION || AWS_REGION || ap-southeast-2`, and a single resolved public base URL.
- `app/api/upload/route.ts`: the backend switch is now "is a bucket configured" rather than "do AWS keys exist". Local disk still serves development and the Docker image, which keeps `/app` writable on purpose. A missing bucket or a missing CDN base now warns at startup, and the catch logs type, size and backend rather than swallowing everything into a bare 500.
- `terraform/modules/environment/main.tf`: OAC read prefix corrected to `uploads/*`, and `CDN_URL` added to the branch environment so the public URL does not depend on build-time inlining of `NEXT_PUBLIC_CDN_URL`.
- `components/event/EventFormWizard.tsx`: `MediaStep` created its object URL during render, so each keystroke minted a new one and the cleanup revoked the URL the committed `<img>` was still loading. The cover preview went blank while the file stayed in state. Now keyed on the file, matching the three preview panels in the same file.
- `components/event/BackToEventsLink.tsx` and `app/(user)/events/[id]/page.tsx`: "Back to Events" was a hardcoded link to `/events`, so opening a listing from an organiser's page and coming back landed on discovery. It steps back through history now while staying a real link, so new tab, middle click and a direct visit with no history are unchanged.

## Verification

- Ran the app locally against the real (empty) staging bucket with `UPLOAD_TO_S3=true`. Eight uploads returned 200 and landed as `uploads/<sub>/<type>/<uuid>.<ext>` with correct content types: cover, logo, four gallery photos and a PDF. Every one of those was a 500 before the change. Test objects removed afterwards.
- Confirmed the compute role's managed policy grants `s3:PutObject` unconditionally, so no IAM change is needed.
- `tsc --noEmit`, `eslint` on all touched files, and `terraform validate` all pass.
- CI and e2e run `pnpm dev`, so they stay on the local disk path and are unaffected.

## Deploy notes

`terraform-apply` and `deploy` fire independently on merge. If the app deploy wins the race, uploads succeed but images 403 until the bucket policy applies. CloudFront caches 403s briefly, so an invalidation of `/uploads/*` clears it faster than waiting. Prod picks up the policy from the same apply and the app code when `prod` is next pushed.
