### PR TITLE
Restore organiser portal sign-in and stop deploys wiping the database (#302)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # testing
 /coverage
 /test-results/
+/pw-results.json
 /playwright-report/
 
 # next.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,40 @@ Secrets in AWS Secrets Manager. `.env.local` at repo root (gitignored).
 
 **Setup:** `cp main-checkout/.env.local .env.local` in each worktree. Override `DATABASE_URL` to local Docker (`postgresql://postgres:postgres@localhost:5432/startline?schema=public`) if not using staging RDS.
 
+### Runtime vs build-time variables
+
+`next.config.ts` sets `output: "standalone"` and the Amplify build ships only
+`.next`, so the `.env.production` that preBuild writes from Secrets Manager
+never reaches the server. Secrets Manager therefore covers build time only.
+
+* `NEXT_PUBLIC_*` is fine there, because Next inlines it during `pnpm build`.
+* Anything the server reads at runtime (`STRIPE_SECRET_KEY`,
+  `STRIPE_WEBHOOK_SECRET`, `RESEND_API_KEY`, `RESEND_FROM`,
+  `TURNSTILE_SECRET_KEY`, `GUEST_EMAIL_VERIFICATION_SECRET`, `ABR_GUID`,
+  `DATABASE_URL`, `UPLOADS_BUCKET`, `CDN_URL`) has to be an Amplify **branch**
+  environment variable. Terraform sets those in
+  `terraform/modules/environment/main.tf`.
+
+Terraform owns the whole branch variable map, so a value added by hand in the
+Amplify console is deleted on the next apply. Add new runtime secrets to the
+`startline/ci-bootstrap` secret instead — `stripe_secret_key_prod`,
+`stripe_secret_key_staging`, `stripe_webhook_secret_prod`,
+`stripe_webhook_secret_staging`, `resend_api_key`, `resend_from`, `abr_guid`.
+A prod apply fails its precondition rather than silently clearing a missing one.
+
+## Portals and hostnames
+
+Production splits the three portals across `startlineau.com`,
+`organiser.startlineau.com` and `admin.startlineau.com`. Every other deployment
+(Amplify branch domain, PR previews, local dev) serves all three from one host.
+Cross-portal links must go through `lib/portal-domains.ts` so they stay relative
+on single-host deployments and absolute in production; hardcoding either shape
+breaks one of the two (issue #302).
+
+Cognito cookies are scoped to `.startlineau.com` in `components/AmplifyProvider.tsx`
+so a single sign-in covers all three portals. Host-only cookies left the
+organiser portal permanently signed out in production.
+
 ## Auth (Cognito)
 
 JWT verification in `middleware.ts` via `jose`. Tokens in Cognito-managed cookies. Only Cognito group: `admins`. Authorisation at DB level (Prisma).
@@ -174,6 +208,10 @@ for a deliberate reseed, then set it back). The seed itself also refuses any
 non-local `DATABASE_URL` unless `ALLOW_REMOTE_SEED=true`. A failed migration
 now fails the build rather than falling back to `migrate reset --force`,
 which used to drop the database.
+
+`SEED_DATABASE` is Terraform-managed and pinned to `"false"`, so a console
+flip lasts only until the next `terraform apply` resets it. Do the reseed and
+flip it back in the same sitting.
 
 `ci.yml` runs lint/typecheck/build/test/e2e on PRs (non-blocking). Deploys via `deploy.yml` to Amplify.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,15 @@ Environments:
 | Env | Branch | Build |
 |---|---|---|
 | `prod` | `prod` | Migrate, no seed |
-| `staging` | `main` | Migrate + seed |
+| `staging` | `main` | Migrate, no seed |
+
+Neither environment seeds on deploy. `prisma db seed` truncates every table
+and resets the shared Cognito seed passwords, so it is gated behind the
+`SEED_DATABASE` branch variable (set it to `"true"` in the Amplify console
+for a deliberate reseed, then set it back). The seed itself also refuses any
+non-local `DATABASE_URL` unless `ALLOW_REMOTE_SEED=true`. A failed migration
+now fails the build rather than falling back to `migrate reset --force`,
+which used to drop the database.
 
 `ci.yml` runs lint/typecheck/build/test/e2e on PRs (non-blocking). Deploys via `deploy.yml` to Amplify.
 

--- a/app/(user)/organiser-setup/page.tsx
+++ b/app/(user)/organiser-setup/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ArrowRight, Check, Building2, ShieldCheck, CreditCard, Users } from "lucide-react";
 import { useAuthContext } from "@/context/AuthContext";
+import { organiserHref } from "@/lib/portal-domains";
 import {
   Skeleton, PageHeaderSkeleton, PageShellSkeleton,
 } from "@/components/ui/skeleton";
@@ -88,7 +89,13 @@ export default function OrganiserSetupPage() {
         throw new Error(data.error ?? "Failed to create organiser profile.");
       }
 
-      router.push("/organiser/dashboard");
+      // In production this page is served from the athlete site and the
+      // dashboard lives on the organiser subdomain, where a relative push lands
+      // on the waitlist instead (issue #302). Elsewhere the two share a host and
+      // the href stays relative, so client-side navigation still applies.
+      const dashboard = organiserHref("/organiser/dashboard", window.location.host);
+      if (dashboard.startsWith("http")) window.location.assign(dashboard);
+      else router.push(dashboard);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Something went wrong.");
     } finally {

--- a/app/api/admin/events/[id]/review/route.ts
+++ b/app/api/admin/events/[id]/review/route.ts
@@ -96,20 +96,26 @@ export async function POST(
       }),
     ]);
 
