### PR TITLE
fix(upload): size caps for all upload types and session refresh before event submit

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getOrganiserSession, getAdminSession, getUserSession } from "@/lib/amplify-server";
 import { matchesMagicBytes } from "@/lib/upload-magic-bytes";
+import { uploadSizeError } from "@/lib/upload-limits";
 import { s3, S3_BUCKET, S3_PUBLIC_BASE_URL } from "@/lib/s3";
 
 // The bucket is the switch, not the presence of AWS keys: Amplify's compute role
@@ -62,8 +63,13 @@ export async function POST(req: NextRequest) {
   if (!TYPE_MIMES[type]?.includes(file.type)) {
     return NextResponse.json({ error: "File type not allowed for this upload." }, { status: 400 });
   }
-  if (type === "document" && file.size > 15 * 1024 * 1024) {
-    return NextResponse.json({ error: "PDF must be 15 MB or smaller." }, { status: 400 });
+
+  // Every type gets a cap, not just PDFs: images used to be unbounded, so a
+  // 60 MB phone photo sailed through here and died against the platform's own
+  // request-size ceiling with an unhelpful status (see issue #300).
+  const sizeError = uploadSizeError(type, file.size);
+  if (sizeError) {
+    return NextResponse.json({ error: sizeError }, { status: 400 });
   }
 
   const mimeExt: Record<string, string> = {

--- a/components/event/EventFormWizard.tsx
+++ b/components/event/EventFormWizard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, startTransition } from "react";
 import { useRouter } from "next/navigation";
+import { fetchAuthSession } from "aws-amplify/auth";
 import Image from "next/image";
 import {
   ArrowLeft, ArrowRight, Check, Plus, Trash2,
@@ -11,6 +12,7 @@ import {
   AlignLeft, Trophy, FileText,
 } from "lucide-react";
 import { encodePrizePool, parsePrizePool, normalisePrizeAmount } from "@/lib/prize-pool";
+import { UPLOAD_LIMITS } from "@/lib/upload-limits";
 import { formatDivisionLabel } from "@/lib/divisions";
 import { DEFAULT_REFUND_TIERS, REFUND_PRESETS, describeTiers, matchRefundPreset, parseTiers, tiersAreValid, type RefundTier } from "@/lib/refund-policy";
 import AddressAutocomplete  from "@/components/ui/AddressAutocomplete";
@@ -769,6 +771,17 @@ function TicketsStep({ form, update }: { form: FormState; update: (p: Partial<Fo
    ══════════════════════════════════════════════════════════════ */
 const MAX_GALLERY_PHOTOS = 8;
 const MAX_INFO_PDFS = 10;
+// Same caps the /api/upload route enforces. Checking at pick time matters
+// because uploads are deferred to submit: without this, an oversized file is
+// accepted silently and only fails five steps later (issue #300).
+const MAX_PDF_BYTES   = UPLOAD_LIMITS.document.bytes;
+const MAX_IMAGE_BYTES = UPLOAD_LIMITS.cover.bytes;
+const formatMb = (bytes: number) => `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+
+// Shown when an upload or the event save comes back 401. submitToApi refreshes
+// the token first, so landing here means the refresh token itself is gone.
+const SESSION_EXPIRED_MESSAGE =
+  "Your session has expired and nothing was saved. Please sign in again, then retry. Keep this tab open so you don't lose your event details.";
 
 function GalleryThumb({ src, onRemove }: { src: string; onRemove: () => void }) {
   return (
@@ -804,15 +817,40 @@ function MediaStep({ form, update }: { form: FormState; update: (p: Partial<Form
     return () => { if (url?.startsWith("blob:")) URL.revokeObjectURL(url); };
   }, [form.coverImage, form.coverImageUrl]);
 
+  const [coverError,   setCoverError]   = useState("");
+  const [galleryError, setGalleryError] = useState("");
+  const [pdfError,     setPdfError]     = useState("");
+
+  const oversizedMessage = (rejected: File[], maxBytes: number, kind: string) => {
+    const first = rejected[0];
+    const others = rejected.length > 1 ? ` (and ${rejected.length - 1} more)` : "";
+    return `"${first.name}" is ${formatMb(first.size)}${others}. ${kind} must be ${formatMb(maxBytes)} or smaller.`;
+  };
+
+  const pickCover = (file: File | null) => {
+    if (file && file.size > MAX_IMAGE_BYTES) {
+      setCoverError(oversizedMessage([file], MAX_IMAGE_BYTES, "Images"));
+      return;
+    }
+    setCoverError("");
+    update({ coverImage: file });
+  };
+
   const galleryCount = form.photoUrls.length + form.photos.length;
   const addGalleryFiles = (list: FileList | null) => {
-    const files = Array.from(list ?? []).filter(f => f.type.startsWith("image/"));
+    const picked = Array.from(list ?? []).filter(f => f.type.startsWith("image/"));
+    const files = picked.filter(f => f.size <= MAX_IMAGE_BYTES);
+    const rejected = picked.filter(f => f.size > MAX_IMAGE_BYTES);
+    setGalleryError(rejected.length ? oversizedMessage(rejected, MAX_IMAGE_BYTES, "Images") : "");
     const remaining = MAX_GALLERY_PHOTOS - galleryCount;
     if (files.length && remaining > 0) update({ photos: [...form.photos, ...files.slice(0, remaining)] });
   };
 
   const addInfoPdfs = (list: FileList | null) => {
-    const files = Array.from(list ?? []).filter(f => f.type === "application/pdf");
+    const picked = Array.from(list ?? []).filter(f => f.type === "application/pdf");
+    const files = picked.filter(f => f.size <= MAX_PDF_BYTES);
+    const rejected = picked.filter(f => f.size > MAX_PDF_BYTES);
+    setPdfError(rejected.length ? oversizedMessage(rejected, MAX_PDF_BYTES, "PDFs") : "");
     const remaining = MAX_INFO_PDFS - form.informationPdfs.length;
     if (files.length && remaining > 0) {
       update({
@@ -855,8 +893,11 @@ function MediaStep({ form, update }: { form: FormState; update: (p: Partial<Form
             </div>
           )}
           <input type="file" accept="image/*" className="sr-only"
-            onChange={e => update({ coverImage: e.target.files?.[0] ?? null })} />
+            onChange={e => { pickCover(e.target.files?.[0] ?? null); e.target.value = ""; }} />
         </label>
+        {coverError && (
+          <p className="font-headline text-[10px] uppercase tracking-widest text-red-400 mt-1.5">{coverError}</p>
+        )}
       </Field>
 
       <Field label="Gallery photos" hint={`${galleryCount}/${MAX_GALLERY_PHOTOS} · Optional`}>
@@ -878,8 +919,11 @@ function MediaStep({ form, update }: { form: FormState; update: (p: Partial<Form
             </label>
           )}
         </div>
+        {galleryError && (
+          <p className="font-headline text-[10px] uppercase tracking-widest text-red-400 mt-1.5">{galleryError}</p>
+        )}
         <p className="font-headline text-[10px] uppercase tracking-widest text-light mt-2">
-          Shown as a gallery on your event page: venue, atmosphere, past editions.
+          Shown as a gallery on your event page: venue, atmosphere, past editions. Up to 10 MB each.
         </p>
       </Field>
 
@@ -939,6 +983,9 @@ function MediaStep({ form, update }: { form: FormState; update: (p: Partial<Form
               </label>
             )}
           </div>
+        )}
+        {pdfError && (
+          <p className="font-headline text-[10px] uppercase tracking-widest text-red-400 mt-1.5">{pdfError}</p>
         )}
         <p className="font-headline text-[10px] uppercase tracking-widest text-light mt-2">
           Shown as downloads on your event page, up to 15 MB each
@@ -1561,6 +1608,14 @@ export default function EventFormWizard({
     setStep(target);
   };
 
+  // Distinguishes an expired session from a rejected file, and passes the
+  // route's specific reason through instead of a blanket "failed to upload".
+  const uploadErrorText = async (res: Response, fallback: string): Promise<string> => {
+    if (res.status === 401) return SESSION_EXPIRED_MESSAGE;
+    const data: { error?: string } = await res.json().catch(() => ({}));
+    return data.error ? `${fallback} ${data.error}` : `${fallback} Please try again or remove it.`;
+  };
+
   const submitToApi = async (asDraft: boolean, overrideTitle?: string): Promise<boolean> => {
     setSaving(true); setApiError(""); setSubmitErrors([]);
     try {
@@ -1568,13 +1623,22 @@ export default function EventFormWizard({
         setApiError("Select an organiser to create this event for.");
         return false;
       }
+
+      // Cognito access tokens last 60 minutes and nothing refreshes them after
+      // page load, so a wizard session longer than that used to 401 right here
+      // at the end (issue #300). fetchAuthSession refreshes an expired token
+      // from the refresh token and rewrites the cookies the API verifies.
+      // Failure is fine: the e2e bypass has no Cognito session at all, so let
+      // the requests themselves decide.
+      await fetchAuthSession().catch(() => null);
+
       let coverImageUrl: string | null = null;
       if (form.coverImage) {
         const fd = new FormData();
         fd.append("file", form.coverImage);
         fd.append("type", "cover");
         const uploadRes = await fetch("/api/upload", { method: "POST", body: fd });
-        if (!uploadRes.ok) { setApiError("Cover image upload failed. Please try again or remove the image."); return false; }
+        if (!uploadRes.ok) { setApiError(await uploadErrorText(uploadRes, "Cover image upload failed.")); return false; }
         const { fileUrl } = await uploadRes.json(); coverImageUrl = fileUrl;
       }
 
@@ -1586,7 +1650,7 @@ export default function EventFormWizard({
           fd.append("file", pdf.file);
           fd.append("type", "document");
           const uploadRes = await fetch("/api/upload", { method: "POST", body: fd });
-          if (!uploadRes.ok) { setApiError(`PDF "${pdf.file.name}" failed to upload. Please try again or remove it.`); return false; }
+          if (!uploadRes.ok) { setApiError(await uploadErrorText(uploadRes, `PDF "${pdf.file.name}" failed to upload.`)); return false; }
           const { fileUrl } = await uploadRes.json(); url = fileUrl;
         }
         if (url) informationPdfs.push({ url, label: pdf.label.trim(), name: pdf.name });
@@ -1598,7 +1662,7 @@ export default function EventFormWizard({
         fd.append("file", photo);
         fd.append("type", "photo");
         const uploadRes = await fetch("/api/upload", { method: "POST", body: fd });
-        if (!uploadRes.ok) { setApiError(`Gallery photo "${photo.name}" failed to upload. Please try again or remove it.`); return false; }
+        if (!uploadRes.ok) { setApiError(await uploadErrorText(uploadRes, `Gallery photo "${photo.name}" failed to upload.`)); return false; }
         const { fileUrl } = await uploadRes.json(); photoUrls.push(fileUrl);
       }
 
@@ -1646,7 +1710,10 @@ export default function EventFormWizard({
       }
 
       const data = await res.json().catch(() => ({}));
-      if (!res.ok) { setApiError(data.error ?? "Something went wrong."); return false; }
+      if (!res.ok) {
+        setApiError(res.status === 401 ? SESSION_EXPIRED_MESSAGE : (data.error ?? "Something went wrong."));
+        return false;
+      }
       if (asDraft && !eventId && data.id) setEventId(data.id);
       router.push(submitRedirect);
       return true;

--- a/components/organiser/SettingsModal.tsx
+++ b/components/organiser/SettingsModal.tsx
@@ -268,7 +268,10 @@ function PersonalInfoForm() {
     const fd = new FormData();
     fd.append("file", file); fd.append("type", type);
     const res = await fetch("/api/upload", { method: "POST", body: fd });
-    if (!res.ok) throw new Error("Upload failed.");
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || "Upload failed.");
+    }
     const { fileUrl } = await res.json();
     return fileUrl as string;
   };
@@ -283,7 +286,7 @@ function PersonalInfoForm() {
       if (!res.ok) { setError(data.error ?? "Logo upload failed."); return; }
       patch({ logoUrl: url });
       router.refresh();
-    } catch { setError("Logo upload failed."); }
+    } catch (err) { setError(err instanceof Error ? err.message : "Logo upload failed."); }
     finally { setLogoUploading(false); }
   };
 
@@ -297,7 +300,7 @@ function PersonalInfoForm() {
       if (!res.ok) { setError(data.error ?? "Cover upload failed."); return; }
       patch({ coverImageUrl: url });
       router.refresh();
-    } catch { setError("Cover upload failed."); }
+    } catch (err) { setError(err instanceof Error ? err.message : "Cover upload failed."); }
     finally { setCoverUploading(false); }
   };
 

--- a/lib/upload-limits.ts
+++ b/lib/upload-limits.ts
@@ -1,0 +1,24 @@
+// Per-type upload size caps, shared by the /api/upload route (enforcement)
+// and the pickers that select files client-side (early feedback). Uploads in
+// the event wizard are deferred to submit, so without the client-side check an
+// oversized file is accepted silently and only fails five steps later.
+
+export type UploadType = "logo" | "cover" | "photo" | "video" | "avatar" | "document";
+
+export const UPLOAD_LIMITS: Record<UploadType, { bytes: number; label: string }> = {
+  logo:     { bytes: 10 * 1024 * 1024,  label: "Image must be 10 MB or smaller."  },
+  cover:    { bytes: 10 * 1024 * 1024,  label: "Image must be 10 MB or smaller."  },
+  photo:    { bytes: 10 * 1024 * 1024,  label: "Image must be 10 MB or smaller."  },
+  avatar:   { bytes: 10 * 1024 * 1024,  label: "Image must be 10 MB or smaller."  },
+  video:    { bytes: 200 * 1024 * 1024, label: "Video must be 200 MB or smaller." },
+  document: { bytes: 15 * 1024 * 1024,  label: "PDF must be 15 MB or smaller."    },
+};
+
+// Returns the rejection message for an oversized file, or null when the size
+// is within the cap (or the type is unknown; the route's own type allowlist
+// rejects those before size is ever considered).
+export function uploadSizeError(type: string, size: number): string | null {
+  const limit = UPLOAD_LIMITS[type as UploadType];
+  if (!limit) return null;
+  return size > limit.bytes ? limit.label : null;
+}

--- a/src/__tests__/upload-limits.test.ts
+++ b/src/__tests__/upload-limits.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { UPLOAD_LIMITS, uploadSizeError } from "@/lib/upload-limits";
+
+const MB = 1024 * 1024;
+
+describe("uploadSizeError", () => {
+  it("accepts a file exactly at the cap", () => {
+    expect(uploadSizeError("document", 15 * MB)).toBeNull();
+    expect(uploadSizeError("cover", 10 * MB)).toBeNull();
+    expect(uploadSizeError("video", 200 * MB)).toBeNull();
+  });
+
+  it("rejects a file one byte over the cap with the type's message", () => {
+    expect(uploadSizeError("document", 15 * MB + 1)).toBe("PDF must be 15 MB or smaller.");
+    expect(uploadSizeError("cover", 10 * MB + 1)).toBe("Image must be 10 MB or smaller.");
+    expect(uploadSizeError("video", 200 * MB + 1)).toBe("Video must be 200 MB or smaller.");
+  });
+
+  it("caps every allowlisted upload type", () => {
+    for (const type of Object.keys(UPLOAD_LIMITS)) {
+      expect(uploadSizeError(type, 5 * 1024 * MB)).not.toBeNull();
+    }
+  });
+
+  it("defers unknown types to the route's own allowlist", () => {
+    expect(uploadSizeError("archive", 5 * 1024 * MB)).toBeNull();
+  });
+
+  it("keeps image caps consistent across image types", () => {
+    expect(UPLOAD_LIMITS.logo.bytes).toBe(UPLOAD_LIMITS.cover.bytes);
+    expect(UPLOAD_LIMITS.photo.bytes).toBe(UPLOAD_LIMITS.cover.bytes);
+    expect(UPLOAD_LIMITS.avatar.bytes).toBe(UPLOAD_LIMITS.cover.bytes);
+  });
+});


### PR DESCRIPTION
## Description

Closes #300.

Organisers hit two failures in the event wizard: a PDF that would not upload (with no useful reason shown), and a 401 Unauthorised on the event POST afterwards.

### PDF and image size limits

- `/api/upload` previously capped only PDFs (15 MB); images and video were unbounded. Every type now has a cap: images 10 MB, video 200 MB, PDF 15 MB. The caps live in `lib/upload-limits.ts`, shared between the route and the client pickers, with unit tests.
- The wizard uploads files only at submit time, so an oversized PDF or image was accepted silently and failed five steps later with a generic message. The pickers now reject oversized files immediately, naming the file and its size (e.g. "course-map.pdf" is 22.4 MB. PDFs must be 15.0 MB or smaller.).
- Upload failures at submit now show the server's actual reason instead of a blanket "failed to upload". Same for logo/cover uploads in organiser settings.

### The 401 on event submit

Cognito access tokens last 60 minutes and nothing refreshed them after page load, so any wizard session longer than that hit publish with an expired token and lost the form to an unexplained error. `submitToApi` now refreshes the session (via the 30-day refresh token) before the upload chain and the event POST. If a 401 still occurs (refresh token gone), the user sees a clear session-expired message and the form state is preserved.

## Testing

- `pnpm lint`, `pnpm typecheck`: 0 errors
- `pnpm test`: 400/400 pass (5 new tests for the shared size caps)
- `organiser.spec.ts` e2e: 22/25 pass; the 3 failures (ticket tiers, announcement editor, profile reposition) also fail on a clean `main` checkout with the same local DB, so they are pre-existing and unrelated
- The token-expiry path itself cannot be reproduced in e2e (needs a real token aged past 60 minutes); verified by code inspection of `lib/amplify-server.ts` and Amplify's refresh behaviour