### PR TITLE
fix(upload): send files straight to S3 instead of through the compute runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,55 @@ Amplify console is deleted on the next apply. Add new runtime secrets to the
 `stripe_webhook_secret_staging`, `resend_api_key`, `resend_from`, `abr_guid`.
 A prod apply fails its precondition rather than silently clearing a missing one.
 
+## Uploads
+
+**File bytes must never pass through a route handler on a deployed
+environment.** Amplify runs on `platform = "WEB_COMPUTE"`, which is Lambda
+backed, and a multipart request body is base64-encoded into the invocation
+payload. The 6 MB payload ceiling therefore lands just under **4.5 MB of actual
+file**, well below the 10 MB `lib/upload-limits.ts` allows. Anything in between
+is rejected by the platform before the handler runs, and the reply is a **413
+with a zero-length body**, so the client cannot even read a reason off it.
+
+`pnpm upload:probe [base-url]` measures this against a deployed environment
+(staging by default). It needs no credentials: an unauthenticated POST that
+reaches the handler answers `401` with JSON, so the status says which layer
+replied. Measured on staging:
+
+```
+ 4.30 MB -> 401  reached our handler
+ 4.50 MB -> 413  killed by the platform, empty body
+```
+
+The probe also checks that `/api/upload/presign` exists, which is the real
+regression test. **A 404 there means the environment is proxying uploads again
+and anything over ~4.5 MB will fail.** It exits non-zero on either failure, so
+it can gate a deploy.
+
+The browser uploads straight to S3 instead:
+
+| Step | Endpoint | Does |
+|---|---|---|
+| 1 | `POST /api/upload/presign` | Authenticates, checks type/MIME/size, signs a POST scoped to `uploads/{sub}/{type}/{uuid}.{ext}` |
+| 2 | `POST` to the S3 URL | Browser sends the bytes. No size ceiling |
+| 3 | `POST /api/upload/complete` | Ranged GET of the first 16 bytes, magic-byte check, deletes the object if it fails |
+
+`lib/upload-client.ts` (`uploadFile`) drives all three and is the only thing
+UI should call. `/api/upload` still exists and still reads bytes itself, but
+only serves local dev and the Docker image, where there is no bucket — presign
+answers `{mode:"proxy"}` and the client falls back to it.
+
+Two things break this silently if forgotten:
+
+- **CSP.** `connect-src` in `next.config.ts` must list the S3 origin. Without
+  it the browser blocks the upload and nothing reaches the server logs.
+- **Bucket CORS.** `bucket_cors_allowed_origins` in `terraform/main.tf` must
+  cover the portal origins. Prod lists the three domains; staging is `*`.
+
+Step 3 is not optional. Direct-to-S3 means the server never sees the bytes in
+flight, so it is the only remaining check that a file matching an image
+Content-Type is actually an image.
+
 ## Portals and hostnames
 
 Production splits the three portals across `startlineau.com`,

--- a/app/api/upload/complete/route.ts
+++ b/app/api/upload/complete/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { GetObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
+import { getOrganiserSession, getAdminSession, getUserSession } from "@/lib/amplify-server";
+import { matchesMagicBytes } from "@/lib/upload-magic-bytes";
+import { TYPE_MIMES, isUploadType } from "@/lib/upload-limits";
+import { s3, S3_BUCKET, S3_PUBLIC_BASE_URL, UPLOADS_USE_S3 } from "@/lib/s3";
+
+// Direct-to-S3 means the server never sees the bytes on their way past, so the
+// magic-byte check that /api/upload does inline has to happen after the fact.
+// A ranged GET of the first few bytes is enough to tell a real JPEG from a
+// payload wearing its Content-Type, and anything that fails is deleted before
+// its URL is ever handed back. Without this step a signed POST would be a way
+// to park arbitrary content in the bucket under an image content type.
+const MAGIC_BYTE_RANGE = "bytes=0-15";
+
+export async function POST(req: NextRequest) {
+  const session =
+    (await getOrganiserSession()) ??
+    (await getAdminSession()) ??
+    (await getUserSession());
+  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+
+  if (!UPLOADS_USE_S3) {
+    return NextResponse.json({ error: "Direct uploads are not configured." }, { status: 400 });
+  }
+
+  const body: { key?: unknown; type?: unknown; contentType?: unknown } = await req
+    .json()
+    .catch(() => ({}));
+  const { key, type, contentType } = body;
+
+  if (typeof key !== "string" || !isUploadType(type) || typeof contentType !== "string") {
+    return NextResponse.json({ error: "Invalid upload." }, { status: 400 });
+  }
+  if (!TYPE_MIMES[type].includes(contentType)) {
+    return NextResponse.json({ error: "File type not allowed for this upload." }, { status: 400 });
+  }
+  // The presign route keys every object under the caller's own sub. Re-deriving
+  // that prefix here stops one signed-in user naming another user's object and
+  // having the failure path delete it.
+  if (key !== `uploads/${session.sub}/${type}/${key.split("/").pop()}`) {
+    return NextResponse.json({ error: "Invalid upload." }, { status: 400 });
+  }
+
+  let head: Uint8Array;
+  try {
+    const res = await s3.send(
+      new GetObjectCommand({ Bucket: S3_BUCKET, Key: key, Range: MAGIC_BYTE_RANGE })
+    );
+    head = (await res.Body?.transformToByteArray()) ?? new Uint8Array();
+  } catch (err) {
+    // The object should exist: the browser only calls this after S3 accepted
+    // the POST. A miss means the upload was abandoned or the key is wrong.
+    console.error("Upload verify: could not read object", { key }, err);
+    return NextResponse.json({ error: "Upload could not be verified. Please try again." }, { status: 400 });
+  }
+
+  if (!matchesMagicBytes(Buffer.from(head), contentType)) {
+    await s3
+      .send(new DeleteObjectCommand({ Bucket: S3_BUCKET, Key: key }))
+      .catch(err => console.error("Upload verify: could not delete rejected object", { key }, err));
+    return NextResponse.json({ error: "File content does not match its type." }, { status: 400 });
+  }
+
+  return NextResponse.json({ fileUrl: `${S3_PUBLIC_BASE_URL}/${key}` });
+}

--- a/app/api/upload/presign/route.ts
+++ b/app/api/upload/presign/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
+import { getOrganiserSession, getAdminSession, getUserSession } from "@/lib/amplify-server";
+import { UPLOAD_LIMITS, TYPE_MIMES, MIME_EXT, isUploadType, uploadSizeError } from "@/lib/upload-limits";
+import { s3, S3_BUCKET, S3_PUBLIC_BASE_URL, UPLOADS_USE_S3 } from "@/lib/s3";
+
+// Hands the browser a short-lived signature so the file goes straight to S3.
+//
+// Uploads used to stream through /api/upload, which runs on Amplify's
+// WEB_COMPUTE platform. That is Lambda-backed, and the request body is
+// base64-encoded into the invocation payload, so the 6 MB payload ceiling lands
+// just under 4.5 MB of actual file. Our own cap is 10 MB, so every image
+// between those two numbers passed the client-side check and was then rejected
+// by the platform before the route ever ran, with a 413 carrying no body at
+// all. That empty body is why the wizard could only say "please try again"
+// instead of naming a reason (issue #300 capped sizes at 10 MB, which is still
+// more than twice what the runtime accepts; this removes the ceiling instead).
+//
+// Measured on staging: 4.30 MB reaches the handler and 401s, 4.50 MB returns
+// 413 with a zero-length body. See the Uploads section in AGENTS.md.
+//
+// Direct-to-S3 has no such ceiling. The bucket already allows POST from the
+// portal origins and exposes ETag, so no infrastructure change is needed.
+
+const PRESIGN_EXPIRY_SECONDS = 300;
+
+export async function POST(req: NextRequest) {
+  const session =
+    (await getOrganiserSession()) ??
+    (await getAdminSession()) ??
+    (await getUserSession());
+  if (!session) return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+
+  // Without a bucket there is nothing to sign. Local dev and the Docker image
+  // write to public/uploads, so tell the client to post to /api/upload instead
+  // rather than failing: on a laptop the payload ceiling does not exist.
+  if (!UPLOADS_USE_S3) return NextResponse.json({ mode: "proxy" });
+
+  const body: { type?: unknown; contentType?: unknown; size?: unknown } = await req
+    .json()
+    .catch(() => ({}));
+  const { type, contentType, size } = body;
+
+  if (!isUploadType(type)) {
+    return NextResponse.json({ error: "Invalid upload type." }, { status: 400 });
+  }
+  if (typeof contentType !== "string" || !TYPE_MIMES[type].includes(contentType)) {
+    return NextResponse.json({ error: "File type not allowed for this upload." }, { status: 400 });
+  }
+  if (typeof size !== "number" || !Number.isFinite(size) || size <= 0) {
+    return NextResponse.json({ error: "Invalid file size." }, { status: 400 });
+  }
+  const sizeError = uploadSizeError(type, size);
+  if (sizeError) return NextResponse.json({ error: sizeError }, { status: 400 });
+
+  const key = `uploads/${session.sub}/${type}/${randomUUID()}.${MIME_EXT[contentType] ?? "bin"}`;
+
+  try {
+    const { url, fields } = await createPresignedPost(s3, {
+      Bucket: S3_BUCKET,
+      Key: key,
+      Expires: PRESIGN_EXPIRY_SECONDS,
+      Fields: { "Content-Type": contentType },
+      // S3 enforces both, so a client that lies in the request above still
+      // cannot store an oversized object or one under a different type. The
+      // size check here only exists to fail fast with a readable message.
+      Conditions: [
+        ["content-length-range", 1, UPLOAD_LIMITS[type].bytes],
+        ["eq", "$Content-Type", contentType],
+      ],
+    });
+    return NextResponse.json({ mode: "s3", url, fields, key, fileUrl: `${S3_PUBLIC_BASE_URL}/${key}` });
+  } catch (err) {
+    console.error("Presign failed:", { type, size, bucket: S3_BUCKET }, err);
+    return NextResponse.json({ error: "Could not start the upload. Please try again." }, { status: 500 });
+  }
+}

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -5,16 +5,15 @@ import { join } from "path";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getOrganiserSession, getAdminSession, getUserSession } from "@/lib/amplify-server";
 import { matchesMagicBytes } from "@/lib/upload-magic-bytes";