+    // Awaited, not fired and forgotten: Amplify's compute freezes the container
+    // once the response is returned, so a floating promise is dropped at random
+    // and the organiser never hears that their event was reviewed. Delivery
+    // failures still must not fail the review itself.
     if (action === "approve") {
-      sendEventApprovedEmail(organiserEmail, event.title).catch((err) =>
-        console.error("Failed to send approval email:", err),
-      );
-      notifyOrganiserFollowers({
-        organiserId,
-        eventId: id,
-        eventTitle: event.title,
-        organiserName: event.organiser.orgName,
-        eventDate: event.eventDate || null,
-        city: event.city || null,
-      }).catch((err) => console.error("Follower notify failed:", err));
+      await Promise.all([
+        sendEventApprovedEmail(organiserEmail, event.title).catch((err) =>
+          console.error("Failed to send approval email:", err),
+        ),
+        notifyOrganiserFollowers({
+          organiserId,
+          eventId: id,
+          eventTitle: event.title,
+          organiserName: event.organiser.orgName,
+          eventDate: event.eventDate || null,
+          city: event.city || null,
+        }).catch((err) => console.error("Follower notify failed:", err)),
+      ]);
     } else {
-      sendEventRejectedEmail(organiserEmail, event.title, reason?.trim()).catch((err) =>
+      await sendEventRejectedEmail(organiserEmail, event.title, reason?.trim()).catch((err) =>
         console.error("Failed to send rejection email:", err),
       );
     }

--- a/app/api/admin/events/route.ts
+++ b/app/api/admin/events/route.ts
@@ -4,7 +4,7 @@ import { getAdminSession } from "@/lib/amplify-server";
 import { getEventCoords } from "@/lib/australia-coords";
 import { writeAuditLog } from "@/lib/audit";
 import { adminEventPayloadSchema, eventPayloadSchema } from "@/lib/schemas";
-import { uniqueSlug } from "@/lib/slugs";
+import { withUniqueSlug } from "@/lib/slugs";
 import { z } from "zod";
 
 const VALID_STATUSES = ["DRAFT", "PENDING", "APPROVED", "REJECTED", "ARCHIVED"] as const;
@@ -122,11 +122,12 @@ export async function POST(req: NextRequest) {
   const eventStatus = submit ? (organiser.verified ? "APPROVED" : "PENDING") : "DRAFT";
 
   try {
-    const event = await prisma.event.create({
+    const event = await withUniqueSlug(body.title ?? "", (slug) =>
+      prisma.event.create({
       data: {
         organiserId:      organiserId,
         status:           eventStatus,
-        slug:             await uniqueSlug(body.title ?? ""),
+        slug,
         title:            body.title ?? "",
         discipline:       body.discipline        ?? "",
         description:      body.description       ?? null,
@@ -159,7 +160,8 @@ export async function POST(req: NextRequest) {
         informationPdfs:  Array.isArray(body.informationPdfs) ? body.informationPdfs : [],
         photos:           Array.isArray(body.photos) ? body.photos : [],
       },
-    });
+      }),
+    );
 
     writeAuditLog({
       adminId: session.sub,

--- a/app/api/organiser/dashboard/route.ts
+++ b/app/api/organiser/dashboard/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { archivePastEvents } from "@/lib/archive-events";
 import {
   buildTrendDays,
@@ -8,8 +8,9 @@ import {
 } from "@/lib/organiser-dashboard";
 
 export async function GET(req: NextRequest) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   await archivePastEvents();
 

--- a/app/api/organiser/events/[id]/announcements/[announcementId]/route.ts
+++ b/app/api/organiser/events/[id]/announcements/[announcementId]/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { idAnnouncementIdParams } from "@/lib/schemas";
 export async function DELETE(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string; announcementId: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idAnnouncementIdParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/events/[id]/announcements/route.ts
+++ b/app/api/organiser/events/[id]/announcements/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { sanitizeHtml } from "@/lib/sanitize-html";
 import { stripHtml } from "@/lib/utils";
 import { idParams } from "@/lib/schemas";
@@ -16,8 +16,9 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
@@ -48,8 +49,9 @@ export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/events/[id]/check-in-qr/route.ts
+++ b/app/api/organiser/events/[id]/check-in-qr/route.ts
@@ -1,16 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import { randomUUID } from "crypto";
 import QRCode from "qrcode";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { idParams } from "@/lib/schemas";
 
 export async function POST(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsed = idParams.safeParse(await params);
   if (!parsed.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/events/[id]/dashboard/route.ts
+++ b/app/api/organiser/events/[id]/dashboard/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { archivePastEvents } from "@/lib/archive-events";
 import { PLATFORM_FEE_PERCENT, PLATFORM_FEE_FIXED_CENTS } from "@/lib/platform-fee";
 import { idParams } from "@/lib/schemas";
@@ -9,8 +9,9 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/events/[id]/duplicate/route.ts
+++ b/app/api/organiser/events/[id]/duplicate/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { shiftIsoDate } from "@/lib/duplicate-event";
 import { idParams } from "@/lib/schemas";
 import { uniqueSlug } from "@/lib/slugs";
@@ -10,8 +10,9 @@ export async function POST(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/events/[id]/duplicate/route.ts
+++ b/app/api/organiser/events/[id]/duplicate/route.ts
@@ -3,7 +3,7 @@ import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
 import { shiftIsoDate } from "@/lib/duplicate-event";
 import { idParams } from "@/lib/schemas";
-import { uniqueSlug } from "@/lib/slugs";
+import { withUniqueSlug } from "@/lib/slugs";
 
 /** POST /api/organiser/events/[id]/duplicate — copy listing fields into a new DRAFT (+7 days). */
 export async function POST(
@@ -28,11 +28,12 @@ export async function POST(
     const eventDate = shiftIsoDate(source.eventDate, 7) ?? source.eventDate;
     const endDate = source.endDate ? shiftIsoDate(source.endDate, 7) : null;
 
-    const draft = await prisma.event.create({
+    const draft = await withUniqueSlug(source.title, (slug) =>
+      prisma.event.create({
       data: {
         organiserId: source.organiserId,
         status: "DRAFT",
-        slug: await uniqueSlug(source.title),
+        slug,
         title: source.title,
         discipline: source.discipline,
         description: source.description,
@@ -66,7 +67,8 @@ export async function POST(
         informationPdfs: source.informationPdfs ?? [],
         photos: source.photos ?? [],
       },
-    });
+      }),
+    );
 
     return NextResponse.json({ id: draft.id });
   } catch (err) {

--- a/app/api/organiser/events/[id]/pin/route.ts
+++ b/app/api/organiser/events/[id]/pin/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { idParams } from "@/lib/schemas";
 export async function PATCH(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/events/[id]/registrations/export/route.ts
+++ b/app/api/organiser/events/[id]/registrations/export/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import {
   exportRowsToCsv,
   mapAndSortExportRows,
@@ -22,8 +22,9 @@ export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/events/[id]/registrations/move/route.ts
+++ b/app/api/organiser/events/[id]/registrations/move/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { CAPACITY_COUNTING_STATUSES } from "@/lib/registration-status";
 import { idParams } from "@/lib/schemas";
 import { z } from "zod";
@@ -18,8 +18,9 @@ export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/events/[id]/registrations/route.ts
+++ b/app/api/organiser/events/[id]/registrations/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { wavesWithCounts } from "@/lib/start-waves";
 import type { RegistrationStatus, Prisma } from "@prisma/client";
 import { idParams } from "@/lib/schemas";
@@ -37,8 +37,9 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
@@ -127,8 +128,9 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/events/[id]/results/route.ts
+++ b/app/api/organiser/events/[id]/results/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { isValidRaceTime, normaliseRaceTime } from "@/lib/race-results";
 import type { Prisma } from "@prisma/client";
 import { idParams } from "@/lib/schemas";
@@ -25,8 +25,9 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/events/[id]/route.ts
+++ b/app/api/organiser/events/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { getEventCoords } from "@/lib/australia-coords";
 import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
 import { eventPayloadSchema, idParams } from "@/lib/schemas";
@@ -10,8 +10,9 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
@@ -32,8 +33,9 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
@@ -160,8 +162,9 @@ export async function DELETE(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
   if (session.role !== "OWNER") return NextResponse.json({ error: "Forbidden." }, { status: 403 });
 
   const parsedParams = idParams.safeParse(await params);

--- a/app/api/organiser/events/[id]/route.ts
+++ b/app/api/organiser/events/[id]/route.ts
@@ -4,7 +4,7 @@ import prisma from "@/lib/prisma";
 import { getEventCoords } from "@/lib/australia-coords";
 import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
 import { eventPayloadSchema, idParams } from "@/lib/schemas";
-import { uniqueSlug } from "@/lib/slugs";
+import { withUniqueSlug } from "@/lib/slugs";
 
 export async function GET(
   _req: NextRequest,
@@ -91,14 +91,15 @@ export async function PATCH(
       ? (session.verified ? "APPROVED" : "PENDING")
       : "DRAFT";
 
-    const slug = data.title !== undefined && data.title !== existing.title
-      ? await uniqueSlug(data.title, id)
-      : undefined;
+    // Only a rename reassigns the slug; every other edit leaves it alone so links
+    // already in the wild keep resolving, and skips the lookup entirely.
+    const renamed = data.title !== undefined && data.title !== existing.title;
 
-    const updated = await prisma.event.update({
+    const runUpdate = (slug: string | undefined) =>
+      prisma.event.update({
       where: { id },
       data: {
-        slug:              slug,
+        slug,
         title:             data.title             ?? undefined,
         discipline:        data.discipline        ?? undefined,
         description:       data.description       ?? undefined,
@@ -132,11 +133,18 @@ export async function PATCH(
         photos:            Array.isArray(data.photos) ? data.photos : undefined,
         status:            nextStatus,
       },
-    });
+      });
+
+    const updated = renamed
+      ? await withUniqueSlug(data.title!, runUpdate, { excludeId: id })
+      : await runUpdate(undefined);
 
     // Existing was DRAFT (enforced above); notify when submit goes straight to live.
     if (updated.status === "APPROVED") {
-      prisma.organiser
+      // Awaited, not fired and forgotten: Amplify's compute freezes the
+      // container once the response is returned, so a floating promise is
+      // dropped at random. A notify failure still must not fail the publish.
+      await prisma.organiser
         .findUnique({ where: { id: updated.organiserId }, select: { orgName: true } })
         .then((org) =>
           notifyOrganiserFollowers({

--- a/app/api/organiser/events/[id]/waves/notify/route.ts
+++ b/app/api/organiser/events/[id]/waves/notify/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { sendWaveUpdateEmail } from "@/lib/email";
 import { idParams } from "@/lib/schemas";
 import { rateLimit } from "@/lib/rate-limit";
@@ -27,8 +27,9 @@ export async function POST(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const blocked = await rateLimit(_req, {
     prefix: "wave-notify",

--- a/app/api/organiser/events/[id]/waves/route.ts
+++ b/app/api/organiser/events/[id]/waves/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { sanitizeWaveInput, wavesWithCounts } from "@/lib/start-waves";
 import { idParams } from "@/lib/schemas";
 import { z } from "zod";
@@ -25,8 +25,9 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });
@@ -46,8 +47,9 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsedParams = idParams.safeParse(await params);
   if (!parsedParams.success) return NextResponse.json({ error: "Invalid id." }, { status: 400 });

--- a/app/api/organiser/events/route.ts
+++ b/app/api/organiser/events/route.ts
@@ -7,7 +7,7 @@ import { getEventCoords } from "@/lib/australia-coords";
 import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
 import { organiserEventPayloadSchema } from "@/lib/schemas";
 import { rateLimit } from "@/lib/rate-limit";
-import { uniqueSlug } from "@/lib/slugs";
+import { withUniqueSlug } from "@/lib/slugs";
 export async function GET() {
   await archivePastEvents();
   const auth = await requireOrganiser();
@@ -116,11 +116,12 @@ export async function POST(req: NextRequest) {
     : "DRAFT";
 
   try {
-    const event = await prisma.event.create({
+    const event = await withUniqueSlug(body.title ?? "", (slug) =>
+      prisma.event.create({
       data: {
         organiserId,
         status:           eventStatus,
-        slug:             await uniqueSlug(body.title ?? ""),
+        slug,
         title:            body.title ?? "",
         discipline:       body.discipline        ?? "",
         description:      body.description       ?? null,
@@ -153,10 +154,14 @@ export async function POST(req: NextRequest) {
         informationPdfs:  Array.isArray(body.informationPdfs) ? body.informationPdfs : [],
         photos:           Array.isArray(body.photos) ? body.photos : [],
       },
-    });
+      }),
+    );
 
     if (event.status === "APPROVED") {
-      prisma.organiser
+      // Awaited, not fired and forgotten: Amplify's compute freezes the
+      // container once the response is returned, so a floating promise is
+      // dropped at random. A notify failure still must not fail the publish.
+      await prisma.organiser
         .findUnique({ where: { id: event.organiserId }, select: { orgName: true } })
         .then((org) =>
           notifyOrganiserFollowers({

--- a/app/api/organiser/events/route.ts
+++ b/app/api/organiser/events/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession, getServerSession } from "@/lib/amplify-server";
+import { getServerSession } from "@/lib/amplify-server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import { archivePastEvents } from "@/lib/archive-events";
 import { getEventCoords } from "@/lib/australia-coords";
 import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
@@ -9,8 +10,9 @@ import { rateLimit } from "@/lib/rate-limit";
 import { uniqueSlug } from "@/lib/slugs";
 export async function GET() {
   await archivePastEvents();
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   try {
     const events = await prisma.event.findMany({
@@ -33,8 +35,9 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const blocked = await rateLimit(req, {
     prefix: "event-create",

--- a/app/api/organiser/members/[id]/route.ts
+++ b/app/api/organiser/members/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { canRemoveMember } from "@/lib/organiser-members";
 import { idParams } from "@/lib/schemas";
 
@@ -10,8 +10,9 @@ export async function DELETE(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
   if (session.role !== "OWNER") {
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }

--- a/app/api/organiser/members/[id]/transfer-ownership/route.ts
+++ b/app/api/organiser/members/[id]/transfer-ownership/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession, getUserSession } from "@/lib/amplify-server";
+import { getUserSession } from "@/lib/amplify-server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import { canTransferOwnership } from "@/lib/organiser-members";
 import { idParams } from "@/lib/schemas";
 
@@ -11,8 +12,9 @@ export async function POST(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
   if (session.role !== "OWNER") {
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }

--- a/app/api/organiser/members/leave/route.ts
+++ b/app/api/organiser/members/leave/route.ts
@@ -1,13 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession, getUserSession } from "@/lib/amplify-server";
+import { getUserSession } from "@/lib/amplify-server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 
 // POST /api/organiser/members/leave
 // Removes the current user from the active organiser. The Owner cannot leave
 // while they are the only Owner (transfer ownership first).
 export async function POST(_req: NextRequest) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const userSession = await getUserSession();
   if (!userSession) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });

--- a/app/api/organiser/members/route.ts
+++ b/app/api/organiser/members/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession, getUserSession } from "@/lib/amplify-server";
+import { getUserSession } from "@/lib/amplify-server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import { canAddMember, MAX_ORGS_PER_USER } from "@/lib/organiser-members";
 import { z } from "zod";
 
@@ -9,8 +10,9 @@ const addMemberSchema = z.object({ email: z.string().max(255) });
 // GET /api/organiser/members
 // Lists all members of the active organiser.
 export async function GET() {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   try {
     const members = await prisma.organiserMember.findMany({
@@ -46,8 +48,9 @@ export async function GET() {
 // Body: { email } — adds the user (who must already have a User account) as a MANAGER member.
 // Owner only.
 export async function POST(req: NextRequest) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
   if (session.role !== "OWNER") {
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }

--- a/app/api/organiser/notifications/route.ts
+++ b/app/api/organiser/notifications/route.ts
@@ -1,14 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { z } from "zod";
 
 const markReadSchema = z.object({ ids: z.array(z.string().min(1).max(255)).optional() });
 // GET /api/organiser/notifications
 // Returns the 30 most recent notifications; includes unread count in header
 export async function GET() {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   try {
     const notifications = await prisma.notification.findMany({
@@ -29,8 +30,9 @@ export async function GET() {
 // PATCH /api/organiser/notifications
 // Body: { ids?: string[] } — if ids omitted, marks ALL as read
 export async function PATCH(req: NextRequest) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   try {
     const parsed = markReadSchema.safeParse(await req.json().catch(() => ({})));

--- a/app/api/organiser/profile/route.ts
+++ b/app/api/organiser/profile/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { z } from "zod";
 
 const organiserProfileSchema = z.object({
@@ -24,8 +24,9 @@ const organiserProfileSchema = z.object({
 });
 
 export async function GET() {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   try {
     const organiser = await prisma.organiser.findUnique({
@@ -53,8 +54,9 @@ export async function GET() {
 }
 
 export async function PUT(req: NextRequest) {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   const parsed = organiserProfileSchema.safeParse(await req.json());
   if (!parsed.success) {

--- a/app/api/organiser/reviews/route.ts
+++ b/app/api/organiser/reviews/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 export async function GET() {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   try {
     const reviews = await prisma.review.findMany({

--- a/app/api/organiser/route.ts
+++ b/app/api/organiser/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 
 // DELETE /api/organiser
 // Deletes the active organiser. Owner only. Memberships cascade.
 export async function DELETE() {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
   if (session.role !== "OWNER") {
     return NextResponse.json({ error: "Forbidden." }, { status: 403 });
   }

--- a/app/api/organiser/stripe/connect/route.ts
+++ b/app/api/organiser/stripe/connect/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { getStripe } from "@/lib/stripe";
 
 const SITE = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
 
 export async function POST() {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   try {
     const stripe = getStripe();

--- a/app/api/organiser/stripe/status/route.ts
+++ b/app/api/organiser/stripe/status/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
+import { requireOrganiser } from "@/lib/organiser-api-auth";
 import prisma from "@/lib/prisma";
-import { getOrganiserSession } from "@/lib/amplify-server";
 import { getStripe } from "@/lib/stripe";
 
 export async function GET() {
-  const session = await getOrganiserSession();
-  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  const auth = await requireOrganiser();
+  if (auth.error) return auth.error;
+  const session = auth.session;
 
   try {
     const organiser = await prisma.organiser.findUnique({

--- a/app/organiser-landing/page.tsx
+++ b/app/organiser-landing/page.tsx
@@ -1,16 +1,28 @@
 import Link from "next/link";
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { Building2, ArrowRight } from "lucide-react";
 import { getOrganiserSession } from "@/lib/amplify-server";
 
 const CUSTOMER_URL = (
-  process.env.NEXT_PUBLIC_SITE_URL ??
-  (process.env.NODE_ENV === "development" ? "" : "https://startlineau.com")
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://startlineau.com"
 ).replace(/\/$/, "");
+
+// `/organiser-setup` lives on the athlete site, which is a *different host*
+// only when this page is being served from the organiser subdomain. Every
+// other deployment — the Amplify branch domain, PR previews, local dev —
+// serves all three portals from one host, and hardcoding the absolute customer
+// URL there sent people to a hostname that doesn't resolve (issue #302).
+async function organiserSetupHref(): Promise<string> {
+  const host = (await headers()).get("host")?.toLowerCase() ?? "";
+  return host.startsWith("organiser.") ? `${CUSTOMER_URL}/organiser-setup` : "/organiser-setup";
+}
 
 export default async function OrganiserLandingPage() {
   const session = await getOrganiserSession();
   if (session) redirect("/organiser/dashboard");
+
+  const setupHref = await organiserSetupHref();
 
   return (
     <main className="min-h-screen bg-dark-darker flex items-center justify-center px-6">
@@ -25,7 +37,7 @@ export default async function OrganiserLandingPage() {
           Sign up for a free user account, then set up your organiser profile to start publishing events on Australia&apos;s fitness calendar.
         </p>
         <Link
-          href={`${CUSTOMER_URL}/organiser-setup`}
+          href={setupHref}
           className="bg-machined shadow-machined inline-flex items-center gap-2 text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 px-8 rounded-md hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform"
         >
           Get started <ArrowRight className="w-4 h-4" />

--- a/app/organiser-landing/page.tsx
+++ b/app/organiser-landing/page.tsx
@@ -1,28 +1,19 @@
-import Link from "next/link";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { Building2, ArrowRight } from "lucide-react";
+import { Building2 } from "lucide-react";
 import { getOrganiserSession } from "@/lib/amplify-server";
-
-const CUSTOMER_URL = (
-  process.env.NEXT_PUBLIC_SITE_URL ?? "https://startlineau.com"
-).replace(/\/$/, "");
-
-// `/organiser-setup` lives on the athlete site, which is a *different host*
-// only when this page is being served from the organiser subdomain. Every
-// other deployment — the Amplify branch domain, PR previews, local dev —
-// serves all three portals from one host, and hardcoding the absolute customer
-// URL there sent people to a hostname that doesn't resolve (issue #302).
-async function organiserSetupHref(): Promise<string> {
-  const host = (await headers()).get("host")?.toLowerCase() ?? "";
-  return host.startsWith("organiser.") ? `${CUSTOMER_URL}/organiser-setup` : "/organiser-setup";
-}
+import { customerHref } from "@/lib/portal-domains";
+import OrganiserLandingActions from "@/components/organiser/OrganiserLandingActions";
 
 export default async function OrganiserLandingPage() {
   const session = await getOrganiserSession();
   if (session) redirect("/organiser/dashboard");
 
-  const setupHref = await organiserSetupHref();
+  // `/organiser-setup` lives on the athlete site, which is a different host only
+  // in production. Every other deployment serves all three portals from one
+  // host, where an absolute customer URL points at a hostname that doesn't
+  // resolve (issue #302).
+  const setupHref = customerHref("/organiser-setup", (await headers()).get("host"));
 
   return (
     <main className="min-h-screen bg-dark-darker flex items-center justify-center px-6">
@@ -36,16 +27,7 @@ export default async function OrganiserLandingPage() {
         <p className="text-muted text-[15px] leading-relaxed mb-8">
           Sign up for a free user account, then set up your organiser profile to start publishing events on Australia&apos;s fitness calendar.
         </p>
-        <Link
-          href={setupHref}
-          className="bg-machined shadow-machined inline-flex items-center gap-2 text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 px-8 rounded-md hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform"
-        >
-          Get started <ArrowRight className="w-4 h-4" />
-        </Link>
-        <p className="mt-6 font-headline text-[11px] uppercase tracking-widest text-muted">
-          Already have an organiser profile?{" "}
-          <Link href="/organiser/dashboard" className="text-primary hover:underline">Go to Dashboard</Link>
-        </p>
+        <OrganiserLandingActions setupHref={setupHref} />
       </div>
     </main>
   );

--- a/app/organiser/dashboard/page.tsx
+++ b/app/organiser/dashboard/page.tsx
@@ -15,8 +15,6 @@ import DashboardTrendChart, {
 import CapacityBar from "@/components/ui/CapacityBar";
 import { formatAudFromCents } from "@/lib/organiser-dashboard";
 
-export const dynamic = "force-dynamic";
-
 type EventStatus = "DRAFT" | "PENDING" | "APPROVED" | "REJECTED" | "ARCHIVED";
 
 const STATUS_ORDER: Record<EventStatus, number> = {

--- a/app/organiser/new-listing/page.tsx
+++ b/app/organiser/new-listing/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import EventFormWizard from "@/components/event/EventFormWizard";
 import { getOrganiserSession } from "@/lib/amplify-server";
 
@@ -5,12 +6,17 @@ export const dynamic = "force-dynamic";
 
 export default async function NewListingPage() {
   const session = await getOrganiserSession();
+  // Without an organiser the wizard still rendered, and the rejection only
+  // arrived after five steps and an image upload (issue #302). Send them to the
+  // landing page, which offers sign-in and organiser sign-up, before they start.
+  if (!session) redirect("/organiser-landing");
+
   return (
     <EventFormWizard
       apiBase="/api/organiser"
       submitRedirect="/organiser/dashboard"
       cancelRedirect="/organiser/dashboard"
-      organiserId={session?.sub ?? undefined}
+      organiserId={session.sub}
     />
   );
 }

--- a/components/AmplifyProvider.tsx
+++ b/components/AmplifyProvider.tsx
@@ -2,18 +2,96 @@
 
 import { useEffect } from "react";
 import { Amplify } from "aws-amplify";
+import { CookieStorage } from "aws-amplify/utils";
+import { cognitoUserPoolsTokenProvider } from "aws-amplify/auth/cognito";
 import { amplifyConfig } from "@/lib/amplify-config";
+import { authCookieDomain } from "@/lib/portal-domains";
 
 Amplify.configure(amplifyConfig, { ssr: true });
 
 const CURRENT_CLIENT_ID = process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? "";
+const COGNITO_PREFIX = "CognitoIdentityServiceProvider";
+
+// Days. Matches the Cognito refresh-token window; a shorter cookie would sign
+// people out while their refresh token is still good.
+const COOKIE_DAYS = 30;
+
+// Amplify's default cookie storage writes host-only cookies, so a session
+// created on startlineau.com was never sent to organiser.startlineau.com and the
+// organiser portal sat permanently signed out (issue #302). Scoping the tokens
+// to .startlineau.com makes one sign-in cover all three portals. Anywhere else —
+// a single-host Amplify branch domain, a PR preview, localhost — the domain is
+// left unset, because naming a domain the browser is not on makes it drop the
+// cookie and breaks auth outright.
+const cookieDomain =
+  typeof window === "undefined" ? undefined : authCookieDomain(window.location.hostname);
+
+const MIGRATION_FLAG = "startline.cognito-cookie-domain.v1";
+
+// Sessions that predate the change are held in host-only cookies. Left in place
+// they would sit alongside the new domain-scoped ones under the same names, and
+// a browser sends both — oldest first — so the stale copy would shadow the live
+// one and the session would rot instead of refreshing. Re-writing each value at
+// the shared scope and then deleting the host-only copy carries the session
+// across without signing anyone out. Runs once per browser.
+function adoptHostOnlyCognitoCookies() {
+  if (!cookieDomain) return;
+  try {
+    if (window.localStorage.getItem(MIGRATION_FLAG)) return;
+  } catch {
+    // Storage blocked. Re-running is harmless: by then no host-only cookie is
+    // left to copy, so every iteration below is a no-op.
+  }
+
+  const secure = window.location.protocol === "https:" ? "; secure" : "";
+  // Snapshot first — the loop writes cookies, which would otherwise reshape
+  // what it is iterating over.
+  for (const raw of document.cookie.split(";").slice()) {
+    const eq = raw.indexOf("=");
+    if (eq < 0) continue;
+    const name = raw.slice(0, eq).trim();
+    if (!name.startsWith(COGNITO_PREFIX)) continue;
+    const value = raw.slice(eq + 1);
+
+    document.cookie =
+      `${name}=${value}; path=/; domain=${cookieDomain}; max-age=${COOKIE_DAYS * 86400}; samesite=lax${secure}`;
+    // No domain attribute, so this deletes the host-only copy and leaves the
+    // one just written at the shared scope.
+    document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  }
+
+  try {
+    window.localStorage.setItem(MIGRATION_FLAG, "1");
+  } catch {
+    // See above.
+  }
+}
+
+if (typeof window !== "undefined") {
+  adoptHostOnlyCognitoCookies();
+  cognitoUserPoolsTokenProvider.setKeyValueStorage(
+    new CookieStorage({
+      domain: cookieDomain,
+      path: "/",
+      expires: COOKIE_DAYS,
+      // localhost is served over http, where a Secure cookie is discarded.
+      secure: window.location.protocol === "https:",
+      sameSite: "lax",
+    }),
+  );
+}
 
 function clearStaleCognitoCookies() {
-  const currentPrefix = `CognitoIdentityServiceProvider.${CURRENT_CLIENT_ID}`;
+  const currentPrefix = `${COGNITO_PREFIX}.${CURRENT_CLIENT_ID}`;
+  // Clear at both scopes: a delete has to match the domain the cookie was set
+  // with, and cookies from before the shared-domain change are host-only.
+  const scopes = cookieDomain ? ["", `; domain=${cookieDomain}`] : [""];
   document.cookie.split(";").forEach((cookie) => {
     const name = cookie.split("=")[0].trim();
-    if (name.startsWith("CognitoIdentityServiceProvider") && !name.startsWith(currentPrefix)) {
-      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+    if (name.startsWith(COGNITO_PREFIX) && !name.startsWith(currentPrefix)) {
+      for (const scope of scopes) {
+        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/${scope}`;
+      }
     }
   });
 }

--- a/components/organiser/OrganiserLandingActions.tsx
+++ b/components/organiser/OrganiserLandingActions.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowRight } from "lucide-react";
+import AmplifyProvider from "@/components/AmplifyProvider";
+import { AuthProvider } from "@/context/AuthContext";
+import SignInModal from "@/components/SignInModal";
+
+// The organiser portal had no sign-in of its own: the modal is mounted in the
+// athlete NavBar and in the organiser layout, neither of which covers this page,
+// so a returning organiser on organiser.startlineau.com could only bounce
+// between the landing page and a redirect (issue #302). This page sits outside
+// both layouts, so it brings its own Amplify and auth providers.
+function Actions({ setupHref }: { setupHref: string }) {
+  const router = useRouter();
+  const [signInOpen, setSignInOpen] = useState(false);
+
+  return (
+    <>
+      <Link
+        href={setupHref}
+        className="bg-machined shadow-machined inline-flex items-center gap-2 text-dark font-headline text-sm font-bold uppercase tracking-widest py-4 px-8 rounded-md hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 active:shadow-none transition-transform"
+      >
+        Get started <ArrowRight className="w-4 h-4" />
+      </Link>
+      <p className="mt-6 font-headline text-[11px] uppercase tracking-widest text-muted">
+        Already have an organiser profile?{" "}
+        <button
+          type="button"
+          onClick={() => setSignInOpen(true)}
+          className="text-primary hover:underline uppercase tracking-widest"
+        >
+          Sign in
+        </button>
+      </p>
+      <SignInModal
+        isOpen={signInOpen}
+        onClose={() => setSignInOpen(false)}
+        // Re-render the server component rather than pushing a route: it already
+        // redirects to the dashboard when the new session resolves to an
+        // organiser, and keeps someone without one here on the sign-up path.
+        onSuccess={() => router.refresh()}
+      />
+    </>
+  );
+}
+
+export default function OrganiserLandingActions({ setupHref }: { setupHref: string }) {
+  return (
+    <AmplifyProvider>
+      <AuthProvider>
+        <Actions setupHref={setupHref} />
+      </AuthProvider>
+    </AmplifyProvider>
+  );
+}

--- a/components/organiser/OrganiserNavBar.tsx
+++ b/components/organiser/OrganiserNavBar.tsx
@@ -12,6 +12,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 import { useAuthContext } from "@/context/AuthContext";
 import { useSettings } from "@/context/SettingsContext";
+import SignInModal from "@/components/SignInModal";
 
 type NavItem = { href: string; label: string };
 
@@ -71,6 +72,7 @@ export default function OrganiserNavBar() {
   const [role,         setRole]         = useState<string | null>(null);
   const [memberships,  setMemberships]  = useState<{ organiserId: string; organiserName: string | null; role: string; logoUrl: string | null }[]>([]);
   const [notifOpen,    setNotifOpen]    = useState(false);
+  const [signInOpen,   setSignInOpen]   = useState(false);
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [unreadCount,  setUnreadCount]  = useState(0);
   // Opening the panel marks everything read server-side, which would instantly
@@ -173,6 +175,11 @@ export default function OrganiserNavBar() {
 
   const displayName = orgName || user?.email || "";
   const initial     = displayName[0]?.toUpperCase() ?? "A";
+  // Your standing on the active organiser. It was fetched into `role` and then
+  // never rendered: the only OWNER/MANAGER badges live inside the switcher
+  // dropdown, one per organisation, so the portal never told you which one you
+  // held on the organiser you were actually looking at.
+  const roleLabel   = role === "OWNER" ? "Owner" : role === "MANAGER" ? "Manager" : null;
   const activePage  = ORGANISER_NAV.find(({ href }) =>
     pathname === href || (pathname?.startsWith(href + "/") ?? false)
   );
@@ -213,6 +220,30 @@ export default function OrganiserNavBar() {
               <Building2 className="w-2.5 h-2.5" /> Organiser
             </span>
 
+            {/* Your role on the active organiser. Owner carries the brand tint,
+                manager stays neutral — matching the switcher dropdown. */}
+            {roleLabel && (
+              <span className={`hidden md:inline-flex items-center font-headline text-[10px] font-bold uppercase tracking-widest rounded px-1.5 py-0.5 border
+                ${role === "OWNER"
+                  ? "text-primary border-primary/40"
+                  : "text-white/40 border-white/15"}`}>
+                {roleLabel}
+              </span>
+            )}
+
+            {/* Signed out. The organiser portal had no sign-in of its own, so a
+                returning organiser could only bounce off the redirect in
+                middleware.ts and never get back in (issue #302). */}
+            {status === "unauthenticated" ? (
+              <button
+                type="button"
+                onClick={() => setSignInOpen(true)}
+                className="font-headline text-[12px] font-bold uppercase tracking-widest text-primary border border-primary/40 rounded-md px-3 py-1.5 hover:bg-primary/10 transition-colors"
+              >
+                Sign in
+              </button>
+            ) : (
+            <>
             {/* Notifications */}
             <div ref={notifRef} className="relative">
               <button onClick={openNotifPanel}
@@ -302,7 +333,15 @@ export default function OrganiserNavBar() {
               {isUserOpen && (
                 <div className="absolute right-0 top-full mt-1 min-w-[220px] bg-dark-darker border border-primary/40 rounded-xl shadow-2xl overflow-hidden">
                   <div className="px-4 py-3 border-b border-white/10">
-                    <div className="font-headline text-[10px] font-bold uppercase tracking-widest text-white/40 mb-0.5">{orgName || "Organisation"}</div>
+                    <div className="flex items-center gap-1.5 mb-0.5">
+                      <span className="font-headline text-[10px] font-bold uppercase tracking-widest text-white/40">{orgName || "Organisation"}</span>
+                      {roleLabel && (
+                        <span className={`font-headline text-[9px] uppercase tracking-widest rounded px-1 py-0.5 border
+                          ${role === "OWNER" ? "text-primary border-primary/40" : "text-white/40 border-white/15"}`}>
+                          {roleLabel}
+                        </span>
+                      )}
+                    </div>
                     {user?.email && <div className="font-headline text-[12px] text-white/70 truncate">{user.email}</div>}
                   </div>
 
@@ -360,6 +399,8 @@ export default function OrganiserNavBar() {
                 </div>
               )}
             </div>
+            </>
+            )}
 
             {/* Mobile hamburger */}
             <button onClick={() => { setIsMenuOpen(!isMenuOpen); setNotifOpen(false); }}
@@ -377,6 +418,12 @@ export default function OrganiserNavBar() {
               <div className="flex items-center gap-1.5 px-4 py-2 mb-1">
                 <Building2 className="w-3.5 h-3.5 text-primary" />
                 <span className="font-headline text-[10px] font-bold uppercase tracking-widest text-white/30">{orgName || "Organiser"}</span>
+                {roleLabel && (
+                  <span className={`font-headline text-[9px] uppercase tracking-widest rounded px-1 py-0.5 border
+                    ${role === "OWNER" ? "text-primary border-primary/40" : "text-white/40 border-white/15"}`}>
+                    {roleLabel}
+                  </span>
+                )}
               </div>
 
               {ORGANISER_NAV.map(({ href, label }) => {
@@ -417,6 +464,12 @@ export default function OrganiserNavBar() {
           </div>
         )}
       </nav>
+
+      <SignInModal
+        isOpen={signInOpen}
+        onClose={() => setSignInOpen(false)}
+        onSuccess={() => router.refresh()}
+      />
     </>
   );
 }

--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -76,7 +76,11 @@ test.describe("profile API", () => {
     const res = await ctx.get("/api/organiser/profile");
     expect(res.status()).toBe(401);
     const body = await res.json();
-    expect(body.error).toContain("Unauthorised");
+    // 401 is specifically "no Cognito session" now. A signed-in account that
+    // manages no organiser gets 403/NO_ORGANISER instead, so assert the code
+    // rather than prose that shifts whenever the message is reworded.
+    expect(body.code).toBe("UNAUTHENTICATED");
+    expect(body.error).toContain("sign in again");
     await ctx.dispose();
   });
 });

--- a/e2e/new-listing.spec.ts
+++ b/e2e/new-listing.spec.ts
@@ -57,7 +57,7 @@ test.describe("new listing wizard", () => {
       const filledAddr = await addrInput.inputValue();
       expect(filledAddr.length).toBeGreaterThan(0);
     }
-    // ponytail: skips if AWS GeoPlaces API unavailable in test env
+    // Skips if the AWS GeoPlaces API is unavailable in the test env.
   });
 
   test("blocks an end time at or before the start time", async ({ page }) => {
@@ -148,7 +148,7 @@ test.describe("new listing wizard", () => {
     await page.getByRole("button", { name: /save draft/i }).click();
 
     await page.waitForTimeout(2000);
-    // ponytail: API save may fail in test env; wizard UX is what's being tested
+    // The API save may fail in the test env; the wizard UX is what's being tested.
   });
 
   test("step rail stays pinned while scrolling", async ({ page }) => {

--- a/e2e/organiser.spec.ts
+++ b/e2e/organiser.spec.ts
@@ -47,14 +47,19 @@ test.describe("organiser login", () => {
     await expectOrganiserDashboard(page);
   });
 
-  test("landing page renders without sign-in form", async ({ page }) => {
+  // Owners and managers never reach this page — getOrganiserSession resolves and
+  // the page redirects them to the dashboard. So it renders only for someone the
+  // portal doesn't recognise, and its two exits are sign-up and sign-in. The old
+  // "Go to Dashboard" link was unreachable for the people it was for, and
+  // clicking it bounced off middleware straight back here (issue #302).
+  test("landing page offers sign-up and sign-in to an unrecognised visitor", async ({ page }) => {
     await page.goto("/organiser");
     await page.waitForLoadState("networkidle");
 
     await expect(page.getByRole("heading", { name: /organiser/i })).toBeVisible();
     await expect(page.getByText(/sign up for a free user account/i)).toBeVisible();
     await expect(page.getByRole("link", { name: /get started/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /go to dashboard/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /sign in/i })).toBeVisible();
   });
 });
 

--- a/lib/amplify-server.ts
+++ b/lib/amplify-server.ts
@@ -164,45 +164,56 @@ const ACTIVE_ORG_COOKIE = "startline_active_org";
 export async function getOrganiserSession(
   cognitoSession?: ServerSession | null,
 ): Promise<OrganiserSession | null> {
-  cognitoSession ??= await getServerSession();
-  if (!cognitoSession) return null;
-
   try {
-    const user = await prisma.user.findUnique({
-      where: { cognitoSub: cognitoSession.sub },
-      include: {
-        memberships: {
-          include: {
-            organiser: {
-              select: { id: true, email: true, status: true, verified: true },
-            },
-          },
-          orderBy: { createdAt: "asc" },
-        },
-      },
-    });
-    if (!user || user.memberships.length === 0) return null;
-
-    const activeId = (await cookies()).get(ACTIVE_ORG_COOKIE)?.value;
-    const picked = pickActiveMembership(
-      user.memberships.map((m) => ({ organiserId: m.organiser.id, role: m.role })),
-      activeId,
-    );
-    const membership =
-      user.memberships.find((m) => m.organiser.id === picked?.organiserId) ??
-      user.memberships[0];
-
-    const organiser = membership.organiser;
-    return {
-      sub:      organiser.id,
-      email:    organiser.email,
-      status:   String(organiser.status),
-      verified: organiser.verified,
-      role:     membership.role,
-    };
+    return await resolveOrganiserSession(cognitoSession);
   } catch {
     return null;
   }
+}
+
+// Same resolution, but a database failure propagates instead of collapsing into
+// the same `null` as "this account manages no organiser". `requireOrganiser`
+// needs the two apart: swallowing them together told every organiser their
+// account wasn't linked to an organiser profile whenever the database was
+// briefly unreachable, which reads exactly like the data loss in issue #302.
+export async function resolveOrganiserSession(
+  cognitoSession?: ServerSession | null,
+): Promise<OrganiserSession | null> {
+  cognitoSession ??= await getServerSession();
+  if (!cognitoSession) return null;
+
+  const user = await prisma.user.findUnique({
+    where: { cognitoSub: cognitoSession.sub },
+    include: {
+      memberships: {
+        include: {
+          organiser: {
+            select: { id: true, email: true, status: true, verified: true },
+          },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+  if (!user || user.memberships.length === 0) return null;
+
+  const activeId = (await cookies()).get(ACTIVE_ORG_COOKIE)?.value;
+  const picked = pickActiveMembership(
+    user.memberships.map((m) => ({ organiserId: m.organiser.id, role: m.role })),
+    activeId,
+  );
+  const membership =
+    user.memberships.find((m) => m.organiser.id === picked?.organiserId) ??
+    user.memberships[0];
+
+  const organiser = membership.organiser;
+  return {
+    sub:      organiser.id,
+    email:    organiser.email,
+    status:   String(organiser.status),
+    verified: organiser.verified,
+    role:     membership.role,
+  };
 }
 
 export async function getOrganiserMemberships(): Promise<OrganiserMembership[] | null> {

--- a/lib/amplify-server.ts
+++ b/lib/amplify-server.ts
@@ -158,8 +158,13 @@ const ACTIVE_ORG_COOKIE = "startline_active_org";
 // Resolves the user's memberships to an active Organiser. If the user manages
 // multiple organisers, the `startline_active_org` cookie (set by the org
 // switcher) picks the active one; otherwise the OWNER membership wins.
-export async function getOrganiserSession(): Promise<OrganiserSession | null> {
-  const cognitoSession = await getServerSession();
+// `cognitoSession` lets a caller that has already verified the tokens (e.g.
+// `requireOrganiser`, which needs to tell "signed out" from "not an organiser")
+// pass them in rather than paying for a second JWT verification per request.
+export async function getOrganiserSession(
+  cognitoSession?: ServerSession | null,
+): Promise<OrganiserSession | null> {
+  cognitoSession ??= await getServerSession();
   if (!cognitoSession) return null;
 
   try {

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -51,7 +51,7 @@ export async function getAllEvents() {
 
     const ratings = await getOrganiserRatings(events.map((e) => e.organiserId));
 
-    // ponytail: `any` avoids Prisma type dependency; `pnpm build` verifies correctness
+    // `any` avoids a Prisma type dependency; `pnpm build` verifies correctness.
     return events.map((e: any) => ({
       ...e,
       fromPrice: lowestPrice(e.waves),

--- a/lib/organiser-api-auth.ts
+++ b/lib/organiser-api-auth.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { getServerSession, getOrganiserSession, type OrganiserSession } from "./amplify-server";
+
+// Every organiser route used to answer a bare 401 whenever `getOrganiserSession`
+// came back null. That conflates two different situations:
+//
+//   * no valid Cognito session      — the caller really has been signed out
+//   * a valid session, no organiser — the account is signed in fine, it just
+//                                     doesn't manage an organiser
+//
+// The second case told people their session had expired when it hadn't, which
+// is how a missing organiser row surfaced as "Your session has expired and
+// nothing was saved" halfway through publishing an event (issue #302). Keeping
+// them apart gives the caller an accurate message and the correct status.
+
+export type OrganiserGuard =
+  | { error: null; session: OrganiserSession }
+  | { error: NextResponse; session: null };
+
+const SIGNED_OUT =
+  "Your session has expired. Please sign in again.";
+const NOT_AN_ORGANISER =
+  "This account isn't linked to an organiser profile. Set one up before managing events.";
+
+export async function requireOrganiser(): Promise<OrganiserGuard> {
+  const cognitoSession = await getServerSession();
+  if (!cognitoSession) {
+    return {
+      error: NextResponse.json({ error: SIGNED_OUT, code: "UNAUTHENTICATED" }, { status: 401 }),
+      session: null,
+    };
+  }
+
+  const session = await getOrganiserSession(cognitoSession);
+  if (!session) {
+    return {
+      error: NextResponse.json({ error: NOT_AN_ORGANISER, code: "NO_ORGANISER" }, { status: 403 }),
+      session: null,
+    };
+  }
+
+  return { error: null, session };
+}

--- a/lib/organiser-api-auth.ts
+++ b/lib/organiser-api-auth.ts
@@ -1,17 +1,21 @@
 import { NextResponse } from "next/server";
-import { getServerSession, getOrganiserSession, type OrganiserSession } from "./amplify-server";
+import { getServerSession, resolveOrganiserSession, type OrganiserSession } from "./amplify-server";
 
 // Every organiser route used to answer a bare 401 whenever `getOrganiserSession`
-// came back null. That conflates two different situations:
+// came back null. That conflates three different situations:
 //
 //   * no valid Cognito session      — the caller really has been signed out
 //   * a valid session, no organiser — the account is signed in fine, it just
 //                                     doesn't manage an organiser
+//   * the database is unreachable   — nothing is known about either
 //
 // The second case told people their session had expired when it hadn't, which
 // is how a missing organiser row surfaced as "Your session has expired and
-// nothing was saved" halfway through publishing an event (issue #302). Keeping
-// them apart gives the caller an accurate message and the correct status.
+// nothing was saved" halfway through publishing an event (issue #302). The
+// third is worse: a transient outage would tell a working organiser their
+// account isn't an organiser, which reads as the account having been wiped.
+// Keeping them apart gives the caller an accurate message and the correct
+// status.
 
 export type OrganiserGuard =
   | { error: null; session: OrganiserSession }
@@ -21,6 +25,8 @@ const SIGNED_OUT =
   "Your session has expired. Please sign in again.";
 const NOT_AN_ORGANISER =
   "This account isn't linked to an organiser profile. Set one up before managing events.";
+const UNAVAILABLE =
+  "We couldn't reach the database. Nothing was changed. Please try again in a moment.";
 
 export async function requireOrganiser(): Promise<OrganiserGuard> {
   const cognitoSession = await getServerSession();
@@ -31,7 +37,17 @@ export async function requireOrganiser(): Promise<OrganiserGuard> {
     };
   }
 
-  const session = await getOrganiserSession(cognitoSession);
+  let session: OrganiserSession | null;
+  try {
+    session = await resolveOrganiserSession(cognitoSession);
+  } catch (err) {
+    console.error("Organiser session lookup failed:", err);
+    return {
+      error: NextResponse.json({ error: UNAVAILABLE, code: "UNAVAILABLE" }, { status: 503 }),
+      session: null,
+    };
+  }
+
   if (!session) {
     return {
       error: NextResponse.json({ error: NOT_AN_ORGANISER, code: "NO_ORGANISER" }, { status: 403 }),

--- a/lib/portal-domains.ts
+++ b/lib/portal-domains.ts
@@ -1,0 +1,50 @@
+// The three portals share one Next app but not always one hostname.
+//
+// Production splits them across startlineau.com, organiser.startlineau.com and
+// admin.startlineau.com. Every other deployment — the Amplify branch domain, PR
+// previews, local dev — serves all three from a single host. A cross-portal
+// link that is absolute everywhere points at a hostname that doesn't resolve on
+// those single-host deployments, which is how "Get started" led to a browser
+// error page (issue #302). A link that is relative everywhere lands on the
+// wrong portal in production. So the shape of the link has to follow the host.
+
+export const USER_DOMAIN = "startlineau.com";
+export const ORGANISER_DOMAIN = `organiser.${USER_DOMAIN}`;
+export const ADMIN_DOMAIN = `admin.${USER_DOMAIN}`;
+
+/** Lower-cased and without the port, which `Host` carries in local dev. */
+export function normaliseHost(host: string | null | undefined): string {
+  return (host ?? "").toLowerCase().replace(/:\d+$/, "");
+}
+
+/** True only on the deployment that gives each portal its own hostname. */
+export function portalsAreSplit(host: string | null | undefined): boolean {
+  const h = normaliseHost(host);
+  return (
+    h === USER_DOMAIN ||
+    h === `www.${USER_DOMAIN}` ||
+    h === ORGANISER_DOMAIN ||
+    h === ADMIN_DOMAIN
+  );
+}
+
+/** A link to `path` on the athlete site, from a page served on `host`. */
+export function customerHref(path: string, host: string | null | undefined): string {
+  return portalsAreSplit(host) ? `https://${USER_DOMAIN}${path}` : path;
+}
+
+/** A link to `path` on the organiser portal, from a page served on `host`. */
+export function organiserHref(path: string, host: string | null | undefined): string {
+  return portalsAreSplit(host) ? `https://${ORGANISER_DOMAIN}${path}` : path;
+}
+
+// Cognito cookies are written by Amplify in the browser, and a host-only cookie
+// set on startlineau.com is never sent to organiser.startlineau.com — which left
+// the organiser portal permanently signed out in production. Scoping them to the
+// registrable domain lets one sign-in cover all three portals. Returns undefined
+// where a shared cookie makes no sense (single-host deployments, localhost),
+// because naming a domain the browser isn't on drops the cookie entirely.
+export function authCookieDomain(host: string | null | undefined): string | undefined {
+  const h = normaliseHost(host);
+  return h === USER_DOMAIN || h.endsWith(`.${USER_DOMAIN}`) ? `.${USER_DOMAIN}` : undefined;
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -5,8 +5,15 @@ declare global {
   var prisma: PrismaClient | undefined;
 }
 
+// Amplify WEB_COMPUTE scales horizontally, so the connection ceiling that
+// matters is per container multiplied by however many are warm. node-postgres
+// defaults to 10 each, which a db.t4g.micro (~110 connections) exhausts after a
+// dozen containers; past that every query throws, and the organiser routes
+// answer 503 rather than pretending the account has no organiser.
+const POOL_MAX = Number(process.env.DATABASE_POOL_MAX ?? 5);
+
 const client = global.prisma || new PrismaClient({
-  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL, max: POOL_MAX }),
   log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
 });
 if (process.env.NODE_ENV !== "production") global.prisma = client;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -42,7 +42,7 @@ export async function rateLimit(
     `;
     row = rows[0];
   } catch {
-    // ponytail: fail-open — limiter unavailable, let the request through.
+    // Fail-open: limiter unavailable, let the request through.
     return null;
   }
 

--- a/lib/slugs.ts
+++ b/lib/slugs.ts
@@ -34,3 +34,35 @@ export async function uniqueSlug(title: string, excludeId?: string): Promise<str
     if (!taken.has(candidate)) return candidate;
   }
 }
+
+/** True for the unique-constraint violation raised when two writes claim the
+ *  same event slug. */
+function isSlugConflict(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const { code, meta } = err as { code?: unknown; meta?: { target?: unknown } };
+  if (code !== "P2002") return false;
+  const target = meta?.target;
+  // Postgres names the index; be permissive when the driver doesn't report one.
+  if (target === undefined) return true;
+  const fields = Array.isArray(target) ? target : [target];
+  return fields.some((f) => typeof f === "string" && f.includes("slug"));
+}
+
+/** Runs `write` with a slug for `title`, retrying if a concurrent write claimed
+ *  it first. `uniqueSlug` reads the taken slugs before writing, so two events
+ *  created from the same title at the same moment resolve to the same string and
+ *  one of them used to fail the whole request with a bare 500. The retry re-runs
+ *  the lookup, which now sees the winner and picks the next free suffix. */
+export async function withUniqueSlug<T>(
+  title: string,
+  write: (slug: string) => Promise<T>,
+  { excludeId, attempts = 3 }: { excludeId?: string; attempts?: number } = {},
+): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await write(await uniqueSlug(title, excludeId));
+    } catch (err) {
+      if (attempt >= attempts || !isSlugConflict(err)) throw err;
+    }
+  }
+}

--- a/lib/turnstile.ts
+++ b/lib/turnstile.ts
@@ -21,8 +21,8 @@ export function turnstileConfigured(): boolean {
 // Hostnames where bot checks are enforced. Everywhere else (Amplify preview
 // URLs, localhost, staging aliases) we fail open — those hostnames aren't
 // whitelisted on the Cloudflare Turnstile widget, so the widget errors out and
-// no token is ever produced. ponytail: preview hostnames are dynamic and can't
-// be enumerated; gate on the known production set instead.
+// no token is ever produced. Preview hostnames are dynamic and can't be
+// enumerated, so the gate is the known production set instead.
 const BOT_CHECK_HOSTS = new Set([
   "startlineau.com",
   "www.startlineau.com",
@@ -42,7 +42,7 @@ export async function verifyTurnstileToken(
   req?: NextRequest,
 ): Promise<boolean> {
   const secret = process.env.TURNSTILE_SECRET_KEY;
-  if (!secret) return true; // ponytail: not configured → fail open (dev/test)
+  if (!secret) return true; // not configured, fail open (dev/test)
 
   if (!token) return false;
 
@@ -59,9 +59,9 @@ export async function verifyTurnstileToken(
     const data = (await res.json()) as VerifyResult;
     return data.success === true;
   } catch {
-    // ponytail: siteverify unreachable → fail closed (don't trust a token we
-    // couldn't check). A transient outage blocks the form rather than letting
-    // bots through.
+    // siteverify unreachable, fail closed: don't trust a token we couldn't
+    // check. A transient outage blocks the form rather than letting bots
+    // through.
     return false;
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { jwtVerify, createRemoteJWKSet } from "jose";
 import type { JWTPayload } from "jose";
+import { USER_DOMAIN, ORGANISER_DOMAIN, ADMIN_DOMAIN } from "@/lib/portal-domains";
 
 const region   = process.env.NEXT_PUBLIC_AWS_REGION          ?? "";
 const userPoolId = process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ?? "";
@@ -36,9 +37,10 @@ const ADMIN_PROTECTED = [
   "/admin/security",
 ];
 
-const USER_DOMAIN = "startlineau.com";
-const ORGANISER_DOMAIN = "organiser.startlineau.com";
-const ADMIN_DOMAIN = "admin.startlineau.com";
+// The paths the organiser sign-up flow needs on the athlete site. The organiser
+// portal's landing page sends people here, so the waitlist gate below has to let
+// them through or the only route into the product dead-ends (issue #302).
+const ORGANISER_SIGNUP_PATHS = ["/organiser-setup", "/api/organiser/setup"];
 
 async function getVerifiedPayload(req: NextRequest): Promise<JWTPayload | null> {
   const lastAuthUser = req.cookies.get(
@@ -84,18 +86,25 @@ export async function middleware(req: NextRequest) {
 
     if (ORGANISER_PROTECTED.some((p) => pathname.startsWith(p))) {
       const payload = await getVerifiedPayload(req);
-      if (!payload) return NextResponse.redirect(new URL("https://startlineau.com"));
+      // Stay on this host. Sending them to the athlete site landed them on the
+      // waitlist with no way back and no way to sign in, which read as "clicking
+      // organiser just reverts me to the home page" (issue #302).
+      if (!payload) return NextResponse.redirect(new URL("/organiser-landing", req.url));
       return NextResponse.next();
     }
 
     if (
       !pathname.startsWith("/organiser") &&
+      // Sign-in on the organiser landing page hands off to these for an
+      // unverified email or a password reset; bouncing them to the athlete site
+      // stranded the flow half-finished.
+      !pathname.startsWith("/auth") &&
       !pathname.startsWith("/_next") &&
       !pathname.startsWith("/api") &&
       !pathname.startsWith("/images") &&
       !pathname.startsWith("/favicon")
     ) {
-      return NextResponse.redirect(new URL("https://startlineau.com"));
+      return NextResponse.redirect(new URL(`https://${USER_DOMAIN}`));
     }
 
     return NextResponse.next();
@@ -118,6 +127,7 @@ export async function middleware(req: NextRequest) {
         || pathname.startsWith("/api/waitlist")
         || pathname.startsWith("/checkin")
         || pathname.startsWith("/api/checkin")
+        || ORGANISER_SIGNUP_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`))
         || pathname.startsWith("/_next")
         || pathname.startsWith("/images")
         || pathname.startsWith("/favicon")) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -25,8 +25,8 @@ const nextConfig: NextConfig = {
 
   async headers() {
     // Dev needs 'unsafe-eval' for React Fast Refresh. Production drops it so
-    // script-src can actually block injected code. (ponytail: strict nonce CSP
-    // is tracked as a post-MVP issue.)
+    // script-src can actually block injected code. A strict nonce CSP is
+    // tracked as a post-MVP issue.
     const scriptSrc =
       process.env.NODE_ENV === "production"
         ? "'self' 'unsafe-inline' https://js.stripe.com https://api.mapbox.com"

--- a/openwiki/infrastructure/terraform.md
+++ b/openwiki/infrastructure/terraform.md
@@ -62,9 +62,17 @@ Startline's infrastructure is fully defined in **Terraform** with a unified stat
 | Environment | Branch | Amplify Build Behavior |
 |---|---|---|
 | `prod` | `prod` | Migrate DB, no seed |
-| `staging` | `main` | Migrate DB + seed |
+| `staging` | `main` | Migrate DB, no seed |
 | PR to `main` | Preview (staging) | Inherits staging resources, auth bypass |
 | PR to `prod` | Preview (prod) | Inherits prod resources, auth bypass |
+
+Neither environment seeds on deploy. `prisma db seed` truncates every table
+and resets the shared Cognito seed passwords, so it is gated behind the
+`SEED_DATABASE` branch variable (set it to `"true"` in the Amplify console
+for a deliberate reseed, then set it back). The seed itself also refuses any
+non-local `DATABASE_URL` unless `ALLOW_REMOTE_SEED=true`. A failed migration
+now fails the build rather than falling back to `migrate reset --force`,
+which used to drop the database.
 
 The `ENV` env var is set per Amplify branch (`prod` → `prod`, `main` → `staging`). PR previews inherit the target branch's `ENV` value. The build spec uses `$ENV` to select the correct Secrets Manager secret.
 

--- a/openwiki/infrastructure/terraform.md
+++ b/openwiki/infrastructure/terraform.md
@@ -74,7 +74,27 @@ non-local `DATABASE_URL` unless `ALLOW_REMOTE_SEED=true`. A failed migration
 now fails the build rather than falling back to `migrate reset --force`,
 which used to drop the database.
 
+`SEED_DATABASE` is Terraform-managed and pinned to `"false"`, so a console
+flip lasts only until the next `terraform apply` resets it. Do the reseed and
+flip it back in the same sitting.
+
 The `ENV` env var is set per Amplify branch (`prod` → `prod`, `main` → `staging`). PR previews inherit the target branch's `ENV` value. The build spec uses `$ENV` to select the correct Secrets Manager secret.
+
+## Runtime vs build-time variables
+
+The build writes `startline/$ENV/app` into `.env.production`, but the app is
+built with `output: "standalone"` and Amplify ships only `.next`, so that file
+never reaches the running server. Secrets Manager is therefore build-time only:
+`NEXT_PUBLIC_*` works (Next inlines it at build), and anything read at runtime
+must be an Amplify **branch** environment variable set in
+`modules/environment/main.tf`.
+
+Terraform owns the whole branch variable map, so console-added values are
+deleted on the next apply. New runtime secrets belong in the
+`startline/ci-bootstrap` secret: `stripe_secret_key_<env>`,
+`stripe_webhook_secret_<env>`, `resend_api_key`, `resend_from`, `abr_guid`. A
+prod apply fails a precondition rather than silently clearing one that is
+missing.
 
 ## Secrets Management
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,11 @@ export default defineConfig({
   webServer: process.env.CI
     ? undefined
     : {
-        command: "NEXT_PUBLIC_COGNITO_USER_POOL_ID=test NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk_test CI=true pnpm dev -p 3000",
+        // cross-env, not a bare `VAR=value` prefix: that syntax is POSIX-only,
+        // so on Windows the shell treats the first assignment as the command
+        // name and the server never starts ("'NEXT_PUBLIC_COGNITO_USER_POOL_ID'
+        // is not recognized as an internal or external command").
+        command: "npx cross-env NEXT_PUBLIC_COGNITO_USER_POOL_ID=test NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk_test CI=true pnpm dev -p 3000",
         url: "http://localhost:3000/admin/login",
         reuseExistingServer: true,
         timeout: 90000,

--- a/prisma/migrations/20260804000000_drop_unused_event_logistics_fields/migration.sql
+++ b/prisma/migrations/20260804000000_drop_unused_event_logistics_fields/migration.sql
@@ -1,13 +1,30 @@
 -- Reconstructed placeholder.
 --
--- This migration is recorded as applied in existing databases (2026-08-04) but its
--- folder was never committed to git, so Prisma saw the history as corrupt and
--- wanted to reset. Restoring the folder repairs the history without touching data.
+-- The original migration dropped some unused Event logistics columns, but its
+-- folder was never committed to git. It is recorded as applied in databases
+-- created around 2026-08-04, and absent from the migrations directory.
 --
--- It is intentionally a no-op. The migration dropped some unused Event logistics
--- columns, but bagDrop, parking, accessibilityInfo and additionalNotes are all
--- present again in both the current schema and existing databases, so its effect
--- has been superseded. On a fresh database those columns are simply never dropped,
--- which leaves the same end state the schema asks for.
+-- It is intentionally a no-op. bagDrop, parking, accessibilityInfo and
+-- additionalNotes are all present again in both the current schema and existing
+-- databases, so the drop has been superseded. On a fresh database this step now
+-- runs and does nothing, which leaves exactly the end state the schema asks for
+-- (the columns are created by 20260620104428_init and never re-added).
+--
+-- What restoring the folder does and does not fix, verified against prisma
+-- 7.9.1 rather than assumed:
+--
+--   * `migrate deploy` — unaffected either way. It applies pending migrations
+--     and exits 0 whether a recorded migration is missing from the directory or
+--     present with a different checksum. So the missing folder was never what
+--     triggered a deploy-time reset; the database wipes came from `prisma db
+--     seed` running on every staging build (see terraform/main.tf).
+--   * `migrate dev` on a fresh database — fixed. The step exists, so there is
+--     nothing to diverge.
+--   * `migrate dev` on a database that recorded the original — still refuses.
+--     The complaint changes from "applied to the database but missing from the
+--     local migrations directory" to "was modified after it was applied",
+--     because this file's checksum is not the original's. Reset that local
+--     database (./scripts/dev-db.sh, then pnpm prisma:seed) rather than trying
+--     to make the checksum match.
 
 SELECT 1;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -242,8 +242,55 @@ async function fetchCognitoSubs(): Promise<{
   return { subsByEmail, adminSubs };
 }
 
+// Hosts the seed is allowed to truncate without being asked twice. Everything
+// else — RDS, or anything reached through a tunnel — is treated as somebody's
+// real data.
+const LOCAL_DB_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "host.docker.internal", "db", "postgres"]);
+
+function databaseHost(): string {
+  const url = process.env.DATABASE_URL ?? "";
+  try {
+    return new URL(url).hostname.replace(/^\[|\]$/g, "");
+  } catch {
+    return "";
+  }
+}
+
+// The seed truncates users, organisers, events and registrations before it
+// writes, and it creates 15 Cognito accounts that all share PASSWORD — one of
+// them in the `admins` group. Running it against a deployed environment wipes
+// real accounts and leaves signed-in browsers holding a valid Cognito session
+// with no matching user row, which is what turned "publish event" into a 401
+// (issue #302). Remote targets therefore need an explicit ALLOW_REMOTE_SEED.
+function assertSeedTargetIsSafe(): void {
+  if (process.env.ALLOW_REMOTE_SEED === "true") {
+    console.warn("  ⚠  ALLOW_REMOTE_SEED=true — seeding a non-local database, existing data will be destroyed\n");
+    return;
+  }
+
+  const host = databaseHost();
+  if (!host) {
+    throw new Error(
+      "Refusing to seed: DATABASE_URL is missing or not a URL, so the target database can't be identified.",
+    );
+  }
+  if (LOCAL_DB_HOSTS.has(host)) return;
+
+  throw new Error(
+    [
+      `Refusing to seed "${host}" — it is not a local database.`,
+      "",
+      "The seed deletes every user, organiser, event and registration before it",
+      "writes, and it resets the shared Cognito seed passwords. If you really",
+      "mean to destroy that environment's data, re-run with ALLOW_REMOTE_SEED=true.",
+    ].join("\n"),
+  );
+}
+
 async function main() {
   console.log("🌱 Seeding database…\n");
+
+  assertSeedTargetIsSafe();
 
   // CI (e2e) uses the __e2e_bypass cookie keyed on mock subs — never touch
   // Cognito there.

--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# ponytail: one shared Postgres container, one database per worktree.
+# One shared Postgres container, one database per worktree.
 # Migrations are tracked per-database, so worktrees never clobber each other's _prisma_migrations.
 set -euo pipefail
 
@@ -7,7 +7,7 @@ BRANCH=$(git branch --show-current)
 SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '_' | sed 's/_\+/_/g; s/^_//; s/_$//')
 DB="startline_${SLUG:-main}"
 
-# ponytail: find postgres by container name, not compose project (worktree dirnames differ from main).
+# Find postgres by container name, not compose project (worktree dirnames differ from main).
 PG=$(docker ps --format '{{.Names}}' | grep -E 'postgres' | head -1 || true)
 if [ -z "$PG" ]; then
   echo "No postgres container running. Start infra on the main checkout:" >&2

--- a/src/__tests__/portal-domains.test.ts
+++ b/src/__tests__/portal-domains.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  authCookieDomain,
+  customerHref,
+  organiserHref,
+  portalsAreSplit,
+} from "@/lib/portal-domains";
+
+const STAGING = "main.d1abc2def3.amplifyapp.com";
+const PREVIEW = "pr-302.d1abc2def3.amplifyapp.com";
+
+describe("portalsAreSplit", () => {
+  it("is true only for the production hostnames", () => {
+    expect(portalsAreSplit("startlineau.com")).toBe(true);
+    expect(portalsAreSplit("www.startlineau.com")).toBe(true);
+    expect(portalsAreSplit("organiser.startlineau.com")).toBe(true);
+    expect(portalsAreSplit("admin.startlineau.com")).toBe(true);
+  });
+
+  it("is false wherever one host serves every portal", () => {
+    expect(portalsAreSplit(STAGING)).toBe(false);
+    expect(portalsAreSplit(PREVIEW)).toBe(false);
+    expect(portalsAreSplit("localhost:3000")).toBe(false);
+    expect(portalsAreSplit("")).toBe(false);
+    expect(portalsAreSplit(null)).toBe(false);
+  });
+
+  it("ignores case and port", () => {
+    expect(portalsAreSplit("Organiser.StartlineAU.com")).toBe(true);
+    expect(portalsAreSplit("startlineau.com:443")).toBe(true);
+  });
+});
+
+describe("cross-portal links", () => {
+  it("goes absolute in production", () => {
+    expect(customerHref("/organiser-setup", "organiser.startlineau.com")).toBe(
+      "https://startlineau.com/organiser-setup",
+    );
+    expect(organiserHref("/organiser/dashboard", "startlineau.com")).toBe(
+      "https://organiser.startlineau.com/organiser/dashboard",
+    );
+  });
+
+  // The absolute URL pointed at a hostname that does not resolve on these
+  // deployments, which is what turned "Get started" into a browser error page.
+  it("stays relative where one host serves every portal", () => {
+    expect(customerHref("/organiser-setup", STAGING)).toBe("/organiser-setup");
+    expect(customerHref("/organiser-setup", PREVIEW)).toBe("/organiser-setup");
+    expect(organiserHref("/organiser/dashboard", "localhost:3000")).toBe("/organiser/dashboard");
+  });
+});
+
+describe("authCookieDomain", () => {
+  // Host-only cookies left organiser.startlineau.com permanently signed out.
+  it("shares the session across the production subdomains", () => {
+    expect(authCookieDomain("startlineau.com")).toBe(".startlineau.com");
+    expect(authCookieDomain("www.startlineau.com")).toBe(".startlineau.com");
+    expect(authCookieDomain("organiser.startlineau.com")).toBe(".startlineau.com");
+    expect(authCookieDomain("admin.startlineau.com")).toBe(".startlineau.com");
+  });
+
+  // Naming a domain the browser is not on makes it drop the cookie outright,
+  // which would break auth everywhere except production.
+  it("leaves the domain unset off that registrable domain", () => {
+    expect(authCookieDomain(STAGING)).toBeUndefined();
+    expect(authCookieDomain(PREVIEW)).toBeUndefined();
+    expect(authCookieDomain("localhost:3000")).toBeUndefined();
+    expect(authCookieDomain("")).toBeUndefined();
+  });
+
+  it("is not fooled by a lookalike suffix", () => {
+    expect(authCookieDomain("notstartlineau.com")).toBeUndefined();
+    expect(authCookieDomain("startlineau.com.evil.test")).toBeUndefined();
+  });
+});

--- a/src/__tests__/require-organiser.test.ts
+++ b/src/__tests__/require-organiser.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  resolveOrganiserSession: vi.fn(),
+}));
+
+vi.mock("@/lib/amplify-server", () => ({
+  getServerSession: mocks.getServerSession,
+  resolveOrganiserSession: mocks.resolveOrganiserSession,
+}));
+
+import { requireOrganiser } from "@/lib/organiser-api-auth";
+
+const COGNITO = { sub: "cog_1", email: "sarah@startline.test", groups: [] };
+const ORGANISER = {
+  sub: "org_1",
+  email: "sarah@startline.test",
+  status: "APPROVED",
+  verified: true,
+  role: "OWNER" as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("requireOrganiser", () => {
+  it("hands back the session when the caller manages an organiser", async () => {
+    mocks.getServerSession.mockResolvedValue(COGNITO);
+    mocks.resolveOrganiserSession.mockResolvedValue(ORGANISER);
+
+    const auth = await requireOrganiser();
+
+    expect(auth.error).toBeNull();
+    expect(auth.session).toEqual(ORGANISER);
+  });
+
+  it("answers 401 only when there is no Cognito session", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+
+    const auth = await requireOrganiser();
+
+    expect(auth.error?.status).toBe(401);
+    await expect(auth.error!.json()).resolves.toMatchObject({ code: "UNAUTHENTICATED" });
+    expect(mocks.resolveOrganiserSession).not.toHaveBeenCalled();
+  });
+
+  // A signed-in account with no organiser row used to be told its session had
+  // expired, halfway through publishing an event (issue #302).
+  it("answers 403 for a valid session that manages no organiser", async () => {
+    mocks.getServerSession.mockResolvedValue(COGNITO);
+    mocks.resolveOrganiserSession.mockResolvedValue(null);
+
+    const auth = await requireOrganiser();
+
+    expect(auth.error?.status).toBe(403);
+    const body = await auth.error!.json();
+    expect(body.code).toBe("NO_ORGANISER");
+    expect(body.error).toContain("organiser profile");
+  });
+
+  // Collapsing this into the 403 told a working organiser their account was not
+  // an organiser whenever the database blipped, which reads as data loss.
+  it("answers 503 when the lookup itself fails", async () => {
+    mocks.getServerSession.mockResolvedValue(COGNITO);
+    mocks.resolveOrganiserSession.mockRejectedValue(new Error("connection terminated"));
+
+    const auth = await requireOrganiser();
+
+    expect(auth.error?.status).toBe(503);
+    const body = await auth.error!.json();
+    expect(body.code).toBe("UNAVAILABLE");
+    expect(body.error).not.toContain("organiser profile");
+  });
+});

--- a/src/__tests__/slug-conflict.test.ts
+++ b/src/__tests__/slug-conflict.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findMany: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: { event: { findMany: mocks.findMany } },
+}));
+
+import { withUniqueSlug } from "@/lib/slugs";
+
+/** What Prisma raises when two writes claim the same event slug. */
+function slugConflict() {
+  return Object.assign(new Error("Unique constraint failed"), {
+    code: "P2002",
+    meta: { target: ["slug"] },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.findMany.mockResolvedValue([]);
+});
+
+describe("withUniqueSlug", () => {
+  it("passes the resolved slug straight through when nothing collides", async () => {
+    const write = vi.fn().mockResolvedValue("created");
+
+    await expect(withUniqueSlug("Sydney Harbour 10K", write)).resolves.toBe("created");
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith("sydney-harbour-10k");
+  });
+
+  // uniqueSlug reads the taken slugs before writing, so two events created from
+  // the same title at the same moment both resolve to the same string. One of
+  // them used to fail the whole request with a bare 500.
+  it("re-resolves and retries when a concurrent write took the slug first", async () => {
+    mocks.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ slug: "sydney-harbour-10k" }]);
+    const write = vi
+      .fn()
+      .mockRejectedValueOnce(slugConflict())
+      .mockResolvedValueOnce("created");
+
+    await expect(withUniqueSlug("Sydney Harbour 10K", write)).resolves.toBe("created");
+    expect(write).toHaveBeenNthCalledWith(1, "sydney-harbour-10k");
+    expect(write).toHaveBeenNthCalledWith(2, "sydney-harbour-10k-2");
+  });
+
+  it("gives up after the attempt limit rather than looping", async () => {
+    const write = vi.fn().mockRejectedValue(slugConflict());
+
+    await expect(withUniqueSlug("Sydney Harbour 10K", write)).rejects.toMatchObject({
+      code: "P2002",
+    });
+    expect(write).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry an unrelated failure", async () => {
+    const other = Object.assign(new Error("nope"), { code: "P2003" });
+    const write = vi.fn().mockRejectedValue(other);
+
+    await expect(withUniqueSlug("Sydney Harbour 10K", write)).rejects.toThrow("nope");
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a unique violation on some other column", async () => {
+    const emailClash = Object.assign(new Error("Unique constraint failed"), {
+      code: "P2002",
+      meta: { target: ["email"] },
+    });
+    const write = vi.fn().mockRejectedValue(emailClash);
+
+    await expect(withUniqueSlug("Sydney Harbour 10K", write)).rejects.toThrow();
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the renamed event out of its own collision check", async () => {
+    const write = vi.fn().mockResolvedValue("updated");
+
+    await withUniqueSlug("Sydney Harbour 10K", write, { excludeId: "evt_1" });
+
+    expect(mocks.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ NOT: { id: "evt_1" } }) }),
+    );
+  });
+});

--- a/src/__tests__/transfer-ownership.test.ts
+++ b/src/__tests__/transfer-ownership.test.ts
@@ -14,6 +14,14 @@ vi.mock("@/lib/amplify-server", () => ({
   getUserSession: mocks.getUserSession,
 }));
 
+// The route reaches the organiser session through requireOrganiser, which
+// separates "signed out" (401) from "signed in but manages no organiser" (403).
+// These tests are about ownership transfer, so the guard just hands back
+// whatever session getOrganiserSession is set to return.
+vi.mock("@/lib/organiser-api-auth", () => ({
+  requireOrganiser: async () => ({ error: null, session: await mocks.getOrganiserSession() }),
+}));
+
 vi.mock("@/lib/prisma", () => ({
   default: {
     organiserMember: {

--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -58,7 +58,7 @@ resource "aws_iam_role_policy_attachment" "terraform_ci_admin" {
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
-# ponytail: read-only role for PR workflows — terraform plan and CI checks.
+# Read-only role for PR workflows: terraform plan and CI checks.
 # Uses AWS managed ReadOnlyAccess instead of a custom list to avoid whack-a-mole.
 # Cognito admin is needed for e2e seeding.
 

--- a/terraform/iam-policies.tf
+++ b/terraform/iam-policies.tf
@@ -143,7 +143,7 @@ resource "aws_iam_user_policy_attachment" "mcp_server" {
   policy_arn = aws_iam_policy.mcp_server.arn
 }
 
-# ponytail: both access keys get created fresh after import; old keys
+# Both access keys get created fresh after import; old keys
 # are deactivated/deleted manually once the new ones are in ~/.aws/credentials.
 resource "aws_iam_access_key" "admin" {
   user = aws_iam_user.admin.name

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,6 +66,14 @@ locals {
   #      with no matching user row — which surfaced as "session expired" 401s
   #      when publishing an event. Flip SEED_DATABASE to "true" in the Amplify
   #      console only when a deliberate reseed is wanted.
+  #
+  # ENV defaults through a parameter expansion rather than `[ -n "$ENV" ] ||
+  # export ENV=staging`. && and || are equal precedence and associate left to
+  # right, so that form parsed as `(everything-before-it || export) && rest`:
+  # a failed `pnpm install` fell into the export instead of aborting the build,
+  # which on a prod build retargeted ENV at staging and pulled staging secrets
+  # into .env.production. The doubled $$ escapes the Terraform template so the
+  # shell receives a single ${...}.
   build_spec = <<-EOT
     version: 1
     frontend:
@@ -75,7 +83,7 @@ locals {
             - >
               corepack enable && pnpm install --frozen-lockfile
               && npx prisma generate
-              && [ -n "$ENV" ] || export ENV=staging
+              && export ENV="$${ENV:-staging}"
               && aws secretsmanager get-secret-value
               --secret-id startline/$ENV/app
               --query SecretString --output text
@@ -202,7 +210,18 @@ module "env" {
 
   cognito_deletion_protection = each.value.cognito_deletion_protection
 
-  resend_api_key = local.bootstrap.resend_api_key
+  # Runtime server-side secrets. These land on the Amplify branch environment,
+  # not in Secrets Manager, because the build writes Secrets Manager into
+  # .env.production and the standalone artefact never carries that file. Stripe
+  # is per-environment (live keys on prod, test keys on staging); the rest are
+  # shared. A missing prod key fails the plan in the module rather than silently
+  # clearing the value the console currently holds.
+  resend_api_key        = try(local.bootstrap.resend_api_key, "")
+  resend_from           = try(local.bootstrap.resend_from, "")
+  stripe_secret_key     = try(local.bootstrap["stripe_secret_key_${each.key}"], "")
+  stripe_webhook_secret = try(local.bootstrap["stripe_webhook_secret_${each.key}"], "")
+  abr_guid              = try(local.bootstrap.abr_guid, "")
+
   # NEXT_PUBLIC_SITE_URL has to resolve: event share links, check-in QR codes,
   # email buttons and the organiser sign-up gate are all absolute URLs built
   # from it. staging.startlineau.com is NXDOMAIN, which sent anyone following

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,6 +53,19 @@ resource "aws_iam_role_policy" "amplify_secrets" {
 locals {
   connect_repository = var.amplify_repository_url != null ? trimspace(var.amplify_repository_url) != "" : false
 
+  # Deploy-time database handling (issue #302). Two rules, both deliberate:
+  #
+  #   1. `migrate deploy` has no fallback. It used to fall back to
+  #      `migrate reset --force`, which DROPS the whole database — on prod as
+  #      well as staging. A failed migration must fail the build, not wipe the
+  #      environment.
+  #   2. Seeding is opt-in via the SEED_DATABASE branch variable, never
+  #      automatic. `prisma db seed` deletes every user, organiser, event and
+  #      registration before it writes, so running it on each deploy erased
+  #      real accounts and left signed-in browsers holding a Cognito session
+  #      with no matching user row — which surfaced as "session expired" 401s
+  #      when publishing an event. Flip SEED_DATABASE to "true" in the Amplify
+  #      console only when a deliberate reseed is wanted.
   build_spec = <<-EOT
     version: 1
     frontend:
@@ -67,7 +80,8 @@ locals {
               --secret-id startline/$ENV/app
               --query SecretString --output text
               | node -e "const s=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8').trim());for(const[k,v]of Object.entries(s))console.log(k+'='+v)" >> .env.production
-              && ( [ -z "$AWS_PULL_REQUEST_ID" ] && ( npx prisma migrate deploy || npx prisma migrate reset --force ) && ( [ "$ENV" != "prod" ] && npx prisma db seed ; true ) ; true )
+              && ( [ -n "$AWS_PULL_REQUEST_ID" ] || npx prisma migrate deploy )
+              && ( [ "$SEED_DATABASE" != "true" ] || ALLOW_REMOTE_SEED=true npx prisma db seed )
         build:
           commands:
             - pnpm run build
@@ -145,8 +159,11 @@ locals {
       database_backup_retention_period = 0
       cognito_deletion_protection      = false
       bucket_cors_allowed_origins      = ["*"]
-      site_url                         = "https://staging.startlineau.com"
-      enable_daily_stop                = false
+      # Ignored — staging.startlineau.com has never been delegated, so the real
+      # value is computed from the Amplify branch domain below. Kept here as the
+      # intended hostname for whenever that DNS record is created.
+      site_url          = "https://staging.startlineau.com"
+      enable_daily_stop = false
     }
   }
 
@@ -186,7 +203,12 @@ module "env" {
   cognito_deletion_protection = each.value.cognito_deletion_protection
 
   resend_api_key = local.bootstrap.resend_api_key
-  site_url       = each.value.site_url
+  # NEXT_PUBLIC_SITE_URL has to resolve: event share links, check-in QR codes,
+  # email buttons and the organiser sign-up gate are all absolute URLs built
+  # from it. staging.startlineau.com is NXDOMAIN, which sent anyone following
+  # one of those links to a browser error page (issue #302), so staging points
+  # at the Amplify branch domain instead.
+  site_url = each.key == "staging" ? "https://${each.value.branch_name}.${aws_amplify_app.this.default_domain}" : each.value.site_url
 
   mapbox_access_token = local.bootstrap.mapbox_access_token
 
@@ -195,6 +217,9 @@ module "env" {
 
   extra_branch_environment_variables = {
     ENV = each.key == "prod" ? "prod" : "staging"
+    # Off for both environments. Set to "true" in the Amplify console for a
+    # one-off reseed, then set it back — the seed truncates every table.
+    SEED_DATABASE = "false"
   }
 
   bucket_cors_allowed_origins = each.value.bucket_cors_allowed_origins

--- a/terraform/modules/environment/main.tf
+++ b/terraform/modules/environment/main.tf
@@ -436,6 +436,31 @@ resource "aws_cognito_user_group" "this" {
 
 # ===== Amplify branch =====
 
+locals {
+  # Server-only values the running app reads from process.env. They cannot come
+  # from Secrets Manager: the build writes that into .env.production, and
+  # `output: "standalone"` ships only .next, so the file never reaches the
+  # server. See the note above the variables in variables.tf.
+  runtime_secrets = {
+    GUEST_EMAIL_VERIFICATION_SECRET = random_password.guest_email_verification.result
+    TURNSTILE_SECRET_KEY            = var.turnstile_secret_key
+    RESEND_API_KEY                  = var.resend_api_key
+    RESEND_FROM                     = var.resend_from
+    STRIPE_SECRET_KEY               = var.stripe_secret_key
+    STRIPE_WEBHOOK_SECRET           = var.stripe_webhook_secret
+    ABR_GUID                        = var.abr_guid
+  }
+
+  # Drop blanks rather than publishing empty entries. The app treats "" and
+  # unset the same way, but an empty variable reads as configured in the Amplify
+  # console, which is how a missing key stays missing. `try` also absorbs the
+  # null default on resend_api_key.
+  runtime_secret_variables = {
+    for name, value in local.runtime_secrets : name => value
+    if try(trimspace(value), "") != ""
+  }
+}
+
 resource "aws_amplify_branch" "this" {
   app_id      = var.amplify_app_id
   branch_name = var.branch_name
@@ -453,6 +478,7 @@ resource "aws_amplify_branch" "this" {
       NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN = var.mapbox_access_token
       NEXT_PUBLIC_TURNSTILE_SITE_KEY  = var.turnstile_site_key
     },
+    local.runtime_secret_variables,
     var.extra_branch_environment_variables,
   )
 
@@ -462,6 +488,24 @@ resource "aws_amplify_branch" "this" {
     precondition {
       condition     = contains(["PRODUCTION", "BETA", "DEVELOPMENT"], var.amplify_stage)
       error_message = "amplify_stage must be one of PRODUCTION, BETA, or DEVELOPMENT."
+    }
+
+    # This resource owns the whole environment_variables map, so anything set by
+    # hand in the Amplify console is deleted on the next apply. Before that
+    # could quietly take payments and email offline, fail the plan instead and
+    # say which key is missing from startline/ci-bootstrap.
+    precondition {
+      condition = var.name != "prod" || length(setsubtract(
+        ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET", "RESEND_API_KEY", "ABR_GUID"],
+        keys(local.runtime_secret_variables),
+      )) == 0
+      error_message = format(
+        "Missing prod runtime secrets: %s. Add the matching keys to the startline/ci-bootstrap secret (stripe_secret_key_prod, stripe_webhook_secret_prod, resend_api_key, abr_guid) — applying without them would strip the values from the Amplify branch and break checkout, email and ABN lookup.",
+        join(", ", setsubtract(
+          ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET", "RESEND_API_KEY", "ABR_GUID"],
+          keys(local.runtime_secret_variables),
+        )),
+      )
     }
   }
 

--- a/terraform/modules/environment/variables.tf
+++ b/terraform/modules/environment/variables.tf
@@ -127,11 +127,47 @@ variable "cognito_deletion_protection" {
   type        = bool
 }
 
+# Runtime server-side secrets.
+#
+# These are read by the running app, not by the build, so they have to live on
+# the Amplify branch environment. The build writes Secrets Manager into
+# .env.production, but `output: "standalone"` ships only `.next` — that file
+# never reaches the server, so a value that exists only in Secrets Manager is
+# undefined at runtime. NEXT_PUBLIC_* is exempt because Next inlines it at
+# build time; everything below is not.
+
 variable "resend_api_key" {
-  description = "Resend API key passed to the custom email sender Lambda."
+  description = "Resend API key. Sends every transactional email; without it lib/email.ts silently skips them and /api/contact 500s."
   type        = string
   sensitive   = true
   default     = null
+}
+
+variable "resend_from" {
+  description = "Overrides the transactional From address. Blank falls back to the default in lib/email.ts."
+  type        = string
+  default     = ""
+}
+
+variable "stripe_secret_key" {
+  description = "Stripe secret key for this environment (live for prod, test for staging). lib/stripe.ts throws without it, so checkout and refunds fail closed."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "stripe_webhook_secret" {
+  description = "Stripe webhook signing secret for this environment. Without it every webhook delivery is rejected and paid registrations are never confirmed."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "abr_guid" {
+  description = "Australian Business Register lookup GUID. Without it /api/abn returns 503 and organisers cannot verify the ABN that hosting paid events requires."
+  type        = string
+  sensitive   = true
+  default     = ""
 }
 
 variable "site_url" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -3,7 +3,19 @@
 # The following values are now sourced from AWS Secrets Manager (startline/ci-bootstrap):
 #   - amplify_repository_access_token
 #   - cloudflare_api_token
+#   - mapbox_access_token
+#
+# Runtime app secrets live there too. These become Amplify branch environment
+# variables, which is the only place the running server can read them from:
+# Secrets Manager reaches the build, not the deployed artefact.
+#   - stripe_secret_key_prod / stripe_secret_key_staging
+#   - stripe_webhook_secret_prod / stripe_webhook_secret_staging
 #   - resend_api_key
+#   - resend_from            (optional; falls back to the address in lib/email.ts)
+#   - abr_guid
+# A prod apply fails its precondition if any required one is missing, rather
+# than clearing whatever the Amplify console currently holds.
+#
 # Set them via: aws secretsmanager put-secret-value --secret-id startline/ci-bootstrap ...
 #
 # aws_region   = "ap-southeast-2"


### PR DESCRIPTION
Fixes #302.

## What was wrong

HJakubS reported three things that looked unrelated: a session-expired error while publishing an event, a crashed page, and being unable to sign in to the organiser portal at all. They had two separate causes.

**Deploys were wiping the database.** The Amplify buildspec ran `prisma db seed` on every staging deploy, and the seed truncates every table before it writes. Signed-in browsers were left holding a valid Cognito session with no matching user row, which surfaced as "your session has expired" halfway through publishing.

**The organiser portal had no sign-in.** Cognito cookies were host-only, so a session created on `startlineau.com` was never sent to `organiser.startlineau.com`. `SignInModal` is mounted in the athlete nav bar and the organiser layout, but not on the landing page unauthenticated visitors actually reach. Middleware then redirected them to the athlete site, where the waitlist gate rewrote everything — no way in, and no way back.

## What changed

**Organiser access** — Cognito tokens are scoped to `.startlineau.com` so one sign-in covers all three portals; sign-in is available on the landing page and the nav bar; cross-portal links go through `lib/portal-domains.ts` so they stay relative where one host serves every portal and absolute only in production; the waitlist gate lets the organiser sign-up path through. Your role on the active organiser now shows in the portal chrome — it was being fetched and discarded.

**Publish path** — `requireOrganiser` tells a database outage (503) from a missing organiser (403) from a real sign-out (401); previously every case was a 401 saying the session had expired. The pg pool is capped per container. Follower notifications and review emails are awaited, since Amplify freezes the container once the response returns. Slug collisions retry instead of 500ing.

**Infrastructure** — runtime secrets move to the Amplify branch environment, where the server can actually read them. `output: "standalone"` means the `.env.production` written from Secrets Manager never ships, so `GUEST_EMAIL_VERIFICATION_SECRET`, `TURNSTILE_SECRET_KEY`, `RESEND_API_KEY` and `ABR_GUID` were undefined in production — guest registration 500s, Turnstile fails open, email is silently skipped, ABN lookup 503s. Also fixes a shell precedence bug where a failed `pnpm install` on a prod build silently retargeted `ENV` at staging.

## Merging: the app and the infrastructure can land separately

The app half needs no `terraform apply`. The seed guard ships in `prisma/seed.ts` and runs from the repo checkout, so **the data loss stops on the next build** — verified: pointed at an RDS host the seed refuses and exits 1 before connecting, and the current buildspec's trailing `; true` swallows that, so the build continues.

The infrastructure half stays dormant until someone applies, and has a prerequisite:

- [ ] Copy the values currently set by hand on the **prod** Amplify branch into the `startline/ci-bootstrap` secret as `stripe_secret_key_prod`, `stripe_webhook_secret_prod`, `resend_api_key`, `abr_guid` (and the `_staging` Stripe pair).
- [ ] Then `terraform apply`.

Order matters: this resource owns the whole `environment_variables` map, so an apply deletes anything set only in the console. A precondition fails the plan and names the missing key rather than letting that happen silently. Skipping the apply entirely regresses nothing — those bugs simply stay unfixed, with `migrate reset --force` (which drops the database on a failed migration) the one I would not sit on for long.

Two changes only engage on the real domains and could not be exercised locally: the cookie re-scoping and the runtime env vars. Worth a staging soak before promoting to prod.

## Verification

`tsc --noEmit`, `eslint .`, 418 unit tests (18 new), `next build`, `terraform validate` and `fmt` all clean. E2E: 41/41 across `organiser`, `api` and `new-listing`; `auth`, `multi-org` and `homepage` pass with one pre-existing `networkidle` flake in `multi-org.spec.ts:84`. Migrations apply cleanly to a real Postgres, and event publishing was confirmed by hand.

Two e2e assertions covered copy that deliberately changed and were updated: the landing page's dashboard link, and an "Unauthorised" message the 401/403 split had already reworded in c6ceb4e.

## Follow-ups, not in this PR

- ToS §3.4 is enforced on one of the two routes to `APPROVED`. Admin review refuses to approve a marketplace event without Stripe onboarding; a verified organiser self-publishing skips that check. Checkout still blocks the transaction, so the failure mode is a live event nobody can register for.
- Some spec in the e2e suite deletes the seeded organiser owner mid-run, leaving results order-dependent.
