### PR TITLE
ABN submission gate and issue #304 general fixes

### DIFF
--- a/app/(user)/activity/page.tsx
+++ b/app/(user)/activity/page.tsx
@@ -151,6 +151,9 @@ function RegisteredCard({
 }) {
   const refundRequested = meta?.status === "REFUND_REQUESTED";
   const refunded = meta?.status === "REFUNDED";
+  // A free entry has no money attached, so the same flow reads as giving up the
+  // spot rather than asking for money back (issue #304).
+  const freeEntry = (meta?.paidCents ?? 0) === 0;
   return (
     <div className="flex flex-col">
       <EventCard
@@ -182,11 +185,13 @@ function RegisteredCard({
         <div className="mt-1.5 flex justify-end">
           {refunded ? (
             <span className="font-headline text-[10px] font-bold uppercase tracking-widest text-muted">
-              Refunded {money(meta.refundAmountCents)}
+              {freeEntry ? "Spot released" : `Refunded ${money(meta.refundAmountCents)}`}
             </span>
           ) : refundRequested ? (
             <span className="font-headline text-[10px] font-bold uppercase tracking-widest text-amber-300">
-              Refund requested{meta.refundAmountCents > 0 ? ` · ${money(meta.refundAmountCents)}` : ""}
+              {freeEntry
+                ? "Cancellation requested"
+                : `Refund requested${meta.refundAmountCents > 0 ? ` · ${money(meta.refundAmountCents)}` : ""}`}
             </span>
           ) : (
             <button
@@ -194,7 +199,7 @@ function RegisteredCard({
               onClick={() => onRequestRefund(meta)}
               className="font-headline text-[10px] font-bold uppercase tracking-widest text-muted-dark hover:text-red-300 transition-colors"
             >
-              Request refund
+              {freeEntry ? "Cancel my spot" : "Request refund"}
             </button>
           )}
         </div>
@@ -331,6 +336,9 @@ export default function ActivityPage() {
       setRefunding(false);
     }
   };
+
+  // The open dialog's entry is free when nothing was paid for it.
+  const freeRefundTarget = !!refundTarget && refundTarget.meta.paidCents === 0;
 
   const markAllRead = () => {
     setNotifs((prev) => prev.map((n) => ({ ...n, read: true })));
@@ -533,7 +541,7 @@ export default function ActivityPage() {
       <Dialog open={!!refundTarget} onOpenChange={(open) => { if (!open) setRefundTarget(null); }}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Request a refund</DialogTitle>
+            <DialogTitle>{freeRefundTarget ? "Cancel my spot" : "Request a refund"}</DialogTitle>
             <DialogDescription>
               {refundTarget?.title}. You will come out of the start list and free your spot.
             </DialogDescription>
@@ -543,7 +551,17 @@ export default function ActivityPage() {
             <div className="space-y-3">
               {/* The number first. This is what the athlete is actually deciding on. */}
               <div className="rounded-md bg-dark px-4 py-3">
-                {refundTarget.meta.outsidePolicy ? (
+                {freeRefundTarget ? (
+                  <>
+                    <p className="font-headline text-[13px] font-bold uppercase tracking-widest text-light">
+                      Free entry
+                    </p>
+                    <p className="text-[13px] text-muted leading-relaxed mt-1">
+                      This entry cost nothing, so there is no refund to make. Cancelling gives your spot back
+                      to the event and takes you out of the start list.
+                    </p>
+                  </>
+                ) : refundTarget.meta.outsidePolicy ? (
                   <>
                     <p className="font-headline text-[13px] font-bold uppercase tracking-widest text-amber-300">
                       No refund at this date
@@ -570,16 +588,20 @@ export default function ActivityPage() {
                 )}
               </div>
 
-              <div>
-                <p className="font-headline text-[10px] font-bold uppercase tracking-widest text-muted-dark mb-1">
-                  This event&apos;s policy
-                </p>
-                {refundTarget.meta.policyLines.map((line, i) => (
-                  <p key={i} className="text-[12px] text-muted leading-relaxed">{line}</p>
-                ))}
-              </div>
+              {!freeRefundTarget && (
+                <>
+                  <div>
+                    <p className="font-headline text-[10px] font-bold uppercase tracking-widest text-muted-dark mb-1">
+                      This event&apos;s policy
+                    </p>
+                    {refundTarget.meta.policyLines.map((line, i) => (
+                      <p key={i} className="text-[12px] text-muted leading-relaxed">{line}</p>
+                    ))}
+                  </div>
 
-              <p className="text-[12px] text-muted-dark leading-relaxed">{REFUND_PROCESS_COPY}</p>
+                  <p className="text-[12px] text-muted-dark leading-relaxed">{REFUND_PROCESS_COPY}</p>
+                </>
+              )}
             </div>
           )}
 
@@ -588,10 +610,12 @@ export default function ActivityPage() {
             <Button variant="ghost" onClick={() => setRefundTarget(null)}>Keep my spot</Button>
             <Button onClick={confirmRefund} disabled={refunding}>
               {refunding
-                ? "Requesting…"
-                : refundTarget?.meta.outsidePolicy
-                  ? "Ask anyway"
-                  : `Request ${money(refundTarget?.meta.refundAmountCents ?? 0)}`}
+                ? freeRefundTarget ? "Cancelling…" : "Requesting…"
+                : freeRefundTarget
+                  ? "Cancel my spot"
+                  : refundTarget?.meta.outsidePolicy
+                    ? "Ask anyway"
+                    : `Request ${money(refundTarget?.meta.refundAmountCents ?? 0)}`}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/(user)/events/[id]/page.tsx
+++ b/app/(user)/events/[id]/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from "next";
 import { MapPin, Calendar, ExternalLink, Trophy, Clock, Ticket, FileText } from "lucide-react";
 import BackToEventsLink from "@/components/event/BackToEventsLink";
 import { getAllEvents, getPublicEventById } from "@/lib/events";
-import { todayIso } from "@/lib/event-types";
+import { isFreeEvent, todayIso } from "@/lib/event-types";
 import { parsePrizePool } from "@/lib/prize-pool";
 import { describeTiers, parseTiers, REFUND_PROCESS_COPY } from "@/lib/refund-policy";
 import { sanitizeHtml } from "@/lib/sanitize-html";
@@ -368,6 +368,8 @@ export default async function EventDetailPage({ params }: { params: Promise<{ id
               </div>
             )}
 
+            {/* A free event takes no money, so there is no policy to publish. */}
+            {!isFreeEvent(event.ticketDrops) && (
             <div className="bg-dark rounded-xl p-5 sm:p-6">
               <h3 className="font-headline text-xs font-medium uppercase tracking-widest text-muted mb-2">Refund &amp; Transfer Policy</h3>
               <ul className="space-y-1">
@@ -380,6 +382,7 @@ export default async function EventDetailPage({ params }: { params: Promise<{ id
               )}
               <p className="text-[13px] text-muted-dark leading-relaxed mt-3">{REFUND_PROCESS_COPY}</p>
             </div>
+            )}
 
           </div>
         </div>

--- a/app/(user)/events/[id]/register/ReviewPayStep.tsx
+++ b/app/(user)/events/[id]/register/ReviewPayStep.tsx
@@ -144,10 +144,13 @@ function ReviewPayForm({
           <PaymentElement />
         </div>
 
-        {/* What cancelling would return, stated before they pay rather than buried in terms. */}
-        <div className="rounded-[12px] border border-dark-lighter bg-dark px-4 py-3 mb-4">
-          <p className="text-[12.5px] text-light leading-relaxed">{refundHeadline}</p>
-        </div>
+        {/* What cancelling would return, stated before they pay rather than buried in
+            terms. Empty on a free event, which has no refund policy to state. */}
+        {refundHeadline && (
+          <div className="rounded-[12px] border border-dark-lighter bg-dark px-4 py-3 mb-4">
+            <p className="text-[12.5px] text-light leading-relaxed">{refundHeadline}</p>
+          </div>
+        )}
 
         {/* Terms */}
         <div className="flex items-start gap-3">
@@ -194,10 +197,12 @@ function ReviewPayForm({
             </div>
             <div className="px-4 py-3 max-h-40 overflow-y-auto text-muted text-[12px] leading-relaxed space-y-2">
               <p>Event terms and conditions are set by the organiser. By registering you agree to participate in accordance with the organiser&apos;s rules and the Startline platform guidelines.</p>
-              <div>
-                <p className="font-headline text-[10px] font-bold uppercase tracking-widest text-primary mb-1">Refund policy</p>
-                {refundLines.map((line, i) => <p key={i}>{line}</p>)}
-              </div>
+              {refundLines.length > 0 && (
+                <div>
+                  <p className="font-headline text-[10px] font-bold uppercase tracking-widest text-primary mb-1">Refund policy</p>
+                  {refundLines.map((line, i) => <p key={i}>{line}</p>)}
+                </div>
+              )}
               <p>Ensure the details you have provided are accurate before paying.</p>
             </div>
           </div>

--- a/app/(user)/events/[id]/register/page.tsx
+++ b/app/(user)/events/[id]/register/page.tsx
@@ -15,6 +15,7 @@ import TurnstileWidget from "@/components/TurnstileWidget";
 import { useAuthContext } from "@/context/AuthContext";
 import { cn } from "@/lib/utils";
 import { daysUntil, describeTiers, parseTiers, refundAmountCents } from "@/lib/refund-policy";
+import { isFreeEvent } from "@/lib/event-types";
 
 const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "";
 const BOT_CHECK_HOSTS = ["startlineau.com", "www.startlineau.com", "staging.startlineau.com"];
@@ -320,12 +321,16 @@ function RegisterContent() {
   const tierSummary = tierLines.map((t) => (t.qty > 1 ? `${t.qty} × ${t.label}` : t.label)).join(", ");
 
   // Refund position at the moment of paying, in dollars rather than in principle.
+  // A free event has no policy to state — nothing is paid, so nothing comes back
+  // — and both surfaces below take an empty list as "say nothing" (issue #304).
+  const freeEvent = isFreeEvent(event?.waves);
   const refundTiers = parseTiers(event?.refundTiers);
-  const refundLines = describeTiers(refundTiers);
+  const refundLines = freeEvent ? [] : describeTiers(refundTiers);
   const daysToEvent = event ? daysUntil(event.eventDate, new Date().toISOString().slice(0, 10)) : 0;
   const refundIfCancelledNow = refundAmountCents(refundTiers, Math.round(total * 100), daysToEvent) / 100;
-  const refundHeadline =
-    refundIfCancelledNow > 0
+  const refundHeadline = freeEvent
+    ? ""
+    : refundIfCancelledNow > 0
       ? `Cancel today and you get ${money(refundIfCancelledNow)} of ${money(total)} back. The amount drops as the event gets closer.`
       : `This event's policy does not cover a refund at this date, so treat this entry as final.`;
 

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -6,11 +6,12 @@ import Image from "next/image";
 import Link from "next/link";
 import {
   MapPin, Calendar, Check, X, RefreshCw, ChevronDown, ChevronUp,
-  Pin, PinOff, Trash2, CheckSquare, Square, Plus, Pencil,
+  Pin, PinOff, Trash2, CheckSquare, Square, Plus, Pencil, AlertTriangle,
 } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { TableSkeleton } from "@/components/ui/skeleton";
+import { hasAbn } from "@/lib/abn";
 
 export const dynamic = "force-dynamic";
 
@@ -30,7 +31,26 @@ interface AdminEventRow {
   coverImageUrl: string | null;
   rejectionReason: string | null;
   reviewedAt: string | null;
-  organiser: { id: string; orgName: string | null; contactName: string | null; email: string };
+  registrationType: string | null;
+  organiser: {
+    id: string;
+    orgName: string | null;
+    contactName: string | null;
+    email: string;
+    abn: string | null;
+    stripeOnboardingComplete: boolean;
+  };
+}
+
+// Why a marketplace listing cannot be approved yet, or null when it can. The
+// organiser is allowed to submit with these missing, so the review queue is
+// where the gap has to be visible: without this an admin only finds out by
+// clicking approve and reading a 422.
+function approvalBlocker(event: AdminEventRow): string | null {
+  if (event.registrationType !== "startline") return null;
+  if (!hasAbn(event.organiser.abn)) return "No ABN on file";
+  if (!event.organiser.stripeOnboardingComplete) return "Stripe onboarding incomplete";
+  return null;
 }
 
 const TABS: { status: EventStatus; label: string }[] = [
@@ -126,6 +146,7 @@ function EventRow({
 }) {
   const [approving,    setApproving]    = useState(false);
   const [approveError, setApproveError] = useState("");
+  const blocker = approvalBlocker(event);
   const [rejectOpen,   setRejectOpen]   = useState(false);
   const [rejecting,    setRejecting]    = useState(false);
   const [pinning,      setPinning]      = useState(false);
@@ -267,7 +288,8 @@ function EventRow({
             <>
               <button
                 onClick={handleApprove}
-                disabled={approving || rejecting}
+                disabled={approving || rejecting || blocker !== null}
+                title={blocker ? `Cannot approve: ${blocker}.` : undefined}
                 className="flex items-center gap-1.5 font-headline text-[12px] font-bold uppercase tracking-widest bg-primary text-dark px-3 py-2 rounded-md hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 {approving
@@ -346,6 +368,20 @@ function EventRow({
         </div>
       </div>
 
+      {/* Organiser profile incomplete — the reason approve is unavailable */}
+      {event.status === "PENDING" && blocker && (
+        <div className="px-5 pb-4 pl-12">
+          <div className="flex items-start gap-3 bg-amber-400/[0.08] border border-amber-400/20 rounded-lg px-4 py-3">
+            <AlertTriangle className="w-4 h-4 text-amber-400 mt-0.5 shrink-0" />
+            <div className="text-[13px] text-amber-200">
+              <span className="font-bold">Organiser profile incomplete: {blocker}.</span>{" "}
+              This event cannot be approved until{" "}
+              {event.organiser.orgName || event.organiser.email} completes their profile.
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Approve error */}
       {approveError && (
         <div className="px-5 pb-4 pl-12">
@@ -414,11 +450,13 @@ function BulkActionBar({
   const [rejectOpen,    setRejectOpen]    = useState(false);
   const [bulkReason,    setBulkReason]    = useState("");
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [skipped,       setSkipped]       = useState<{ id: string; title: string; reason: string }[]>([]);
 
   const ids = Array.from(selectedIds);
 
   const run = async (action: string, reason?: string) => {
     setLoading(true);
+    setSkipped([]);
     try {
       const res = await fetch("/api/admin/events/bulk", {
         method:  "POST",
@@ -426,8 +464,16 @@ function BulkActionBar({
         body:    JSON.stringify({ ids, action, reason }),
       });
       if (res.ok) {
-        onBulkDone(ids, action);
-        onClearSelection();
+        const data = await res.json().catch(() => ({})) as {
+          blocked?: { id: string; title: string; reason: string }[];
+        };
+        const blocked = data.blocked ?? [];
+        // Only clear what actually changed. Reporting every id as done would
+        // drop events off the queue that are still sitting in PENDING.
+        const blockedIds = new Set(blocked.map((e) => e.id));
+        onBulkDone(ids.filter((id) => !blockedIds.has(id)), action);
+        setSkipped(blocked);
+        if (blocked.length === 0) onClearSelection();
         setRejectOpen(false);
         setConfirmDelete(false);
         setBulkReason("");
@@ -442,6 +488,18 @@ function BulkActionBar({
       <span className="font-headline text-[12px] font-bold uppercase tracking-widest text-muted">
         {ids.length} selected
       </span>
+
+      {skipped.length > 0 && (
+        <div className="w-full flex items-start gap-2 bg-amber-400/[0.08] border border-amber-400/20 rounded-lg px-3 py-2 order-last">
+          <AlertTriangle className="w-4 h-4 text-amber-400 mt-0.5 shrink-0" />
+          <div className="text-[13px] text-amber-200">
+            <span className="font-bold">
+              {skipped.length} event{skipped.length === 1 ? "" : "s"} not approved.
+            </span>{" "}
+            {skipped.map((e) => `${e.title} (${e.reason})`).join("; ")}
+          </div>
+        </div>
+      )}
 
       {activeTab === "PENDING" && !rejectOpen && !confirmDelete && (
         <>

--- a/app/api/admin/events/[id]/review/route.ts
+++ b/app/api/admin/events/[id]/review/route.ts
@@ -5,6 +5,7 @@ import { sendEventApprovedEmail, sendEventRejectedEmail } from "@/lib/email";
 import { writeAuditLog } from "@/lib/audit";
 import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
 import { idParams } from "@/lib/schemas";
+import { hasAbn } from "@/lib/abn";
 import { z } from "zod";
 
 const reviewActionSchema = z.object({
@@ -41,7 +42,7 @@ export async function POST(
       select: {
         id: true, title: true, status: true, registrationType: true,
         eventDate: true, city: true,
-        organiser: { select: { id: true, email: true, orgName: true, stripeOnboardingComplete: true } },
+        organiser: { select: { id: true, email: true, orgName: true, stripeOnboardingComplete: true, abn: true } },
       },
     });
 
@@ -52,6 +53,18 @@ export async function POST(
         { error: "Only PENDING events can be reviewed." },
         { status: 409 },
       );
+    }
+
+    // The organiser is no longer blocked from submitting without an ABN, so the
+    // requirement has to hold here instead: a marketplace listing cannot go live
+    // until the organiser's profile carries one.
+    if (action === "approve" && event.registrationType === "startline") {
+      if (!hasAbn(event.organiser.abn)) {
+        return NextResponse.json(
+          { error: "This organiser has no ABN on file. Marketplace events cannot be approved until their profile is complete.", code: "ABN_MISSING" },
+          { status: 422 },
+        );
+      }
     }
 
     // Per ToS §3.4 — marketplace listings cannot go live until Stripe onboarding is complete

--- a/app/api/admin/events/bulk/route.ts
+++ b/app/api/admin/events/bulk/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getAdminSession } from "@/lib/amplify-server";
 import { writeAuditLog } from "@/lib/audit";
+import { hasAbn } from "@/lib/abn";
 import { z } from "zod";
 
 const bulkActionSchema = z.object({
@@ -29,23 +30,54 @@ export async function POST(req: NextRequest) {
 
   try {
     let affected = 0;
+    let blocked: { id: string; title: string; reason: string }[] = [];
 
     if (action === "delete") {
       const result = await prisma.event.deleteMany({ where: { id: { in: ids } } });
       affected = result.count;
     } else {
+      let approvable = ids;
+
+      // Bulk approve used to write straight through, so it could publish an
+      // event that the single-approve route refuses. Both gates are re-checked
+      // here or the rule is one checkbox away from being bypassed. The ABN test
+      // counts digits, which SQL cannot express, so the partition happens here
+      // rather than in the where clause.
+      if (action === "approve") {
+        const candidates = await prisma.event.findMany({
+          where:  { id: { in: ids }, status: "PENDING" },
+          select: {
+            id: true, title: true, registrationType: true,
+            organiser: { select: { abn: true, stripeOnboardingComplete: true } },
+          },
+        });
+        const blockedFor = (e: (typeof candidates)[number]): string | null => {
+          if (e.registrationType !== "startline") return null;
+          if (!hasAbn(e.organiser.abn)) return "No ABN on file";
+          if (!e.organiser.stripeOnboardingComplete) return "Stripe onboarding incomplete";
+          return null;
+        };
+        blocked = candidates
+          .map((e) => ({ id: e.id, title: e.title, reason: blockedFor(e) }))
+          .filter((e): e is { id: string; title: string; reason: string } => e.reason !== null);
+        const blockedIds = new Set(blocked.map((e) => e.id));
+        approvable = ids.filter((id) => !blockedIds.has(id));
+      }
+
       const newStatus = action === "approve" ? "APPROVED" : "REJECTED";
-      const result = await prisma.event.updateMany({
-        where: { id: { in: ids }, status: "PENDING" },
-        data: {
-          status: newStatus,
-          reviewedById: session.sub,
-          reviewedAt: new Date(),
-          ...(action === "reject"
-            ? { rejectionReason: reason!.trim() }
-            : { rejectionReason: null }),
-        },
-      });
+      const result = approvable.length
+        ? await prisma.event.updateMany({
+            where: { id: { in: approvable }, status: "PENDING" },
+            data: {
+              status: newStatus,
+              reviewedById: session.sub,
+              reviewedAt: new Date(),
+              ...(action === "reject"
+                ? { rejectionReason: reason!.trim() }
+                : { rejectionReason: null }),
+            },
+          })
+        : { count: 0 };
       affected = result.count;
     }
 
@@ -54,10 +86,10 @@ export async function POST(req: NextRequest) {
       action: `BULK_${action.toUpperCase()}`,
       targetType: "event",
       targetId: ids.join(","),
-      meta: { count: affected, reason: reason ?? null },
+      meta: { count: affected, reason: reason ?? null, blocked: blocked.length },
     });
 
-    return NextResponse.json({ ok: true, affected });
+    return NextResponse.json({ ok: true, affected, blocked });
   } catch (err) {
     console.error("Admin bulk action error:", err);
     return NextResponse.json({ error: "Service unavailable." }, { status: 503 });

--- a/app/api/admin/events/route.ts
+++ b/app/api/admin/events/route.ts
@@ -30,12 +30,17 @@ const EVENT_SELECT = {
   coverImageUrl:   true,
   rejectionReason: true,
   reviewedAt:      true,
+  registrationType: true,
   organiser: {
     select: {
       id:          true,
       orgName:     true,
       contactName: true,
       email:       true,
+      // Drives the "profile incomplete" warning on the review queue, so an
+      // admin sees why an event cannot be approved before clicking approve.
+      abn:                      true,
+      stripeOnboardingComplete: true,
     },
   },
 } as const;

--- a/app/api/organiser/events/[id]/route.ts
+++ b/app/api/organiser/events/[id]/route.ts
@@ -5,6 +5,7 @@ import { getEventCoords } from "@/lib/australia-coords";
 import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
 import { eventPayloadSchema, idParams } from "@/lib/schemas";
 import { withUniqueSlug } from "@/lib/slugs";
+import { hasAbn, ABN_REQUIRED_MESSAGE } from "@/lib/abn";
 
 export async function GET(
   _req: NextRequest,
@@ -73,22 +74,19 @@ export async function PATCH(
       }
     }
 
+    // See the create route: a missing ABN costs the event its auto-approval
+    // rather than rejecting the edit and stranding the organiser's changes.
+    let abnOk = true;
     if ((data.registrationType ?? "startline") === "startline") {
       const org = await prisma.organiser.findUnique({
         where: { id: session.sub },
         select: { abn: true },
       });
-      const abnDigits = org?.abn?.replace(/\D/g, "") ?? "";
-      if (abnDigits.length < 9) {
-        return NextResponse.json(
-          { error: "An ABN is required to host paid events on Startline. Add your ABN in Payments or onboarding, or use external registration." },
-          { status: 400 },
-        );
-      }
+      abnOk = hasAbn(org?.abn);
     }
 
     const nextStatus = submit
-      ? (session.verified ? "APPROVED" : "PENDING")
+      ? (session.verified && abnOk ? "APPROVED" : "PENDING")
       : "DRAFT";
 
     // Only a rename reassigns the slug; every other edit leaves it alone so links
@@ -159,7 +157,11 @@ export async function PATCH(
         .catch((err) => console.error("Follower notify failed:", err));
     }
 
-    return NextResponse.json({ id: updated.id, status: updated.status });
+    return NextResponse.json({
+      id:     updated.id,
+      status: updated.status,
+      ...(submit && !abnOk ? { abnRequired: true, notice: ABN_REQUIRED_MESSAGE } : {}),
+    });
   } catch (err) {
     console.error("Event update error:", err);
     return NextResponse.json({ error: "Failed to update event." }, { status: 500 });

--- a/app/api/organiser/events/route.ts
+++ b/app/api/organiser/events/route.ts
@@ -8,6 +8,7 @@ import { notifyOrganiserFollowers } from "@/lib/notify-organiser-followers";
 import { organiserEventPayloadSchema } from "@/lib/schemas";
 import { rateLimit } from "@/lib/rate-limit";
 import { withUniqueSlug } from "@/lib/slugs";
+import { hasAbn, ABN_REQUIRED_MESSAGE } from "@/lib/abn";
 export async function GET() {
   await archivePastEvents();
   const auth = await requireOrganiser();
@@ -96,23 +97,27 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // A missing ABN no longer blocks the organiser from finishing their event.
+  // It used to reject the whole submission at the last step, after five steps
+  // and an image upload, which read as losing the work. It now costs the event
+  // its auto-approval instead: the listing saves, and an admin has to add the
+  // missing detail before it can go live.
   const registrationType = body.registrationType ?? "startline";
-  if (registrationType === "startline") {
+  const needsAbn = registrationType === "startline";
+  let abnOk = true;
+  if (needsAbn) {
     const org = await prisma.organiser.findUnique({
       where: { id: organiserId },
       select: { abn: true },
     });
-    const abnDigits = org?.abn?.replace(/\D/g, "") ?? "";
-    if (abnDigits.length < 9) {
-      return NextResponse.json(
-        { error: "An ABN is required to host paid events on Startline. Add your ABN in Payments or onboarding, or use external registration." },
-        { status: 400 },
-      );
-    }
+    abnOk = hasAbn(org?.abn);
   }
 
+  // Verified organisers normally skip review. Not without an ABN: auto-approving
+  // would put a paid listing live with no ABN attached, which is the outcome the
+  // requirement exists to prevent, and the admin would never see it.
   const eventStatus = submit
-    ? (verified ? "APPROVED" : "PENDING")
+    ? (verified && abnOk ? "APPROVED" : "PENDING")
     : "DRAFT";
 
   try {
@@ -176,7 +181,13 @@ export async function POST(req: NextRequest) {
         .catch((err) => console.error("Follower notify failed:", err));
     }
 
-    return NextResponse.json({ id: event.id, status: event.status });
+    // The organiser finds out here, once the work is saved, rather than being
+    // turned away at the last step with nothing kept.
+    return NextResponse.json({
+      id:     event.id,
+      status: event.status,
+      ...(submit && !abnOk ? { abnRequired: true, notice: ABN_REQUIRED_MESSAGE } : {}),
+    });
   } catch (err) {
     console.error("Event create error:", err);
     return NextResponse.json({ error: "Failed to save event." }, { status: 500 });

--- a/app/api/user/registrations/[id]/refund-request/route.ts
+++ b/app/api/user/registrations/[id]/refund-request/route.ts
@@ -109,13 +109,18 @@ export async function POST(
       data: memberIds.map((m) => ({
         userId: m.userId,
         type: "ORGANISER_REFUND_REQUEST" as const,
-        title: "Refund requested",
+        // A free entry has no money attached, so it is a cancellation rather than
+        // a refund and is described as one (issue #304).
+        title: paidCents === 0 ? "Entry cancelled" : "Refund requested",
         body:
-          `${registration.athleteName} asked for a refund on ${registration.event.title}. ` +
-          `They have left wave assignment and freed their spot. ` +
-          (percent === 0
-            ? "Your policy does not cover a refund at this date, so this is a discretionary request."
-            : `Your policy covers ${percent}% of what they paid.`),
+          paidCents === 0
+            ? `${registration.athleteName} cancelled their free entry to ${registration.event.title}. ` +
+              `They have left wave assignment and freed their spot. There is nothing to refund.`
+            : `${registration.athleteName} asked for a refund on ${registration.event.title}. ` +
+              `They have left wave assignment and freed their spot. ` +
+              (percent === 0
+                ? "Your policy does not cover a refund at this date, so this is a discretionary request."
+                : `Your policy covers ${percent}% of what they paid.`),
         eventId: registration.event.id,
       })),
     });

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,14 +8,19 @@
   --color-dark: #1f1f1f;
   --color-darker: #141414;
   --color-dark-light: #2a2a2a;
-  --color-dark-lighter: #353535;
+  /* Also the default outline colour for inputs, cards and dividers. The old
+     #353535 was all but invisible against the dark backgrounds (issue #304). */
+  --color-dark-lighter: #4d4d4d;
 
   --color-light: #f5f7fa;
   --color-light-dark: #e8ebf0;
 
-  --color-muted: #8a8f98;
-  --color-muted-light: #a0a5ae;
-  --color-muted-dark: #6e737b;
+  /* Secondary text. These were mid-greys (#8a8f98 / #6e737b) that failed to
+     read on the dark ground, so they now sit just below --color-light: still a
+     step down in emphasis, but white enough to read (issue #304). */
+  --color-muted: #e6e9ee;
+  --color-muted-light: #f0f2f5;
+  --color-muted-dark: #bcc1ca;
 
   --font-sans: var(--font-chakra-petch), var(--font-inter), system-ui, sans-serif;
   --font-headline: var(--font-chakra-petch), sans-serif;

--- a/app/organiser/new-listing/page.tsx
+++ b/app/organiser/new-listing/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import EventFormWizard from "@/components/event/EventFormWizard";
 import { getOrganiserSession } from "@/lib/amplify-server";
+import prisma from "@/lib/prisma";
+import { hasAbn } from "@/lib/abn";
 
 export const dynamic = "force-dynamic";
 
@@ -11,12 +13,20 @@ export default async function NewListingPage() {
   // landing page, which offers sign-in and organiser sign-up, before they start.
   if (!session) redirect("/organiser-landing");
 
+  // Read here rather than from a client fetch: the wizard only needs to know
+  // whether to show an advisory notice, and this page already has the session.
+  const organiser = await prisma.organiser.findUnique({
+    where:  { id: session.sub },
+    select: { abn: true },
+  });
+
   return (
     <EventFormWizard
       apiBase="/api/organiser"
       submitRedirect="/organiser/dashboard"
       cancelRedirect="/organiser/dashboard"
       organiserId={session.sub}
+      organiserHasAbn={hasAbn(organiser?.abn)}
     />
   );
 }

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -548,7 +548,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
         {view === "signin" && userExists === null && !challengeFlow && (
           <>
             <div className="mb-6">
-              <span className="font-headline text-[11px] font-medium uppercase tracking-[0.25em] text-primary block mb-2">User Portal</span>
+              <span className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary block mb-2">User Portal</span>
               <h2 className="font-headline text-5xl font-black italic tracking-tighter leading-[0.9] mb-3">
                 Welcome<br /><span className="text-primary">back.</span>
               </h2>
@@ -589,7 +589,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
         {view === "signin" && userExists === false && (
           <>
             <div className="mb-6">
-              <span className="font-headline text-[11px] font-medium uppercase tracking-[0.25em] text-primary block mb-2">User Portal</span>
+              <span className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary block mb-2">User Portal</span>
               <h2 className="font-headline text-5xl font-black italic tracking-tighter leading-[0.9] mb-3">
                 No account<br /><span className="text-primary">found.</span>
               </h2>
@@ -613,7 +613,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
         {view === "signin" && userExists === true && userStatus === "CONFIRMED" && !challengeFlow && (
           <>
             <div className="mb-6">
-              <span className="font-headline text-[11px] font-medium uppercase tracking-[0.25em] text-primary block mb-2">User Portal</span>
+              <span className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary block mb-2">User Portal</span>
               <h2 className="font-headline text-5xl font-black italic tracking-tighter leading-[0.9] mb-3">
                 Welcome<br /><span className="text-primary">back.</span>
               </h2>
@@ -661,7 +661,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
         {view === "signin" && challengeFlow && (
           <>
             <div className="mb-6">
-              <span className="font-headline text-[11px] font-medium uppercase tracking-[0.25em] text-primary block mb-2">Set New Password</span>
+              <span className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary block mb-2">Set New Password</span>
               <h2 className="font-headline text-4xl font-black italic tracking-tighter leading-[0.9] mb-2">
                 Update your<br /><span className="text-primary">password.</span>
               </h2>
@@ -720,7 +720,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
         {view === "mfa" && (
           <>
             <div className="mb-6">
-              <span className="font-headline text-[11px] font-medium uppercase tracking-[0.25em] text-primary block mb-2">Two-Factor Authentication</span>
+              <span className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary block mb-2">Two-Factor Authentication</span>
               <h2 className="font-headline text-4xl font-black italic tracking-tighter leading-[0.9] mb-2">
                 {mfaStep === "select" ? <><span>Choose your</span><br /><span className="text-primary">method.</span></> :
                  mfaStep === "setup"  ? <><span>Set up</span><br /><span className="text-primary">MFA.</span></> :
@@ -811,7 +811,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
         {view === "signup" && (
           <>
             <div className="mb-4">
-              <span className="font-headline text-[11px] font-medium uppercase tracking-[0.25em] text-primary block mb-2">User Portal</span>
+              <span className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary block mb-2">User Portal</span>
               <h2 className="font-headline text-4xl font-black italic tracking-tighter leading-[0.9] mb-2">
                 Join<br /><span className="text-primary">Startline.</span>
               </h2>
@@ -863,7 +863,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
         {view === "onboarding" && (
           <>
             <div className="mb-5 pt-2">
-              <span className="font-headline text-[11px] font-medium uppercase tracking-[0.25em] text-primary block mb-2">Account Creation</span>
+              <span className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary block mb-2">Account Creation</span>
               <h2 className="font-headline text-4xl font-black italic tracking-tighter leading-[0.9] mb-2">
                 Welcome to<br /><span className="text-primary">Startline.</span>
               </h2>
@@ -1014,7 +1014,7 @@ export default function SignInModal({ isOpen, onClose, onSuccess }: SignInModalP
         {view === "username" && (
           <>
             <div className="mb-6 pt-2">
-              <span className="font-headline text-[11px] font-medium uppercase tracking-[0.25em] text-primary block mb-2">One last thing</span>
+              <span className="font-headline text-[11px] font-bold uppercase tracking-[0.25em] text-primary block mb-2">One last thing</span>
               <h2 className="font-headline text-4xl font-black italic tracking-tighter leading-[0.9] mb-2">
                 Choose your<br /><span className="text-primary">handle.</span>
               </h2>

--- a/components/event/EventFormWizard.tsx
+++ b/components/event/EventFormWizard.tsx
@@ -4,18 +4,20 @@ import { useState, useRef, useEffect, startTransition } from "react";
 import { useRouter } from "next/navigation";
 import { fetchAuthSession } from "aws-amplify/auth";
 import Image from "next/image";
+import Link from "next/link";
 import {
   ArrowLeft, ArrowRight, Check, Plus, Trash2,
   Upload, X, MapPin, Calendar, Users,
   ChevronDown, ChevronUp, Clock, Eye,
   Ticket, ExternalLink, DollarSign, Bold, Italic, Underline,
-  AlignLeft, Trophy, FileText,
+  AlignLeft, Trophy, FileText, AlertTriangle,
 } from "lucide-react";
 import { encodePrizePool, parsePrizePool, normalisePrizeAmount } from "@/lib/prize-pool";
 import { UPLOAD_LIMITS } from "@/lib/upload-limits";
 import { uploadFile, UploadError } from "@/lib/upload-client";
 import { formatDivisionLabel } from "@/lib/divisions";
 import { DEFAULT_REFUND_TIERS, REFUND_PRESETS, describeTiers, matchRefundPreset, parseTiers, tiersAreValid, type RefundTier } from "@/lib/refund-policy";
+import { isFreeEvent } from "@/lib/event-types";
 import AddressAutocomplete  from "@/components/ui/AddressAutocomplete";
 import SuburbAutocomplete   from "@/components/ui/SuburbAutocomplete";
 import LocationPreviewMap   from "@/components/organiser/LocationPreviewMap";
@@ -237,8 +239,11 @@ function BasicsStep({ form, update }: { form: FormState; update: (p: Partial<For
   const [ageMode, setAgeMode] = useState<"open" | "preset" | "custom" | "none">(
     form.minAge === "" ? "none" : form.minAge === "0" ? "open" : AGE_PRESETS.includes(form.minAge) ? "preset" : "custom"
   );
-  const [capMode, setCapMode] = useState<"preset" | "custom" | "none">(
-    form.cap === "" ? "none" : CAP_PRESETS.includes(form.cap) ? "preset" : "custom"
+  // "0" is the open cap — no limit — and mirrors how minAge stores "open to all".
+  // It is saved as a null cap, which is what the rest of the app already reads as
+  // unlimited (capacity checks, the capacity bar, the organiser dashboard).
+  const [capMode, setCapMode] = useState<"open" | "preset" | "custom" | "none">(
+    form.cap === "" ? "none" : form.cap === "0" ? "open" : CAP_PRESETS.includes(form.cap) ? "preset" : "custom"
   );
   const [showCustomCat,  setShowCustomCat]  = useState(false);
   const [customCatInput, setCustomCatInput] = useState("");
@@ -347,6 +352,11 @@ function BasicsStep({ form, update }: { form: FormState; update: (p: Partial<For
 
       <Field label="Participant cap" required hint="Max registrations">
         <div className="flex flex-wrap gap-2 mb-3">
+          <button type="button" onClick={() => { update({ cap: "0" }); setCapMode("open"); }}
+            className={`font-headline text-[12px] font-bold uppercase tracking-widest px-4 py-2.5 rounded-md border transition-colors
+              ${capMode === "open" ? "border-primary bg-primary/10 text-primary" : "border-dark-lighter text-light hover:border-primary/40 hover:text-light"}`}>
+            Open
+          </button>
           {CAP_PRESETS.map(c => {
             const active = capMode === "preset" && form.cap === c;
             return (
@@ -357,7 +367,7 @@ function BasicsStep({ form, update }: { form: FormState; update: (p: Partial<For
               </button>
             );
           })}
-          <button type="button" onClick={() => setCapMode("custom")}
+          <button type="button" onClick={() => { if (form.cap === "0") update({ cap: "" }); setCapMode("custom"); }}
             className={`font-headline text-[12px] font-bold uppercase tracking-widest px-4 py-2.5 rounded-md border transition-colors
               ${capMode === "custom" ? "border-primary bg-primary/10 text-primary" : "border-dark-lighter text-light hover:border-primary/40 hover:text-light"}`}>
             Custom
@@ -366,6 +376,9 @@ function BasicsStep({ form, update }: { form: FormState; update: (p: Partial<For
         {capMode === "custom" && (
           <input type="number" value={form.cap} onChange={e => update({ cap: e.target.value })}
             placeholder="e.g. 4200" className={`${inputCls} w-40`} />
+        )}
+        {capMode === "open" && (
+          <p className="font-headline text-[11px] uppercase tracking-widest text-muted">No limit on registrations</p>
         )}
       </Field>
 
@@ -554,6 +567,11 @@ function TicketsStep({ form, update }: { form: FormState; update: (p: Partial<Fo
   const activePreset = matchRefundPreset(form.refundTiers);
   const isCustom     = activePreset === null;
 
+  // Nothing is paid for a free event, so there is nothing to refund. The policy
+  // picker is replaced with a note rather than making the organiser answer a
+  // question that cannot apply to their event (issue #304).
+  const allTicketsFree = isFreeEvent(form.waves);
+
   return (
     <div>
       {/* Registration platform */}
@@ -732,7 +750,18 @@ function TicketsStep({ form, update }: { form: FormState; update: (p: Partial<Fo
         )}
       </div>
 
-      {/* Refund policy */}
+      {/* Refund policy — priced events only */}
+      {allTicketsFree ? (
+        <Field label="Refund & transfer policy">
+          <div className="rounded-xl border border-dark-lighter bg-dark-light px-5 py-4">
+            <div className="font-headline text-[13px] font-bold uppercase tracking-widest text-light">Not needed</div>
+            <p className="text-[11.5px] text-muted leading-relaxed mt-1">
+              Every ticket category on this event is free, so there is nothing to refund. Add a price to a
+              category if you need a refund policy.
+            </p>
+          </div>
+        </Field>
+      ) : (
       <Field label="Refund & transfer policy" required>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {REFUND_PRESETS.map(preset => {
@@ -763,6 +792,7 @@ function TicketsStep({ form, update }: { form: FormState; update: (p: Partial<Fo
         <textarea rows={2} value={form.refundPolicy} onChange={e => update({ refundPolicy: e.target.value })}
           placeholder="Exceptions or extra notes, e.g. transfers to another athlete…" className={`${textareaCls} mt-4`} />
       </Field>
+      )}
     </div>
   );
 }
@@ -1007,15 +1037,16 @@ const INTENSITY_LABELS: Record<string, string> = {
   low: "Low", moderate: "Moderate", high: "High", extreme: "Extreme",
 };
 
-function ReviewStep({ form, setStep, confirmed, onConfirm }: {
+function ReviewStep({ form, setStep, confirmed, onConfirm, showAbnNotice }: {
   form: FormState; setStep: (n: number) => void; confirmed: boolean; onConfirm: (v: boolean) => void;
+  showAbnNotice: boolean;
 }) {
   const rows: { k: string; v: string; step: number }[] = [
     { k: "Title",          v: form.title || "—",                                                                   step: 0 },
     { k: "Discipline",     v: form.discipline ? form.discipline.toUpperCase() : "—",                               step: 0 },
     { k: "Format",         v: form.format || "—",                                                                  step: 0 },
     { k: "Intensity",      v: form.level ? INTENSITY_LABELS[form.level] : "—",                                    step: 0 },
-    { k: "Cap / Min age",  v: `${form.cap ? parseInt(form.cap).toLocaleString() : "—"} · ${form.minAge === "0" ? "Open to all" : form.minAge ? `${form.minAge}+` : "—"}`, step: 0 },
+    { k: "Cap / Min age",  v: `${form.cap === "0" ? "Open" : form.cap ? parseInt(form.cap).toLocaleString() : "—"} · ${form.minAge === "0" ? "Open to all" : form.minAge ? `${form.minAge}+` : "—"}`, step: 0 },
     { k: "Date",           v: form.date
         ? form.endDate && form.endDate !== form.date
           ? `${new Date(form.date + "T00:00:00").toLocaleDateString("en-AU", { day:"numeric", month:"short", year:"numeric" })} — ${new Date(form.endDate + "T00:00:00").toLocaleDateString("en-AU", { day:"numeric", month:"short", year:"numeric" })}`
@@ -1025,7 +1056,7 @@ function ReviewStep({ form, setStep, confirmed, onConfirm }: {
     { k: "Venue",          v: `${form.venue || "—"}, ${form.city || "—"}, ${form.state ? form.state.toUpperCase() : "—"}`, step: 1 },
     { k: "Tickets",        v: `${form.waves.length} categor${form.waves.length !== 1 ? "ies" : "y"}, from ${form.waves[0]?.price === "0" ? "Free" : form.waves[0]?.price ? `A$${form.waves[0].price}` : "—"}`, step: 2 },
     { k: "Registration",   v: form.registrationType === "startline" ? "Startline" : form.registrationUrl || "—",  step: 2 },
-    { k: "Refund policy",  v: describeTiers(form.refundTiers).join(" "),                   step: 2 },
+    { k: "Refund policy",  v: isFreeEvent(form.waves) ? "Not needed for a free event" : describeTiers(form.refundTiers).join(" "), step: 2 },
     { k: "Prize money",    v: form.prizeMoney ? (normalisePrizeAmount(form.prizeMoneyAmount) ? `$${normalisePrizeAmount(form.prizeMoneyAmount)} prize pool` : "Yes") : "No", step: 2 },
     { k: "Cover image",    v: form.coverImage || form.coverImageUrl ? "Uploaded" : "No image",                    step: 3 },
     { k: "Info PDFs",      v: (() => { const n = form.informationPdfs.length; return n ? `${n} PDF${n !== 1 ? "s" : ""}` : "None"; })(), step: 3 },
@@ -1055,6 +1086,22 @@ function ReviewStep({ form, setStep, confirmed, onConfirm }: {
           You&apos;ll receive a notification each time someone registers.
         </p>
       </div>
+
+      {/* Deliberately advisory, not a block. Submitting still works; the event
+          waits for review instead of going live, and the organiser is told
+          again on the confirmation screen once the work is safely saved. */}
+      {showAbnNotice && (
+        <div className="flex items-start gap-3 bg-amber-400/[0.08] border border-amber-400/20 rounded-md p-4 mb-6">
+          <AlertTriangle className="w-4 h-4 text-amber-400 mt-0.5 shrink-0" />
+          <div className="font-headline text-[13px] text-amber-200 leading-relaxed">
+            <span className="font-bold">Your organiser profile isn&apos;t finished.</span>{" "}
+            You can publish this listing now, but without an ABN it goes to Startline for review
+            instead of straight to live. Add yours in{" "}
+            <Link href="/organiser/payments" className="underline hover:text-amber-100">Payments</Link>{" "}
+            to publish immediately.
+          </div>
+        </div>
+      )}
 
       <label className="flex items-start gap-3 cursor-pointer">
         <input type="checkbox" checked={confirmed} onChange={e => onConfirm(e.target.checked)}
@@ -1438,12 +1485,12 @@ function EventFullPreview({ form, onClose }: { form: FormState; onClose: () => v
                       <p className="font-headline text-[10px] font-medium uppercase tracking-widest text-light mb-0.5">Intensity</p>
                       <p className="font-headline text-base font-black italic text-light">{intensity}</p>
                     </div>
-                    {(cap || form.minAge !== "") && (
+                    {(cap != null || form.minAge !== "") && (
                       <div className="grid grid-cols-2 gap-3">
-                        {cap != null && cap > 0 && (
+                        {cap != null && (
                           <div>
                             <p className="font-headline text-[10px] font-medium uppercase tracking-widest text-light mb-0.5">Participant Cap</p>
-                            <p className="font-headline text-base font-black italic text-light">{cap.toLocaleString()}</p>
+                            <p className="font-headline text-base font-black italic text-light">{cap > 0 ? cap.toLocaleString() : "Open"}</p>
                           </div>
                         )}
                         {form.minAge !== "" && (
@@ -1459,6 +1506,7 @@ function EventFullPreview({ form, onClose }: { form: FormState; onClose: () => v
                   </div>
                 </div>
 
+                {!isFreeEvent(form.waves) && (
                 <div className="bg-dark rounded-xl p-5 sm:p-6">
                   <h3 className="font-headline text-xs font-medium uppercase tracking-widest text-light mb-2">Refund &amp; Transfer Policy</h3>
                   {describeTiers(form.refundTiers).map((line, i) => (
@@ -1468,6 +1516,7 @@ function EventFullPreview({ form, onClose }: { form: FormState; onClose: () => v
                     <p className="text-sm font-medium text-muted leading-relaxed mt-2">{form.refundPolicy}</p>
                   )}
                 </div>
+                )}
               </div>
 
             </div>
@@ -1491,6 +1540,7 @@ interface EventFormWizardProps {
   organiserId?: string;        // admin create — the organiser to create the event for
   requireOrganiser?: boolean;  // admin create — block submit until an organiser is selected
   headingLabel?: string;       // breadcrumb label, default "Create new listing"
+  organiserHasAbn?: boolean;   // false shows a non-blocking "profile incomplete" notice
 }
 
 export default function EventFormWizard({
@@ -1501,6 +1551,7 @@ export default function EventFormWizard({
   organiserId,
   requireOrganiser = false,
   headingLabel = "Create new listing",
+  organiserHasAbn = true,
 }: EventFormWizardProps) {
   const router = useRouter();
   const [step,            setStep]            = useState(0);
@@ -1512,6 +1563,7 @@ export default function EventFormWizard({
   const [visited,         setVisited]         = useState<Set<number>>(new Set());
   const [confirmed,       setConfirmed]       = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
+  const [abnNotice,       setAbnNotice]       = useState<string | null>(null);
   const [showFullPreview, setShowFullPreview] = useState(false);
   const [direction,       setDirection]       = useState<"forward" | "back">("forward");
   const [showMobilePreview, setShowMobilePreview] = useState(false);
@@ -1536,7 +1588,7 @@ export default function EventFormWizard({
           format:            e.format         ?? "",
           level:             e.level          ?? "",
           categories:        Array.isArray(e.categories) ? e.categories : [],
-          cap:               e.cap != null    ? String(e.cap)    : "",
+          cap:               e.cap != null && e.cap > 0 ? String(e.cap) : "0",
           minAge:            e.minAge != null ? String(e.minAge) : "",
           date:              e.eventDate      ?? "",
           endDate:           e.endDate        ?? "",
@@ -1681,13 +1733,13 @@ export default function EventFormWizard({
         format:            form.format,
         level:             form.level,
         categories:        form.categories,
-        cap:               form.cap ? parseInt(form.cap) : null,
+        cap:               form.cap && parseInt(form.cap) > 0 ? parseInt(form.cap) : null,
         minAge:            form.minAge ? parseInt(form.minAge) : null,
         waves:             form.waves,
         inclusions:        originalFields.current.inclusions ?? null,
         activations:       originalFields.current.activations ?? null,
         extras:            form.prizeMoney ? encodePrizePool(form.prizeMoneyAmount, form.prizeMoneyDetails) : (originalFields.current.extras ?? null),
-        refundTiers:       form.refundTiers,
+        refundTiers:       isFreeEvent(form.waves) ? [] : form.refundTiers,
         refundPolicy:      form.refundPolicy,
         registrationType:  form.registrationType,
         feeStructure:      form.feeStructure,
@@ -1713,6 +1765,12 @@ export default function EventFormWizard({
         return false;
       }
       if (asDraft && !eventId && data.id) setEventId(data.id);
+      // The event is saved. Hold the redirect so the organiser is told what the
+      // missing ABN cost them, rather than being refused before anything saved.
+      if (!asDraft && data.abnRequired) {
+        setAbnNotice(data.notice ?? "");
+        return true;
+      }
       router.push(submitRedirect);
       return true;
     } catch {
@@ -1816,7 +1874,7 @@ export default function EventFormWizard({
                 {step === 1 && <WhenStep    form={form} update={update} />}
                 {step === 2 && <TicketsStep form={form} update={update} />}
                 {step === 3 && <MediaStep   key={loadingEvent ? "loading" : (eventId ?? "new")} form={form} update={update} />}
-                {step === 4 && <ReviewStep  form={form} setStep={goTo} confirmed={confirmed} onConfirm={setConfirmed} />}
+                {step === 4 && <ReviewStep  form={form} setStep={goTo} confirmed={confirmed} onConfirm={setConfirmed} showAbnNotice={!organiserHasAbn && form.registrationType === "startline"} />}
 
                 {apiError && (
                   <div className="mt-4 px-4 py-3 rounded-md bg-red-400/10 border border-red-400/20 text-red-300 font-headline text-[13px]">
@@ -1912,6 +1970,39 @@ export default function EventFormWizard({
               <button onClick={() => setShowCancelModal(false)}
                 className="font-headline text-[12px] uppercase tracking-widest text-light hover:text-light transition-colors text-center py-1">
                 Keep editing
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Post-submit. The listing is already saved by the time this shows, so
+          this explains a consequence rather than refusing anything. */}
+      {abnNotice !== null && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 overlay-in">
+          <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+          <div className="relative bg-dark border border-dark-lighter rounded-2xl shadow-2xl w-full max-w-md p-7 modal-in">
+            <div className="flex items-start gap-3 mb-2">
+              <AlertTriangle className="w-5 h-5 text-amber-400 mt-1 shrink-0" />
+              <h2 className="font-headline text-[22px] font-black italic tracking-tight text-light">
+                Event submitted, pending review
+              </h2>
+            </div>
+            <p className="font-headline text-light text-[14px] leading-relaxed mb-2">
+              Your event has been saved and submitted. It won&apos;t go live yet: your organiser
+              profile has no ABN, which Startline needs before you can take payments.
+            </p>
+            <p className="font-headline text-muted text-[13px] leading-relaxed mb-7">
+              Add your ABN and our team can approve the listing. Nothing you entered has been lost.
+            </p>
+            <div className="flex flex-col gap-3">
+              <button onClick={() => router.push("/organiser/payments")}
+                className="w-full font-headline text-[13px] font-bold uppercase tracking-widest px-6 py-3.5 rounded-md border border-primary/40 bg-primary/10 text-primary hover:bg-primary/20 transition-colors flex items-center justify-center gap-2">
+                <ArrowRight className="w-4 h-4" /> Add my ABN
+              </button>
+              <button onClick={() => { setAbnNotice(null); router.push(submitRedirect); }}
+                className="w-full font-headline text-[13px] font-bold uppercase tracking-widest px-6 py-3.5 rounded-md border border-dark-lighter text-light hover:border-primary/40 transition-colors">
+                I&apos;ll do it later
               </button>
             </div>
           </div>

--- a/e2e/abn-gate.spec.ts
+++ b/e2e/abn-gate.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "@playwright/test";
+import { adminLogin } from "./helpers";
+
+// An organiser can now submit a marketplace event without an ABN: the listing
+// saves and waits for review instead of being refused at the last step. The
+// requirement has to hold on the admin side instead, so the review queue says
+// why an event cannot go live and refuses to approve it.
+//
+// Both seeded organisers have an ABN, so the queue is stubbed rather than
+// mutating seed data other specs depend on.
+
+// `organiser` is merged rather than replaced: spreading `over` wholesale would
+// drop stripeOnboardingComplete and trip the Stripe blocker instead of the ABN
+// one, which is a different assertion entirely.
+const row = ({ organiser, ...over }: Record<string, unknown> = {}) => ({
+  id: "evt-no-abn",
+  title: "Sunrise Trail Half",
+  discipline: "running",
+  city: "Melbourne",
+  state: "VIC",
+  eventDate: "2026-11-01",
+  startTime: "07:00",
+  status: "PENDING",
+  isPinned: false,
+  createdAt: "2026-09-01T00:00:00.000Z",
+  coverImageUrl: null,
+  rejectionReason: null,
+  reviewedAt: null,
+  registrationType: "startline",
+  ...over,
+  organiser: {
+    id: "org-1",
+    orgName: "Apex Endurance Events",
+    contactName: "Test Organiser",
+    email: "sarah.mitchell@startline.test",
+    abn: null,
+    stripeOnboardingComplete: true,
+    ...(organiser as object ?? {}),
+  },
+});
+
+const stubQueue = async (page: import("@playwright/test").Page, events: unknown[]) => {
+  await page.route("**/api/admin/events?status=PENDING**", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ events, total: events.length, page: 1, totalPages: 1 }),
+    })
+  );
+};
+
+test.describe("admin review: organiser profile incomplete", () => {
+  test("warns and blocks approval when the organiser has no ABN", async ({ page }) => {
+    await stubQueue(page, [row()]);
+
+    // Approving must not even be attempted from the UI.
+    let approveCalled = false;
+    await page.route("**/api/admin/events/*/review", async route => {
+      approveCalled = true;
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    });
+
+    await adminLogin(page);
+    await page.goto("/admin/events?status=PENDING");
+
+    await expect(page.getByText("Sunrise Trail Half")).toBeVisible();
+    await expect(
+      page.getByText(/Organiser profile incomplete: No ABN on file/i)
+    ).toBeVisible();
+
+    const approve = page.getByRole("button", { name: /^Approve$/i }).first();
+    await expect(approve).toBeDisabled();
+    expect(approveCalled).toBe(false);
+  });
+
+  test("still allows approval once the organiser has an ABN", async ({ page }) => {
+    await stubQueue(page, [row({ organiser: { abn: "51 824 753 556" } })]);
+
+    await adminLogin(page);
+    await page.goto("/admin/events?status=PENDING");
+
+    await expect(page.getByText("Sunrise Trail Half")).toBeVisible();
+    await expect(page.getByText(/Organiser profile incomplete/i)).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^Approve$/i }).first()).toBeEnabled();
+  });
+
+  // External registration takes no money through Startline, so the ABN the rule
+  // protects is not needed and the event must not be held up.
+  test("does not hold up an externally-registered event", async ({ page }) => {
+    await stubQueue(page, [row({ registrationType: "external" })]);
+
+    await adminLogin(page);
+    await page.goto("/admin/events?status=PENDING");
+
+    await expect(page.getByText("Sunrise Trail Half")).toBeVisible();
+    await expect(page.getByText(/Organiser profile incomplete/i)).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^Approve$/i }).first()).toBeEnabled();
+  });
+});

--- a/lib/abn.ts
+++ b/lib/abn.ts
@@ -33,3 +33,22 @@ export async function lookupAbn(abn: string): Promise<AbnResult | null> {
     postcode:   data.AddressPostcode || "",
   };
 }
+
+// Whether an organiser's stored ABN is complete enough to host events that
+// take money through Startline.
+//
+// The threshold is 9 digits rather than the 11 a real ABN carries. That is the
+// rule the event routes have always applied, and raising it here would lock
+// out organisers whose stored value predates any validation. Tightening it is
+// a data-migration decision, not a validation one.
+export const MIN_ABN_DIGITS = 9;
+
+export function hasAbn(abn: string | null | undefined): boolean {
+  return (abn?.replace(/\D/g, "").length ?? 0) >= MIN_ABN_DIGITS;
+}
+
+// Shown wherever an organiser is told their account is not ready to take
+// money. Kept in one place so the wizard, the dashboard and the admin portal
+// all describe the same gap the same way.
+export const ABN_REQUIRED_MESSAGE =
+  "An ABN is required to host paid events on Startline. Add your ABN in Payments or onboarding, or use external registration.";

--- a/lib/event-types.ts
+++ b/lib/event-types.ts
@@ -82,6 +82,19 @@ export function waveIsOpen(wave: PublicWave, today = todayIso()): boolean {
 }
 
 /**
+ * A free event: it has ticket categories and every one of them costs nothing.
+ *
+ * Nothing is ever paid, so there is nothing to refund — the organiser is not
+ * asked for a refund policy and the athlete is not shown one (issue #304). A
+ * category with a blank or unparseable price is not free, so a half-filled draft
+ * never reads as one.
+ */
+export function isFreeEvent(waves: unknown): boolean {
+  if (!Array.isArray(waves) || waves.length === 0) return false;
+  return (waves as PublicWave[]).every((w) => parseFloat(w?.price ?? "") === 0);
+}
+
+/**
  * Lowest advertised price. Only tiers still on sale are considered, so cards
  * and the sticky bar never advertise a closed early-bird price; if every tier
  * has closed, falls back to all tiers so the event still shows a price.

--- a/src/__tests__/abn-gate.test.ts
+++ b/src/__tests__/abn-gate.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { hasAbn } from "@/lib/abn";
+
+const mocks = vi.hoisted(() => ({
+  getAdminSession: vi.fn(),
+  eventFindUnique: vi.fn(),
+  eventFindMany: vi.fn(),
+  eventUpdateMany: vi.fn(),
+  transaction: vi.fn(),
+  writeAuditLog: vi.fn(),
+}));
+
+vi.mock("@/lib/amplify-server", () => ({
+  getAdminSession: mocks.getAdminSession,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    event: {
+      findUnique: mocks.eventFindUnique,
+      findMany:   mocks.eventFindMany,
+      updateMany: mocks.eventUpdateMany,
+      // The approve path builds its update inside $transaction, so this has to
+      // exist even though the transaction itself is stubbed out.
+      update:     vi.fn(),
+    },
+    notification: { create: vi.fn() },
+    $transaction: mocks.transaction,
+  },
+}));
+
+vi.mock("@/lib/audit", () => ({ writeAuditLog: mocks.writeAuditLog }));
+vi.mock("@/lib/email", () => ({
+  sendEventApprovedEmail: vi.fn().mockResolvedValue(undefined),
+  sendEventRejectedEmail: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/notify-organiser-followers", () => ({
+  notifyOrganiserFollowers: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { POST as review } from "@/app/api/admin/events/[id]/review/route";
+import { POST as bulk } from "@/app/api/admin/events/bulk/route";
+
+const ABN = "51 824 753 556";
+
+const reviewReq = (action: string) =>
+  review(
+    new NextRequest("http://localhost/api/admin/events/e1/review", {
+      method: "POST",
+      body: JSON.stringify({ action, reason: action === "reject" ? "not suitable" : undefined }),
+    }),
+    { params: Promise.resolve({ id: "e1" }) },
+  );
+
+const bulkReq = (ids: string[], action = "approve") =>
+  bulk(
+    new NextRequest("http://localhost/api/admin/events/bulk", {
+      method: "POST",
+      body: JSON.stringify({ ids, action }),
+    }),
+  );
+
+const pendingEvent = (over: Record<string, unknown> = {}) => ({
+  id: "e1",
+  title: "Trail Half",
+  status: "PENDING",
+  registrationType: "startline",
+  eventDate: "2026-11-01",
+  city: "Melbourne",
+  organiser: {
+    id: "org-1",
+    email: "sarah@startline.test",
+    orgName: "Apex",
+    stripeOnboardingComplete: true,
+    abn: ABN,
+    ...(over.organiser as object ?? {}),
+  },
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  mocks.getAdminSession.mockResolvedValue({ sub: "admin-1" });
+  mocks.transaction.mockResolvedValue([]);
+});
+
+describe("hasAbn", () => {
+  it("accepts a formatted ABN", () => {
+    expect(hasAbn(ABN)).toBe(true);
+    expect(hasAbn("51824753556")).toBe(true);
+  });
+
+  it("rejects nothing, blanks and stray punctuation", () => {
+    expect(hasAbn(null)).toBe(false);
+    expect(hasAbn(undefined)).toBe(false);
+    expect(hasAbn("")).toBe(false);
+    expect(hasAbn("   ")).toBe(false);
+    expect(hasAbn("-- --")).toBe(false);
+  });
+
+  it("rejects a value too short to be an ABN", () => {
+    expect(hasAbn("12345678")).toBe(false);
+    expect(hasAbn("123456789")).toBe(true);
+  });
+});
+
+describe("POST /api/admin/events/[id]/review", () => {
+  it("refuses to approve a marketplace event when the organiser has no ABN", async () => {
+    mocks.eventFindUnique.mockResolvedValue(pendingEvent({ organiser: { abn: null } }));
+
+    const res = await reviewReq("approve");
+    const body = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(body.code).toBe("ABN_MISSING");
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+
+  it("approves when the organiser has an ABN", async () => {
+    mocks.eventFindUnique.mockResolvedValue(pendingEvent());
+
+    const res = await reviewReq("approve");
+
+    expect(res.status).toBe(200);
+    expect(mocks.transaction).toHaveBeenCalled();
+  });
+
+  // External registration takes no money through Startline, so the ABN the
+  // rule protects is not needed.
+  it("approves an externally-registered event without an ABN", async () => {
+    mocks.eventFindUnique.mockResolvedValue(
+      pendingEvent({ registrationType: "external", organiser: { abn: null } }),
+    );
+
+    const res = await reviewReq("approve");
+
+    expect(res.status).toBe(200);
+  });
+
+  // Rejecting is how an admin clears an event that can never be approved, so
+  // the ABN gate must not block it.
+  it("still allows rejecting an event from an organiser with no ABN", async () => {
+    mocks.eventFindUnique.mockResolvedValue(pendingEvent({ organiser: { abn: null } }));
+
+    const res = await reviewReq("reject");
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/admin/events/bulk", () => {
+  it("skips events whose organiser has no ABN and names them", async () => {
+    mocks.eventFindMany.mockResolvedValue([
+      { id: "e1", title: "Has ABN", registrationType: "startline",
+        organiser: { abn: ABN, stripeOnboardingComplete: true } },
+      { id: "e2", title: "No ABN", registrationType: "startline",
+        organiser: { abn: null, stripeOnboardingComplete: true } },
+    ]);
+    mocks.eventUpdateMany.mockResolvedValue({ count: 1 });
+
+    const res = await bulkReq(["e1", "e2"]);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.affected).toBe(1);
+    expect(body.blocked).toEqual([{ id: "e2", title: "No ABN", reason: "No ABN on file" }]);
+    expect(mocks.eventUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ id: { in: ["e1"] } }) }),
+    );
+  });
+
+  // Bulk approve used to write straight through, so it could publish what the
+  // single-approve route refuses.
+  it("closes the Stripe bypass that bulk approve used to leave open", async () => {
+    mocks.eventFindMany.mockResolvedValue([
+      { id: "e1", title: "No Stripe", registrationType: "startline",
+        organiser: { abn: ABN, stripeOnboardingComplete: false } },
+    ]);
+    mocks.eventUpdateMany.mockResolvedValue({ count: 0 });
+
+    const body = await (await bulkReq(["e1"])).json();
+
+    expect(body.affected).toBe(0);
+    expect(body.blocked[0].reason).toBe("Stripe onboarding incomplete");
+    expect(mocks.eventUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("does not filter a bulk reject", async () => {
+    mocks.eventUpdateMany.mockResolvedValue({ count: 2 });
+
+    const body = await (await bulk(
+      new NextRequest("http://localhost/api/admin/events/bulk", {
+        method: "POST",
+        body: JSON.stringify({ ids: ["e1", "e2"], action: "reject", reason: "duplicate" }),
+      }),
+    )).json();
+
+    expect(body.affected).toBe(2);
+    expect(body.blocked).toEqual([]);
+    expect(mocks.eventFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/abn-submit-status.test.ts
+++ b/src/__tests__/abn-submit-status.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  session: vi.fn(),
+  organiserFindUnique: vi.fn(),
+  eventCreate: vi.fn(),
+}));
+
+vi.mock("@/lib/organiser-api-auth", () => ({
+  requireOrganiser: async () => ({ error: null, session: await mocks.session() }),
+}));
+vi.mock("@/lib/amplify-server", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    organiser: { findUnique: mocks.organiserFindUnique },
+    event:     { create: mocks.eventCreate },
+  },
+}));
+vi.mock("@/lib/rate-limit", () => ({ rateLimit: async () => null }));
+vi.mock("@/lib/archive-events", () => ({ archivePastEvents: async () => {} }));
+vi.mock("@/lib/slugs", () => ({
+  withUniqueSlug: async (_t: string, write: (s: string) => unknown) => write("slug"),
+}));
+vi.mock("@/lib/notify-organiser-followers", () => ({
+  notifyOrganiserFollowers: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { POST } from "@/app/api/organiser/events/route";
+
+const ABN = "51824753556";
+
+// A payload complete enough to pass the submit-time required-field check.
+const payload = (over: Record<string, unknown> = {}) => ({
+  title: "Trail Half", discipline: "running", eventDate: "2026-11-01",
+  startTime: "07:00", city: "Melbourne", state: "VIC",
+  format: "Road", level: "All levels",
+  registrationType: "startline", submit: true,
+  ...over,
+});
+
+const post = (body: Record<string, unknown>) =>
+  POST(new NextRequest("http://localhost/api/organiser/events", {
+    method: "POST",
+    body: JSON.stringify(body),
+  }));
+
+const statusOf = () => mocks.eventCreate.mock.calls[0][0].data.status;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  mocks.session.mockResolvedValue({ sub: "org-1", verified: true, role: "OWNER" });
+  mocks.organiserFindUnique.mockResolvedValue({ abn: ABN });
+  mocks.eventCreate.mockImplementation(async (args: { data: { status: string } }) => ({
+    id: "e1", status: args.data.status, title: "Trail Half",
+  }));
+});
+
+describe("POST /api/organiser/events — submitting without an ABN", () => {
+  // The whole point of the change: the organiser reaches the end of the wizard
+  // and their work is saved, instead of being refused after five steps.
+  it("saves the event instead of rejecting the submission", async () => {
+    mocks.organiserFindUnique.mockResolvedValue({ abn: null });
+
+    const res = await post(payload());
+
+    expect(res.status).toBe(200);
+    expect(mocks.eventCreate).toHaveBeenCalled();
+  });
+
+  it("tells the organiser why, once the event is safely saved", async () => {
+    mocks.organiserFindUnique.mockResolvedValue({ abn: null });
+
+    const body = await (await post(payload())).json();
+
+    expect(body.abnRequired).toBe(true);
+    expect(body.notice).toContain("ABN");
+  });
+
+  // Without this a verified organiser would publish a paid listing with no ABN
+  // and no admin would ever see it, which is the outcome the rule prevents.
+  it("withholds auto-approval from a verified organiser", async () => {
+    mocks.organiserFindUnique.mockResolvedValue({ abn: null });
+
+    await post(payload());
+
+    expect(statusOf()).toBe("PENDING");
+  });
+
+  it("auto-approves a verified organiser that has one", async () => {
+    await post(payload());
+
+    expect(statusOf()).toBe("APPROVED");
+    expect((await (await post(payload())).json()).abnRequired).toBeUndefined();
+  });
+
+  it("still sends an unverified organiser to review", async () => {
+    mocks.session.mockResolvedValue({ sub: "org-1", verified: false, role: "OWNER" });
+
+    await post(payload());
+
+    expect(statusOf()).toBe("PENDING");
+  });
+
+  // External registration takes no money through Startline, so no ABN is needed
+  // and the organiser's verified status alone decides.
+  it("ignores a missing ABN for externally-registered events", async () => {
+    mocks.organiserFindUnique.mockResolvedValue({ abn: null });
+
+    const res = await post(payload({
+      registrationType: "external",
+      registrationUrl: "https://example.com/enter",
+    }));
+
+    expect(statusOf()).toBe("APPROVED");
+    expect((await res.json()).abnRequired).toBeUndefined();
+    // The route looks the organiser up again to notify followers, so assert on
+    // the ABN read specifically rather than on the mock being untouched.
+    expect(mocks.organiserFindUnique).not.toHaveBeenCalledWith(
+      expect.objectContaining({ select: { abn: true } }),
+    );
+  });
+
+  it("leaves a draft as a draft and never nags about it", async () => {
+    mocks.organiserFindUnique.mockResolvedValue({ abn: null });
+
+    const res = await post(payload({ submit: false }));
+
+    expect(statusOf()).toBe("DRAFT");
+    expect((await res.json()).abnRequired).toBeUndefined();
+  });
+});

--- a/src/__tests__/free-event.test.ts
+++ b/src/__tests__/free-event.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { isFreeEvent } from "@/lib/event-types";
+
+// A free event asks for no refund policy and shows none (issue #304), so what
+// counts as free has to be exact: every category free, and nothing half-filled.
+describe("isFreeEvent", () => {
+  it("is true when every ticket category is free", () => {
+    expect(isFreeEvent([{ label: "General", price: "0" }, { label: "Junior", price: "0.00" }])).toBe(true);
+  });
+
+  it("is false when any category is priced", () => {
+    expect(isFreeEvent([{ label: "General", price: "0" }, { label: "VIP", price: "45" }])).toBe(false);
+  });
+
+  it("is false for a category with no price yet", () => {
+    expect(isFreeEvent([{ label: "General", price: "" }])).toBe(false);
+    expect(isFreeEvent([{ label: "General" }])).toBe(false);
+  });
+
+  it("is false with no categories at all", () => {
+    expect(isFreeEvent([])).toBe(false);
+    expect(isFreeEvent(null)).toBe(false);
+    expect(isFreeEvent(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #304.

## ABN submission gate

A missing ABN used to reject an event submission at the last step, after five steps of form filling and an image upload, which read as losing the work. It now costs the event its auto-approval instead: the listing saves and sits at PENDING for an admin, who sees why approval is unavailable. `hasAbn()` and `ABN_REQUIRED_MESSAGE` in `lib/abn.ts` keep the rule and its wording in one place across the organiser wizard, the organiser routes and the admin console.

The 9-digit threshold is carried over deliberately rather than raised to a real ABN's 11. Tightening it would lock out organisers whose stored value predates any validation, which is a data-migration decision.

## Issue #304

**No refunds on free events.** `isFreeEvent()` is the single test (every ticket category priced at zero; a blank price does not count, so a half-filled draft never reads as free). The organiser wizard replaces the required policy picker with a "Not needed" note, and drops the policy from the review row and the live preview. The event page and checkout hide the policy block. On Activity a free entry reads "Cancel my spot" instead of quoting a refund of $0.00, and the organiser notification describes a cancellation rather than a refund. Free events save empty tiers, so nothing downstream quotes a policy that was never chosen.

**Participant cap "Open".** A no-limit option at the front of the cap row, mirroring the existing "Open to all" minimum age. It saves as a null cap, which capacity checks, the capacity bar and the organiser dashboard already read as unlimited. Editing an event that has no cap now shows Open selected.

**Grey text and outlines.** The muted tokens were too dark to read on the dark ground. `--color-muted` moves from #8a8f98 to #e6e9ee, `--color-muted-dark` from #6e737b to #bcc1ca, and the default outline from #353535 to #4d4d4d. One change in `globals.css` lifts every screen rather than patching the two in the issue.

**Two-factor modal.** The "Two-Factor Authentication" heading is bold. Its seven sibling eyebrow labels are bolded too, since a single heavier label would read as a bug when switching between views in the same modal.

## Verification

- `pnpm typecheck` and `pnpm lint` clean
- 453 unit tests across 43 files pass, including new coverage for `isFreeEvent` and the ABN gate
- `e2e/abn-gate.spec.ts` passes (3 tests)
- Checked against a local dev server: the refund block renders on a paid event and is absent on a free one, and the new tokens serve in the compiled CSS

## Known gap, not addressed here

Free events cannot be registered for, so the refund changes above are correct but currently unreachable for athletes.

`app/api/checkout/route.ts:184` rejects any ticket priced at or below zero with a 400 "Invalid ticket price." before Stripe is ever called. Registrations are only created by the Stripe webhook on `payment_intent.succeeded`, so no path creates an entry without a payment.

Lifting that guard alone would not be enough. `calculatePlatformFee(0)` still returns its 145c fixed component, so a free ticket would charge the athlete A$1.45 under the default athlete-pays fee structure, or build a A$0 intent that Stripe will not accept under organiser-pays. A free registration path needs to skip the payment intent entirely and create the registration directly. Worth its own issue.