-import { uploadSizeError } from "@/lib/upload-limits";
-import { s3, S3_BUCKET, S3_PUBLIC_BASE_URL } from "@/lib/s3";
+import { uploadSizeError, TYPE_MIMES, MIME_EXT, isUploadType } from "@/lib/upload-limits";
+import { s3, S3_BUCKET, S3_PUBLIC_BASE_URL, UPLOADS_USE_S3 } from "@/lib/s3";
 
-// The bucket is the switch, not the presence of AWS keys: Amplify's compute role
-// exports keys into the runtime whether or not uploads are configured, and the
-// old gate read that as "S3 is ready". Local disk still serves a laptop and the
-// Docker image, which keep public/uploads writable.
-const useS3 =
-  !!S3_BUCKET &&
-  (process.env.NODE_ENV === "production" || process.env.UPLOAD_TO_S3 === "true");
+// Large files no longer come through here at all: the browser signs a direct
+// POST to S3 via /api/upload/presign, because Amplify's WEB_COMPUTE runtime
+// rejects a multipart body over about 4.5 MB before this route is reached.
+// This path stays for local dev and the Docker image, where there is no bucket
+// and public/uploads is writable.
+const useS3 = UPLOADS_USE_S3;
 
 if (!useS3 && process.env.NODE_ENV === "production") {
   console.warn(
@@ -48,19 +47,10 @@ export async function POST(req: NextRequest) {
   const type = formData.get("type") as string;
 
   if (!file) return NextResponse.json({ error: "No file provided." }, { status: 400 });
-  if (!["logo", "cover", "photo", "video", "avatar", "document"].includes(type)) {
+  if (!isUploadType(type)) {
     return NextResponse.json({ error: "Invalid upload type." }, { status: 400 });
   }
-
-  const TYPE_MIMES: Record<string, string[]> = {
-    logo: ["image/jpeg", "image/png", "image/webp", "image/gif"],
-    cover: ["image/jpeg", "image/png", "image/webp", "image/gif"],
-    photo: ["image/jpeg", "image/png", "image/webp", "image/gif"],
-    avatar: ["image/jpeg", "image/png", "image/webp", "image/gif"],
-    video: ["video/mp4", "video/webm", "video/quicktime", "video/avi", "video/ogg"],
-    document: ["application/pdf"],
-  };
-  if (!TYPE_MIMES[type]?.includes(file.type)) {
+  if (!TYPE_MIMES[type].includes(file.type)) {
     return NextResponse.json({ error: "File type not allowed for this upload." }, { status: 400 });
   }
 
@@ -72,19 +62,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: sizeError }, { status: 400 });
   }
 
-  const mimeExt: Record<string, string> = {
-    "image/jpeg": "jpg",
-    "image/png": "png",
-    "image/webp": "webp",
-    "image/gif": "gif",
-    "video/mp4": "mp4",
-    "video/webm": "webm",
-    "video/quicktime": "mov",
-    "video/avi": "avi",
-    "video/ogg": "ogv",
-    "application/pdf": "pdf",
-  };
-  const ext = mimeExt[file.type] ?? "bin";
+  const ext = MIME_EXT[file.type] ?? "bin";
   const filename = `${randomUUID()}.${ext}`;
   const buffer = Buffer.from(await file.arrayBuffer());
 

--- a/components/UserEditProfileModal.tsx
+++ b/components/UserEditProfileModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import { AlertCircle, Check, CheckCircle, Upload, X } from "lucide-react";
 import { GENDER_OPTIONS, maxDateOfBirthForMinAge } from "@/lib/registration-form";
+import { uploadFile } from "@/lib/upload-client";
 
 const inputCls =
   "w-full bg-dark-light border border-dark-lighter rounded-lg px-3 py-2.5 text-[14px] text-light placeholder:text-muted-dark focus:border-primary focus:outline-none transition-colors";
@@ -191,18 +192,7 @@ export default function UserEditProfileModal({ open, initial, onClose, onSaved }
 
   const patch = (p: Partial<ProfileDraft>) => setForm((f) => ({ ...f, ...p }));
 
-  const uploadImage = async (file: File, type: "avatar") => {
-    const fd = new FormData();
-    fd.append("file", file);
-    fd.append("type", type);
-    const res = await fetch("/api/upload", { method: "POST", body: fd });
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}));
-      throw new Error(data.error || "Upload failed.");
-    }
-    const { fileUrl } = await res.json();
-    return fileUrl as string;
-  };
+  const uploadImage = (file: File, type: "avatar") => uploadFile(file, type);
 
   const handleAvatarUpload = async (file: File) => {
     setAvatarUploading(true);

--- a/components/event/EventFormWizard.tsx
+++ b/components/event/EventFormWizard.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { encodePrizePool, parsePrizePool, normalisePrizeAmount } from "@/lib/prize-pool";
 import { UPLOAD_LIMITS } from "@/lib/upload-limits";
+import { uploadFile, UploadError } from "@/lib/upload-client";
 import { formatDivisionLabel } from "@/lib/divisions";
 import { DEFAULT_REFUND_TIERS, REFUND_PRESETS, describeTiers, matchRefundPreset, parseTiers, tiersAreValid, type RefundTier } from "@/lib/refund-policy";
 import AddressAutocomplete  from "@/components/ui/AddressAutocomplete";
@@ -1609,11 +1610,11 @@ export default function EventFormWizard({
   };
 
   // Distinguishes an expired session from a rejected file, and passes the
-  // route's specific reason through instead of a blanket "failed to upload".
-  const uploadErrorText = async (res: Response, fallback: string): Promise<string> => {
-    if (res.status === 401) return SESSION_EXPIRED_MESSAGE;
-    const data: { error?: string } = await res.json().catch(() => ({}));
-    return data.error ? `${fallback} ${data.error}` : `${fallback} Please try again or remove it.`;
+  // upload's specific reason through instead of a blanket "failed to upload".
+  const uploadErrorText = (err: unknown, fallback: string): string => {
+    if (err instanceof UploadError && err.status === 401) return SESSION_EXPIRED_MESSAGE;
+    const reason = err instanceof Error ? err.message : "";
+    return reason ? `${fallback} ${reason}` : `${fallback} Please try again or remove it.`;
   };
 
   const submitToApi = async (asDraft: boolean, overrideTitle?: string): Promise<boolean> => {
@@ -1634,36 +1635,33 @@ export default function EventFormWizard({
 
       let coverImageUrl: string | null = null;
       if (form.coverImage) {
-        const fd = new FormData();
-        fd.append("file", form.coverImage);
-        fd.append("type", "cover");
-        const uploadRes = await fetch("/api/upload", { method: "POST", body: fd });
-        if (!uploadRes.ok) { setApiError(await uploadErrorText(uploadRes, "Cover image upload failed.")); return false; }
-        const { fileUrl } = await uploadRes.json(); coverImageUrl = fileUrl;
+        try {
+          coverImageUrl = await uploadFile(form.coverImage, "cover");
+        } catch (err) {
+          setApiError(uploadErrorText(err, "Cover image upload failed.")); return false;
+        }
       }
 
       const informationPdfs: { url: string; label: string; name: string }[] = [];
       for (const pdf of form.informationPdfs) {
         let url = pdf.url;
         if (pdf.file) {
-          const fd = new FormData();
-          fd.append("file", pdf.file);
-          fd.append("type", "document");
-          const uploadRes = await fetch("/api/upload", { method: "POST", body: fd });
-          if (!uploadRes.ok) { setApiError(await uploadErrorText(uploadRes, `PDF "${pdf.file.name}" failed to upload.`)); return false; }
-          const { fileUrl } = await uploadRes.json(); url = fileUrl;
+          try {
+            url = await uploadFile(pdf.file, "document");
+          } catch (err) {
+            setApiError(uploadErrorText(err, `PDF "${pdf.file.name}" failed to upload.`)); return false;
+          }
         }
         if (url) informationPdfs.push({ url, label: pdf.label.trim(), name: pdf.name });
       }
 
       const photoUrls: string[] = [...form.photoUrls];
       for (const photo of form.photos) {
-        const fd = new FormData();
-        fd.append("file", photo);
-        fd.append("type", "photo");
-        const uploadRes = await fetch("/api/upload", { method: "POST", body: fd });
-        if (!uploadRes.ok) { setApiError(await uploadErrorText(uploadRes, `Gallery photo "${photo.name}" failed to upload.`)); return false; }
-        const { fileUrl } = await uploadRes.json(); photoUrls.push(fileUrl);
+        try {
+          photoUrls.push(await uploadFile(photo, "photo"));
+        } catch (err) {
+          setApiError(uploadErrorText(err, `Gallery photo "${photo.name}" failed to upload.`)); return false;
+        }
       }
 
       const payload = {

--- a/components/organiser/SettingsModal.tsx
+++ b/components/organiser/SettingsModal.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { useSettings, type SettingsSection } from "@/context/SettingsContext";
 import { Skeleton } from "@/components/ui/skeleton";
+import { uploadFile } from "@/lib/upload-client";
 
 // ── shared form primitives ──────────────────────────────────────────────────
 
@@ -264,17 +265,7 @@ function PersonalInfoForm() {
 
   const patch = (p: Partial<ProfileForm>) => setForm(f => ({ ...f, ...p }));
 
-  const uploadImage = async (file: File, type: "logo" | "cover") => {
-    const fd = new FormData();
-    fd.append("file", file); fd.append("type", type);
-    const res = await fetch("/api/upload", { method: "POST", body: fd });
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}));
-      throw new Error(data.error || "Upload failed.");
-    }
-    const { fileUrl } = await res.json();
-    return fileUrl as string;
-  };
+  const uploadImage = (file: File, type: "logo" | "cover") => uploadFile(file, type);
 
   const handleLogoUpload = async (file: File) => {
     setLogoUploading(true);

--- a/e2e/upload.spec.ts
+++ b/e2e/upload.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "@playwright/test";
+import { organiserLogin } from "./helpers";
+
+// Uploads used to POST the file through /api/upload, which runs on Amplify's
+// WEB_COMPUTE platform. Its Lambda payload ceiling lands just under 4.5 MB of
+// file once the multipart body is base64-encoded (measured: 4.30 MB reaches the
+// handler, 4.50 MB gets an empty-bodied 413), well under the 10 MB the app
+// allows, so a normal phone or stock photo was rejected by the platform before
+// any of our code ran. The browser now asks for a signature and posts straight
+// to S3 instead.
+//
+// Locally there is no bucket, so /api/upload/presign answers {mode:"proxy"}.
+// These stubs stand in for a deployed environment answering {mode:"s3"}, which
+// is the path that has to work on Amplify.
+
+// A realistic bucket origin, so this also proves the CSP connect-src allows
+// the host a presigned POST actually targets.
+const S3_ORIGIN = "https://startline-staging-uploads.s3.ap-southeast-2.amazonaws.com";
+const KEY = "uploads/org_1/cover/signed-object.jpg";
+const CDN_URL = `https://cdn.example.test/${KEY}`;
+
+// Bigger than the compute runtime would have accepted, smaller than our cap:
+// exactly the range that used to fail.
+const SIX_MB_JPEG = Buffer.concat([
+  Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+  Buffer.alloc(6 * 1024 * 1024, 0x7f),
+]);
+
+test.describe("image upload", () => {
+  test("posts the file straight to S3 and has the server verify it", async ({ page }) => {
+    let presignBody: Record<string, unknown> | null = null;
+    let completeBody: Record<string, unknown> | null = null;
+    let s3Posted = false;
+
+    await page.route("**/api/upload/presign", async route => {
+      presignBody = JSON.parse(route.request().postData() ?? "{}");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          mode: "s3",
+          url: `${S3_ORIGIN}/`,
+          fields: { key: KEY, "Content-Type": "image/jpeg" },
+          key: KEY,
+          fileUrl: CDN_URL,
+        }),
+      });
+    });
+
+    await page.route(`${S3_ORIGIN}/**`, async route => {
+      s3Posted = true;
+      // S3 answers a browser POST with 204 and no body.
+      await route.fulfill({ status: 204, body: "" });
+    });
+
+    await page.route("**/api/upload/complete", async route => {
+      completeBody = JSON.parse(route.request().postData() ?? "{}");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ fileUrl: CDN_URL }),
+      });
+    });
+
+    // The modal saves the returned URL onto the profile straight away.
+    await page.route("**/api/organiser/profile", async route => {
+      if (route.request().method() !== "PUT") return route.fallback();
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    });
+
+    // The file must never reach our own API: that is the whole bug.
+    let proxied = false;
+    await page.route("**/api/upload", async route => {
+      proxied = true;
+      await route.fulfill({ status: 500, contentType: "application/json", body: "{}" });
+    });
+
+    await organiserLogin(page);
+    await page.goto("/organiser/profile");
+    await page.getByRole("button", { name: "Edit Profile" }).click();
+    await expect(page.getByText("Cover photo")).toBeVisible();
+
+    await page.locator('input[type="file"]').first().setInputFiles({
+      name: "pexels-runffwpu-5840726.jpg",
+      mimeType: "image/jpeg",
+      buffer: SIX_MB_JPEG,
+    });
+
+    await expect.poll(() => completeBody, { timeout: 20000 }).not.toBeNull();
+
+    expect(proxied).toBe(false);
+    expect(s3Posted).toBe(true);
+    expect(presignBody).toMatchObject({ type: "cover", contentType: "image/jpeg" });
+    expect(presignBody!.size).toBe(SIX_MB_JPEG.byteLength);
+    expect(completeBody).toMatchObject({ key: KEY, type: "cover", contentType: "image/jpeg" });
+  });
+
+  test("surfaces the server's reason when a file is refused", async ({ page }) => {
+    await page.route("**/api/upload/presign", route =>
+      route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Image must be 10 MB or smaller." }),
+      })
+    );
+
+    await organiserLogin(page);
+    await page.goto("/organiser/profile");
+    await page.getByRole("button", { name: "Edit Profile" }).click();
+    await expect(page.getByText("Cover photo")).toBeVisible();
+
+    await page.locator('input[type="file"]').first().setInputFiles({
+      name: "too-big.jpg",
+      mimeType: "image/jpeg",
+      buffer: SIX_MB_JPEG,
+    });
+
+    // The reason has to reach the organiser rather than a blanket failure.
+    await expect(page.getByText("Image must be 10 MB or smaller.")).toBeVisible({ timeout: 20000 });
+  });
+});

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -23,3 +23,11 @@ export const S3_PUBLIC_BASE_URL =
 // provider chain picks up the whole set, and falls back to the shared AWS config
 // on a laptop.
 export const s3 = new S3Client({ region: S3_REGION });
+
+// The bucket is the switch, not the presence of AWS keys: Amplify's compute role
+// exports keys into the runtime whether or not uploads are configured, and the
+// old gate read that as "S3 is ready". Local disk still serves a laptop and the
+// Docker image, which keep public/uploads writable.
+export const UPLOADS_USE_S3 =
+  !!S3_BUCKET &&
+  (process.env.NODE_ENV === "production" || process.env.UPLOAD_TO_S3 === "true");

--- a/lib/upload-client.ts
+++ b/lib/upload-client.ts
@@ -1,0 +1,96 @@
+import { UploadType, UPLOAD_LIMITS, uploadSizeError } from "@/lib/upload-limits";
+
+// Browser-side upload. Asks the server for a signature, sends the bytes
+// straight to S3, then has the server verify what landed.
+//
+// The file never passes through Amplify's WEB_COMPUTE runtime, which is where
+// uploads used to die: its Lambda payload ceiling cuts in just under 4.5 MB of
+// file, well under our own 10 MB cap, and rejects the request with an empty-bodied
+// 413 before any of our code runs. See app/api/upload/presign/route.ts.
+
+export class UploadError extends Error {
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "UploadError";
+    this.status = status;
+  }
+}
+
+const GENERIC = "Upload failed. Please try again.";
+
+async function errorFrom(res: Response, fallback = GENERIC): Promise<UploadError> {
+  const data: { error?: string } = await res.json().catch(() => ({}));
+  return new UploadError(data.error || fallback, res.status);
+}
+
+// Posts to /api/upload, which reads the bytes itself and writes them to
+// public/uploads. Only reached when no bucket is configured, i.e. a laptop or
+// the Docker image, where there is no payload ceiling to work around.
+async function uploadThroughServer(file: File, type: UploadType): Promise<string> {
+  const fd = new FormData();
+  fd.append("file", file);
+  fd.append("type", type);
+  const res = await fetch("/api/upload", { method: "POST", body: fd });
+  if (!res.ok) throw await errorFrom(res);
+  const { fileUrl } = await res.json();
+  return fileUrl as string;
+}
+
+export async function uploadFile(file: File, type: UploadType): Promise<string> {
+  // Fail before the round trip when the file is plainly too big. The pickers
+  // check this too, but every caller gets the guarantee this way.
+  const tooBig = uploadSizeError(type, file.size);
+  if (tooBig) throw new UploadError(tooBig, 400);
+
+  const presignRes = await fetch("/api/upload/presign", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ type, contentType: file.type, size: file.size }),
+  });
+  if (!presignRes.ok) throw await errorFrom(presignRes);
+
+  const presign: {
+    mode: "proxy" | "s3";
+    url?: string;
+    fields?: Record<string, string>;
+    key?: string;
+  } = await presignRes.json();
+
+  if (presign.mode === "proxy") return uploadThroughServer(file, type);
+
+  const { url, fields, key } = presign;
+  if (!url || !fields || !key) throw new UploadError(GENERIC, 500);
+
+  const fd = new FormData();
+  // The signed fields have to precede the file: S3 ignores anything that comes
+  // after it in the form.
+  for (const [name, value] of Object.entries(fields)) fd.append(name, value);
+  fd.append("file", file);
+
+  let s3Res: Response;
+  try {
+    s3Res = await fetch(url, { method: "POST", body: fd });
+  } catch {
+    // A CORS rejection or a dropped connection both land here with no status.
+    throw new UploadError("Could not reach the upload service. Check your connection and try again.", 0);
+  }
+  if (!s3Res.ok) {
+    // S3 answers with XML, not JSON. The one case worth naming is a file that
+    // beat the client-side check, which trips the signed content-length-range.
+    const detail = await s3Res.text().catch(() => "");
+    if (detail.includes("EntityTooLarge")) {
+      throw new UploadError(UPLOAD_LIMITS[type].label, 400);
+    }
+    throw new UploadError(GENERIC, s3Res.status);
+  }
+
+  const completeRes = await fetch("/api/upload/complete", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, type, contentType: file.type }),
+  });
+  if (!completeRes.ok) throw await errorFrom(completeRes);
+  const { fileUrl } = await completeRes.json();
+  return fileUrl as string;
+}

--- a/lib/upload-limits.ts
+++ b/lib/upload-limits.ts
@@ -22,3 +22,36 @@ export function uploadSizeError(type: string, size: number): string | null {
   if (!limit) return null;
   return size > limit.bytes ? limit.label : null;
 }
+
+// The MIME allowlist per upload type, and the extension each MIME maps to.
+// Shared by /api/upload (which reads the bytes itself) and /api/upload/presign
+// (which signs a direct-to-S3 POST). Keeping one copy matters: the presign
+// route pins Content-Type as a signature condition, so a divergence here would
+// let S3 reject an upload the route had already approved.
+export const TYPE_MIMES: Record<UploadType, string[]> = {
+  logo:     ["image/jpeg", "image/png", "image/webp", "image/gif"],
+  cover:    ["image/jpeg", "image/png", "image/webp", "image/gif"],
+  photo:    ["image/jpeg", "image/png", "image/webp", "image/gif"],
+  avatar:   ["image/jpeg", "image/png", "image/webp", "image/gif"],
+  video:    ["video/mp4", "video/webm", "video/quicktime", "video/avi", "video/ogg"],
+  document: ["application/pdf"],
+};
+
+export const MIME_EXT: Record<string, string> = {
+  "image/jpeg":      "jpg",
+  "image/png":       "png",
+  "image/webp":      "webp",
+  "image/gif":       "gif",
+  "video/mp4":       "mp4",
+  "video/webm":      "webm",
+  "video/quicktime": "mov",
+  "video/avi":       "avi",
+  "video/ogg":       "ogv",
+  "application/pdf": "pdf",
+};
+
+export const UPLOAD_TYPES = Object.keys(TYPE_MIMES) as UploadType[];
+
+export function isUploadType(value: unknown): value is UploadType {
+  return typeof value === "string" && value in TYPE_MIMES;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -40,7 +40,11 @@ const nextConfig: NextConfig = {
             value: [
               "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
               `script-src ${scriptSrc}`,
-              "connect-src 'self' https://js.stripe.com https://api.mapbox.com https://events.mapbox.com https://*.tiles.mapbox.com https://cognito-idp.ap-southeast-2.amazonaws.com capacitor:// http://localhost",
+              // The S3 origin is required: uploads POST straight to a presigned
+              // bucket URL rather than through /api/upload, because Amplify's
+              // compute runtime rejects a multipart body over roughly 4.4 MB.
+              // Without it the browser blocks the upload with no server-side trace.
+              "connect-src 'self' https://js.stripe.com https://api.mapbox.com https://events.mapbox.com https://*.tiles.mapbox.com https://cognito-idp.ap-southeast-2.amazonaws.com https://*.s3.ap-southeast-2.amazonaws.com https://*.s3.amazonaws.com capacitor:// http://localhost",
               "img-src 'self' data: blob: https://*.tiles.mapbox.com https://api.mapbox.com https:",
               "worker-src blob: 'self'",
               "style-src 'self' 'unsafe-inline' https://api.mapbox.com",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
     "stripe:validate": "node scripts/validate-stripe-connect.mjs",
     "stripe:lifecycle": "node scripts/validate-stripe-lifecycle.mjs",
     "test:registration": "node scripts/test-registration-payment.mjs",
+    "upload:probe": "node scripts/probe-upload-ceiling.mjs",
     "staging:db:start": "aws rds start-db-instance --db-instance-identifier startline-staging-postgres"
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.1073.0",
     "@aws-sdk/client-geo-places": "^3.1079.0",
-    "@aws-sdk/client-s3": "^3.1041.0",
+    "@aws-sdk/client-s3": "^3.1127.0",
+    "@aws-sdk/s3-presigned-post": "^3.1127.0",
     "@capacitor/browser": "^8.0.4",
     "@capacitor/core": "^8.4.2",
     "@prisma/adapter-pg": "^7.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,11 @@ importers:
         specifier: ^3.1079.0
         version: 3.1110.0
       '@aws-sdk/client-s3':
-        specifier: ^3.1041.0
-        version: 3.1110.0
+        specifier: ^3.1127.0
+        version: 3.1127.0
+      '@aws-sdk/s3-presigned-post':
+        specifier: ^3.1127.0
+        version: 3.1127.0
       '@capacitor/browser':
         specifier: ^8.0.4
         version: 8.0.4(@capacitor/core@8.5.0)
@@ -279,8 +282,8 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/checksums@3.1000.28':
-    resolution: {integrity: sha512-VCpnmyHQ1IH49ni3LXnQj7DPr7rmcJmzYeiCkYdCcfgNtkvOj38cdcL9lapBWoItZWFACJPFJlymqC7/gem3Gw==}
+  '@aws-sdk/checksums@3.1000.29':
+    resolution: {integrity: sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-cognito-identity-provider@3.1110.0':
@@ -303,64 +306,116 @@ packages:
     resolution: {integrity: sha512-SLOziEgQIV/Ja3W9N3VOFH5Gy0LOfTafB4qQJaVX7Rh4Id7NAInWXgihxFgO/YKBlT1qpTegDxrIAar8SwSNvg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-s3@3.1110.0':
-    resolution: {integrity: sha512-40xbEcWjdaYKlZ4/NvndIJ3LotAEQAvHVQ7Z4NVy4Z4xGRN7xXJlHI9bMh/4aMJQ++6h5W5sv+wqjfk0rEKOBg==}
+  '@aws-sdk/client-s3@3.1127.0':
+    resolution: {integrity: sha512-0ZSAgmEda33xPqVPt+bx2KzrXV1cUCKRRVPGliLu+V7DzHPa04CqPSi1maGEM4O0LDP0iI6HRSW5ULloNwayNw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.977.8':
     resolution: {integrity: sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.69':
     resolution: {integrity: sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.71':
     resolution: {integrity: sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.973.14':
     resolution: {integrity: sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.76':
     resolution: {integrity: sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.80':
     resolution: {integrity: sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.82':
+    resolution: {integrity: sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.69':
     resolution: {integrity: sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.973.13':
     resolution: {integrity: sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.75':
     resolution: {integrity: sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.972.74':
-    resolution: {integrity: sha512-2lzoV2z2QO5KJZYGOCnIZ1WVQgzMECvwuzr1xb034a++8QW4U4eGrmC2u4yg1xvNv4TLL/Uv5DLyuAiw0b9z7Q==}
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    resolution: {integrity: sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.43':
     resolution: {integrity: sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/signature-v4-multi-region@3.996.45':
-    resolution: {integrity: sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==}
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-presigned-post@3.1127.0':
+    resolution: {integrity: sha512-czx//OxI/4DUaIlvzxkvwzj+4Zzm5dTgRpG5L88lWSwpUo5MoO4fhlPgUUUF/+VhyKEDcc9SW6OAy/HtZhQEzg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1111.0':
     resolution: {integrity: sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.974.4':
     resolution: {integrity: sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -369,6 +424,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.39':
     resolution: {integrity: sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -1738,6 +1797,10 @@ packages:
     resolution: {integrity: sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.5.2':
     resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
     engines: {node: '>=18.0.0'}
@@ -1759,6 +1822,10 @@ packages:
 
   '@smithy/node-http-handler@4.11.2':
     resolution: {integrity: sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.11.3':
+    resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.7.2':
@@ -5353,7 +5420,7 @@ snapshots:
       '@aws-amplify/api-rest': 4.6.4(@aws-amplify/core@6.16.3)
       '@aws-amplify/core': 6.16.3
       '@aws-amplify/data-schema': 1.25.6
-      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/types': 3.974.5
       graphql: 15.8.0
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -5436,7 +5503,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/types': 3.974.5
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -5444,7 +5511,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/types': 3.974.5
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -5453,15 +5520,15 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/types': 3.974.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/checksums@3.1000.28':
+  '@aws-sdk/checksums@3.1000.29':
     dependencies:
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -5480,12 +5547,12 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/credential-provider-node': 3.972.80
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.82
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.7.2
-      '@smithy/node-http-handler': 4.11.2
+      '@smithy/node-http-handler': 4.11.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -5504,12 +5571,12 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/credential-provider-node': 3.972.80
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.82
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.7.2
-      '@smithy/node-http-handler': 4.11.2
+      '@smithy/node-http-handler': 4.11.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -5517,26 +5584,26 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/credential-provider-node': 3.972.80
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.82
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.7.2
-      '@smithy/node-http-handler': 4.11.2
+      '@smithy/node-http-handler': 4.11.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/client-s3@3.1110.0':
+  '@aws-sdk/client-s3@3.1127.0':
     dependencies:
-      '@aws-sdk/checksums': 3.1000.28
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/credential-provider-node': 3.972.80
-      '@aws-sdk/middleware-sdk-s3': 3.972.74
-      '@aws-sdk/signature-v4-multi-region': 3.996.45
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/checksums': 3.1000.29
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.82
+      '@aws-sdk/middleware-sdk-s3': 3.972.75
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.7.2
-      '@smithy/node-http-handler': 4.11.2
+      '@smithy/node-http-handler': 4.11.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -5551,46 +5618,100 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.69':
     dependencies:
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.71':
     dependencies:
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.7.2
-      '@smithy/node-http-handler': 4.11.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.973.14':
     dependencies:
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/credential-provider-env': 3.972.69
-      '@aws-sdk/credential-provider-http': 3.972.71
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
       '@aws-sdk/credential-provider-login': 3.972.76
-      '@aws-sdk/credential-provider-process': 3.972.69
-      '@aws-sdk/credential-provider-sso': 3.973.13
-      '@aws-sdk/credential-provider-web-identity': 3.972.75
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
       '@aws-sdk/nested-clients': 3.997.43
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/credential-provider-imds': 4.5.2
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.76':
     dependencies:
-      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/core': 3.977.9
       '@aws-sdk/nested-clients': 3.997.43
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -5608,70 +5729,146 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.82':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.69':
     dependencies:
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.973.13':
     dependencies:
-      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/core': 3.977.9
       '@aws-sdk/nested-clients': 3.997.43
       '@aws-sdk/token-providers': 3.1111.0
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.972.75':
     dependencies:
-      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/core': 3.977.9
       '@aws-sdk/nested-clients': 3.997.43
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.74':
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
     dependencies:
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/signature-v4-multi-region': 3.996.45
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.43':
     dependencies:
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/signature-v4-multi-region': 3.996.45
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.7.2
-      '@smithy/node-http-handler': 4.11.2
+      '@smithy/node-http-handler': 4.11.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.45':
+  '@aws-sdk/nested-clients@3.997.44':
     dependencies:
-      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-presigned-post@3.1127.0':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1127.0
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
       '@smithy/signature-v4': 5.7.2
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1111.0':
     dependencies:
-      '@aws-sdk/core': 3.977.8
-      '@aws-sdk/nested-clients': 3.997.43
-      '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.33.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/types@3.974.4':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
     dependencies:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
@@ -5681,6 +5878,11 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.39':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
     dependencies:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
@@ -6902,9 +7104,14 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.5.2':
     dependencies:
-      '@smithy/core': 3.33.2
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -6931,6 +7138,12 @@ snapshots:
   '@smithy/node-http-handler@4.11.2':
     dependencies:
       '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.3':
+    dependencies:
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 

--- a/scripts/probe-upload-ceiling.mjs
+++ b/scripts/probe-upload-ceiling.mjs
@@ -1,0 +1,111 @@
+/**
+ * Proves where a deployed environment rejects an upload, and whether the
+ * direct-to-S3 path is live.
+ *
+ * Uploads used to POST the file through /api/upload, which runs on Amplify's
+ * WEB_COMPUTE (Lambda-backed) platform. The multipart body is base64-encoded
+ * into the invocation payload, so the 6 MB payload ceiling lands just under
+ * 4.5 MB of actual file. Files between that and our own 10 MB cap were killed
+ * by the platform before any of our code ran, with a 413 carrying no body at
+ * all, which is why the wizard could only say "please try again".
+ *
+ * No credentials needed. An unauthenticated POST is a clean probe: if it
+ * reaches our handler it answers 401 with JSON, and if the platform kills it
+ * first you see the platform's answer instead. The status tells you which
+ * layer replied.
+ *
+ * Usage:
+ *   node scripts/probe-upload-ceiling.mjs                 # staging
+ *   node scripts/probe-upload-ceiling.mjs <base-url>      # any environment
+ *   pnpm upload:probe
+ *
+ * Exits non-zero if the fix has regressed.
+ */
+
+const STAGING = "https://main.d2tvgx9pzd2e81.amplifyapp.com";
+const base = (process.argv[2] || STAGING).replace(/\/$/, "");
+
+// Either side of the measured ceiling, plus the size that was reported failing.
+const SIZES_KB = [1024, 4096, 4400, 4608, 8192];
+const KB = 1024;
+
+const post = async (url, bytes) => {
+  const form = new FormData();
+  form.append("type", "photo");
+  form.append("file", new Blob([Buffer.alloc(bytes, 0x7f)], { type: "image/jpeg" }), "probe.jpg");
+  const res = await fetch(url, { method: "POST", body: form });
+  return { status: res.status, body: (await res.text()).slice(0, 120) };
+};
+
+const mb = kb => (kb / 1024).toFixed(2);
+
+async function main() {
+  console.log(`\nProbing ${base}\n`);
+
+  // 1. Is the direct-to-S3 path deployed at all? A 404 means this environment
+  //    is still running the old code and every other result below is moot.
+  console.log("1. Direct-to-S3 route");
+  let presignLive = false;
+  try {
+    const res = await fetch(`${base}/api/upload/presign`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "photo", contentType: "image/jpeg", size: 8 * 1024 * KB }),
+    });
+    presignLive = res.status !== 404;
+    console.log(
+      `  ${presignLive ? "PASS" : "FAIL"} /api/upload/presign -> ${res.status}` +
+        (presignLive
+          ? " (401 unauthenticated is correct; the route is deployed)"
+          : " (not deployed: this environment still proxies uploads)")
+    );
+  } catch (err) {
+    console.log(`  FAIL /api/upload/presign -> unreachable: ${err.message}`);
+  }
+  if (!presignLive) process.exitCode = 1;
+
+  // 2. Show the ceiling that made the fix necessary. This probes the legacy
+  //    proxy route, which still exists to serve local dev.
+  console.log("\n2. Compute-runtime payload ceiling (legacy /api/upload)");
+  let lastOk = null;
+  let firstRejected = null;
+  for (const kb of SIZES_KB) {
+    let line;
+    try {
+      const { status, body } = await post(`${base}/api/upload`, kb * KB);
+      const reachedHandler = status === 401 && body.includes("Unauthorised");
+      if (reachedHandler) lastOk = kb;
+      if (status === 413 && firstRejected === null) firstRejected = kb;
+      line =
+        `  ${String(mb(kb)).padStart(5)} MB -> ${status}` +
+        (reachedHandler
+          ? "  reached our handler"
+          : status === 413
+            ? "  killed by the platform, empty body"
+            : `  ${body.replace(/\s+/g, " ").trim() || "(no body)"}`);
+    } catch (err) {
+      line = `  ${String(mb(kb)).padStart(5)} MB -> error: ${err.message}`;
+    }
+    console.log(line);
+  }
+
+  console.log("\n3. Verdict");
+  if (lastOk !== null && firstRejected !== null) {
+    console.log(
+      `  Ceiling sits between ${mb(lastOk)} MB and ${mb(firstRejected)} MB on the compute runtime.`
+    );
+  }
+  if (presignLive) {
+    console.log("  PASS Uploads bypass the ceiling: the browser posts straight to S3.");
+    console.log("       Now upload a >5 MB photo through the event wizard to confirm end to end.");
+  } else {
+    console.log("  FAIL The presign route is missing, so uploads still route through compute");
+    console.log("       and anything over ~4.5 MB will fail. Deploy the fix to this environment.");
+  }
+  console.log("");
+}
+
+main().catch(err => {
+  console.error(`\nProbe failed: ${err.message}\n`);
+  process.exit(1);
+});

--- a/src/__tests__/upload-presign.test.ts
+++ b/src/__tests__/upload-presign.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  // Declared in here because vi.mock factories are hoisted above the file body,
+  // so a class defined below would not exist yet when the factory runs.
+  class GetObjectCommand {
+    constructor(readonly input: Record<string, unknown>) {}
+  }
+  class DeleteObjectCommand {
+    constructor(readonly input: Record<string, unknown>) {}
+  }
+  return {
+    getOrganiserSession: vi.fn(),
+    getAdminSession: vi.fn(),
+    getUserSession: vi.fn(),
+    createPresignedPost: vi.fn(),
+    send: vi.fn(),
+    useS3: true,
+    GetObjectCommand,
+    DeleteObjectCommand,
+  };
+});
+
+vi.mock("@/lib/amplify-server", () => ({
+  getOrganiserSession: mocks.getOrganiserSession,
+  getAdminSession: mocks.getAdminSession,
+  getUserSession: mocks.getUserSession,
+}));
+
+vi.mock("@aws-sdk/s3-presigned-post", () => ({
+  createPresignedPost: mocks.createPresignedPost,
+}));
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  GetObjectCommand: mocks.GetObjectCommand,
+  DeleteObjectCommand: mocks.DeleteObjectCommand,
+}));
+
+vi.mock("@/lib/s3", () => ({
+  s3: { send: mocks.send },
+  S3_BUCKET: "startline-staging-uploads",
+  S3_PUBLIC_BASE_URL: "https://cdn.startlineau.com",
+  get UPLOADS_USE_S3() {
+    return mocks.useS3;
+  },
+}));
+
+import { POST as presign } from "@/app/api/upload/presign/route";
+import { POST as complete } from "@/app/api/upload/complete/route";
+import { UPLOAD_LIMITS } from "@/lib/upload-limits";
+
+const SUB = "cog_sarah";
+const MB = 1024 * 1024;
+
+const post = (url: string, body: unknown) =>
+  new Request(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    // The routes only ever call req.json(), so a plain Request stands in for
+    // the NextRequest they are typed against.
+  }) as unknown as Parameters<typeof presign>[0];
+
+const presignReq = (body: unknown) => presign(post("http://localhost/api/upload/presign", body));
+const completeReq = (body: unknown) => complete(post("http://localhost/api/upload/complete", body));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  mocks.useS3 = true;
+  mocks.getOrganiserSession.mockResolvedValue({ sub: SUB });
+  mocks.getAdminSession.mockResolvedValue(null);
+  mocks.getUserSession.mockResolvedValue(null);
+  mocks.createPresignedPost.mockResolvedValue({
+    url: "https://startline-staging-uploads.s3.ap-southeast-2.amazonaws.com",
+    fields: { key: "signed", policy: "p", "x-amz-signature": "sig" },
+  });
+});
+
+describe("POST /api/upload/presign", () => {
+  it("refuses a caller with no session", async () => {
+    mocks.getOrganiserSession.mockResolvedValue(null);
+
+    const res = await presignReq({ type: "photo", contentType: "image/jpeg", size: MB });
+
+    expect(res.status).toBe(401);
+    expect(mocks.createPresignedPost).not.toHaveBeenCalled();
+  });
+
+  it("tells the client to proxy when no bucket is configured", async () => {
+    mocks.useS3 = false;
+
+    const res = await presignReq({ type: "photo", contentType: "image/jpeg", size: MB });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ mode: "proxy" });
+  });
+
+  it("rejects an upload type outside the allowlist", async () => {
+    const res = await presignReq({ type: "archive", contentType: "image/jpeg", size: MB });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid upload type.");
+  });
+
+  it("rejects a MIME type that is not allowed for the upload type", async () => {
+    const res = await presignReq({ type: "photo", contentType: "application/pdf", size: MB });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("File type not allowed for this upload.");
+  });
+
+  it("rejects a file over the cap before signing anything", async () => {
+    const res = await presignReq({
+      type: "photo",
+      contentType: "image/jpeg",
+      size: UPLOAD_LIMITS.photo.bytes + 1,
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Image must be 10 MB or smaller.");
+    expect(mocks.createPresignedPost).not.toHaveBeenCalled();
+  });
+
+  // The 8 MB case is the reported bug: it is under our 10 MB cap but over the
+  // ~4.4 MB that survives Amplify's Lambda payload ceiling, so it has to be
+  // signed for a direct upload rather than proxied.
+  it("signs an 8 MB photo that the compute runtime would have rejected", async () => {
+    const res = await presignReq({ type: "photo", contentType: "image/jpeg", size: 8 * MB });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe("s3");
+    expect(body.key).toMatch(new RegExp(`^uploads/${SUB}/photo/[0-9a-f-]+\\.jpg$`));
+    expect(body.fileUrl).toBe(`https://cdn.startlineau.com/${body.key}`);
+  });
+
+  it("pins the size and content type into the signature", async () => {
+    await presignReq({ type: "photo", contentType: "image/png", size: MB });
+
+    const [, args] = mocks.createPresignedPost.mock.calls[0];
+    expect(args.Fields).toEqual({ "Content-Type": "image/png" });
+    expect(args.Conditions).toEqual([
+      ["content-length-range", 1, UPLOAD_LIMITS.photo.bytes],
+      ["eq", "$Content-Type", "image/png"],
+    ]);
+    expect(args.Key).toMatch(/\.png$/);
+  });
+
+  it("keys the object under the caller's own sub", async () => {
+    mocks.getOrganiserSession.mockResolvedValue(null);
+    mocks.getUserSession.mockResolvedValue({ sub: "cog_jade" });
+
+    const res = await presignReq({ type: "avatar", contentType: "image/webp", size: MB });
+
+    expect((await res.json()).key).toMatch(/^uploads\/cog_jade\/avatar\//);
+  });
+});
+
+describe("POST /api/upload/complete", () => {
+  const KEY = `uploads/${SUB}/photo/abc.jpg`;
+  const bodyOf = (bytes: number[]) => ({
+    Body: { transformToByteArray: async () => new Uint8Array(bytes) },
+  });
+  const JPEG = [0xff, 0xd8, 0xff, 0xe0];
+
+  it("returns the CDN url when the bytes match the declared type", async () => {
+    mocks.send.mockResolvedValue(bodyOf(JPEG));
+
+    const res = await completeReq({ key: KEY, type: "photo", contentType: "image/jpeg" });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).fileUrl).toBe(`https://cdn.startlineau.com/${KEY}`);
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads only the leading bytes, not the whole object", async () => {
+    mocks.send.mockResolvedValue(bodyOf(JPEG));
+
+    await completeReq({ key: KEY, type: "photo", contentType: "image/jpeg" });
+
+    const command = mocks.send.mock.calls[0][0];
+    expect(command).toBeInstanceOf(mocks.GetObjectCommand);
+    expect(command.input.Range).toBe("bytes=0-15");
+  });
+
+  // Direct-to-S3 removes the inline magic-byte check, so this is the only
+  // thing standing between a signed POST and arbitrary content in the bucket.
+  it("deletes the object and refuses when the bytes do not match", async () => {
+    mocks.send.mockResolvedValueOnce(bodyOf([0x3c, 0x21, 0x64, 0x6f])).mockResolvedValueOnce({});
+
+    const res = await completeReq({ key: KEY, type: "photo", contentType: "image/jpeg" });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("File content does not match its type.");
+    const deletion = mocks.send.mock.calls[1][0];
+    expect(deletion).toBeInstanceOf(mocks.DeleteObjectCommand);
+    expect(deletion.input.Key).toBe(KEY);
+  });
+
+  it("refuses a key belonging to another user", async () => {
+    const res = await completeReq({
+      key: "uploads/cog_someone_else/photo/abc.jpg",
+      type: "photo",
+      contentType: "image/jpeg",
+    });
+
+    expect(res.status).toBe(400);
+    expect(mocks.send).not.toHaveBeenCalled();
+  });
+
+  it("refuses a key that climbs out of its own prefix", async () => {
+    const res = await completeReq({
+      key: `uploads/${SUB}/photo/../../cog_other/photo/abc.jpg`,
+      type: "photo",
+      contentType: "image/jpeg",
+    });
+
+    expect(res.status).toBe(400);
+    expect(mocks.send).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the caller has no session", async () => {
+    mocks.getOrganiserSession.mockResolvedValue(null);
+
+    const res = await completeReq({ key: KEY, type: "photo", contentType: "image/jpeg" });
+
+    expect(res.status).toBe(401);
+    expect(mocks.send).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Image uploads kept failing on Amplify with `Gallery photo "pexels-runffwpu-5840726.jpg" failed to upload. Please try again or remove it.`

That wording was the clue. The wizard only falls back to it when the response carries no `error` field, but every failure branch in `/api/upload` returns JSON. The request was never reaching our code, which ruled out auth, the size cap, the MIME allowlist and the S3 write.

### Cause

Amplify runs `platform = "WEB_COMPUTE"`, which is Lambda-backed, and a multipart body is base64-encoded into the invocation payload. The 6 MB payload ceiling therefore lands just under **4.5 MB of actual file**, while `lib/upload-limits.ts` allows 10 MB. Anything in between passed the client-side check and was then killed by the platform with a **413 carrying no body at all**.

Measured on staging, unauthenticated. A request that reaches the handler 401s, so the status says which layer replied:

| Payload | Result |
|---|---|
| 1.00 MB | `401 {"error":"Unauthorised."}` reached our handler |
| 4.30 MB | `401 {"error":"Unauthorised."}` reached our handler |
| **4.50 MB** | **`413`, empty body** killed by the platform |
| 8.00 MB | `413`, empty body |

#301 identified this same ceiling but capped uploads at 10 MB, more than twice what the runtime accepts, so files in the gap kept failing. That is why this has recurred.

### Fix

The browser now asks for a signature, posts the bytes straight to S3, and has the server verify what landed.

| Step | Endpoint | Does |
|---|---|---|
| 1 | `POST /api/upload/presign` | Authenticates, checks type/MIME/size, signs a POST scoped to `uploads/{sub}/{type}/{uuid}.{ext}` |
| 2 | `POST` to the S3 URL | Browser sends the bytes. No ceiling |
| 3 | `POST /api/upload/complete` | 16-byte ranged GET, magic-byte check, deletes the object if it fails |

The size cap and Content-Type go into the signature as S3 conditions, so a client that lies still cannot beat them. Step 3 is not optional: direct-to-S3 means the server never sees the bytes in flight, so it is the only thing left stopping a signed POST parking arbitrary content in the bucket under an image content type.

`lib/upload-client.ts` drives all three steps and is now the only thing the UI calls. `/api/upload` still reads bytes itself, but only serves local dev and the Docker image, where there is no bucket and no ceiling.

Also fixes `connect-src` in `next.config.ts`, which had no S3 origin. Without it the browser blocks the upload and nothing reaches the server logs, which would have reproduced the original bug exactly. The E2E test caught this.

The organiser logo/cover and user avatar pickers had the same bug and now share the helper.

### Verified against live infrastructure

- 8 MB presigned POST to `startline-staging-uploads` returns **204**, stores 8,388,612 bytes as `image/jpeg`
- The ranged GET and magic-byte check pass
- Oversizing the signed policy returns **400 EntityTooLarge**, so the cap is enforced by S3, not merely advised
- Swapping `Content-Type` to `text/html` returns **403 AccessDenied**
- Test object deleted afterwards

Bucket CORS already allowed browser POST on both environments and the compute role already holds `PutObject`, `GetObject` and `DeleteObject`, so **no infrastructure change is needed**.

### Testing

- `pnpm lint` 0 errors 0 warnings, `pnpm typecheck` clean
- `pnpm test` 432 passed, 14 new covering presign conditions, key scoping, cross-user key rejection and the verify/delete path
- `pnpm test:e2e` full suite exit 0, 2 new tests asserting the file never touches `/api/upload` and that a rejection reason reaches the organiser
- `pnpm build` compiles, both routes registered

### Not yet exercised

The assembled code has not run on Amplify. The presigned POST will be signed with the compute role's temporary credentials, which embed a session token; testing used long-term credentials. The SDK handles this automatically and #291 already proved those temporary credentials write to this bucket, but it is untested here.

After merge, run `pnpm upload:probe` against staging. It needs no credentials and exits non-zero if uploads have regressed to the proxy path. `/api/upload/presign` returning 404 is the regression signal. Then upload a >5 MB photo through the wizard to close the last gap.

Relates to #300, which was closed while this was still broken and may be worth reopening.
